### PR TITLE
Patch fixing loading of dependent assemblies

### DIFF
--- a/src/FluentMigrator.Runner/Initialization/AssemblyLoader/AssemblyLoaderFromFile.cs
+++ b/src/FluentMigrator.Runner/Initialization/AssemblyLoader/AssemblyLoaderFromFile.cs
@@ -37,7 +37,8 @@ namespace FluentMigrator.Runner.Initialization.AssemblyLoader
 			{
 				fileName = Path.GetFullPath(this.name);
 			}
-			Assembly assembly = Assembly.LoadFile(fileName);
+            
+			Assembly assembly = Assembly.LoadFrom(fileName);
 			return assembly;
 		}
 	}


### PR DESCRIPTION
Migrate.exe was failing when the assembly containing the migrations had dependencies on other projects. This patch has a fix for that.
