### PR TITLE
Proper Handling of Enumerations

### DIFF
--- a/src/FluentMigrator.Runner/Generators/ConstantFormatter.cs
+++ b/src/FluentMigrator.Runner/Generators/ConstantFormatter.cs
@@ -32,6 +32,11 @@ namespace FluentMigrator.Runner.Generators
 			{
 				return "'" + ((DateTime)value).ToString("yyyy-MM-ddTHH:mm:ss")+ "'";
 			}
+            if(value.GetType().IsEnum)
+            {
+                return "'" + value.ToString() + "'";
+            }
+
 
 			return value.ToString();
 		}

--- a/src/FluentMigrator.Tests/Unit/Generators/ConstantFormatterTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/ConstantFormatterTests.cs
@@ -88,6 +88,19 @@ namespace FluentMigrator.Tests.Unit.Generators
 				.ShouldBe("CustomClass");
 		}
 
+	    [Test]
+	    public void EnumIsFormattedAsString()
+	    {
+	        formatter.Format(Foo.Bar)
+                .ShouldBe("'Bar'");
+	    }
+
+        private enum Foo
+        {
+            Bar,
+            Baz
+        }
+
 		private class CustomClass
 		{
 			public override string ToString()


### PR DESCRIPTION
Hi guys, 

We ran into a bug today where FM was not handling enumerations correctly. It was generating insert queries like this:

"INSERT INTO [FIXExecutingBroker](Code,Classification) VALUES ('ABC',Us);" ---> System.Data.SQLite.SQLiteException: SQLite error

I have added a test to handle this case and provided a simple solution as well. Kudos on the great tool.
