### PR TITLE
MigrateUp(version) not committing transaction against Sql Server

### DIFF
--- a/src/FluentMigrator.Runner/MigrationRunner.cs
+++ b/src/FluentMigrator.Runner/MigrationRunner.cs
@@ -74,7 +74,7 @@ namespace FluentMigrator.Runner
 			{
 				foreach (var version in MigrationLoader.Migrations.Keys)
 				{
-					MigrateUp(version);
+					ApplyMigrationUp(version);
 				}
 
 				ApplyProfiles();
@@ -91,14 +91,17 @@ namespace FluentMigrator.Runner
 
 		public void MigrateUp(long version)
 		{
-			if (!_alreadyOutputPreviewOnlyModeWarning && Processor.Options.PreviewOnly)
+			try 
 			{
-				_announcer.Heading("PREVIEW-ONLY MODE");
-				_alreadyOutputPreviewOnlyModeWarning = true;
+				ApplyMigrationUp(version);
+				Processor.CommitTransaction();
+				VersionLoader.LoadVersionInfo();
+			} 
+			catch (Exception) 
+			{
+				Processor.RollbackTransaction();
+				throw;
 			}
-
-			ApplyMigrationUp(version);
-			VersionLoader.LoadVersionInfo();
 		}
 
 		public void MigrateDown(long version)
@@ -119,6 +122,11 @@ namespace FluentMigrator.Runner
 
 		private void ApplyMigrationUp(long version)
 		{
+			if (!_alreadyOutputPreviewOnlyModeWarning && Processor.Options.PreviewOnly) {
+				_announcer.Heading("PREVIEW-ONLY MODE");
+				_alreadyOutputPreviewOnlyModeWarning = true;
+			}
+
 			if (!VersionLoader.VersionInfo.HasAppliedMigration(version))
 			{
 				Up(MigrationLoader.Migrations[version]);

--- a/src/FluentMigrator.Tests/Integration/IntegrationTestBase.cs
+++ b/src/FluentMigrator.Tests/Integration/IntegrationTestBase.cs
@@ -33,12 +33,17 @@ namespace FluentMigrator.Tests.Integration
 	{
 		public void ExecuteWithSupportedProcessors(Action<IMigrationProcessor> test)
 		{
-			ExecuteWithSqlServer(test, IntegrationTestOptions.SqlServer);
+			ExecuteWithSupportedProcessors(test, true);
+		}
+
+		public void ExecuteWithSupportedProcessors(Action<IMigrationProcessor> test, Boolean tryRollback)
+		{
+			ExecuteWithSqlServer(test, IntegrationTestOptions.SqlServer, tryRollback);
 			ExecuteWithSqlite(test, IntegrationTestOptions.SqlLite);
 			ExecuteWithMySql(test, IntegrationTestOptions.MySql);
 		}
 
-		protected static void ExecuteWithSqlServer(Action<IMigrationProcessor> test, IntegrationTestOptions.DatabaseServerOptions serverOptions)
+		protected static void ExecuteWithSqlServer(Action<IMigrationProcessor> test, IntegrationTestOptions.DatabaseServerOptions serverOptions, Boolean tryRollback)
 		{
 			if (!serverOptions.IsEnabled)
 				return;
@@ -47,9 +52,9 @@ namespace FluentMigrator.Tests.Integration
 			var processor = new SqlServerProcessor(connection, new SqlServer2000Generator(), new TextWriterAnnouncer(System.Console.Out), new ProcessorOptions());
 			test(processor);
 
-			if (!processor.WasCommitted)
+			if (tryRollback && !processor.WasCommitted)
 			{
-				processor.RollbackTransaction();
+			    processor.RollbackTransaction();
 			}
 		}
 

--- a/src/FluentMigrator.Tests/Integration/PerformDBOperationTests.cs
+++ b/src/FluentMigrator.Tests/Integration/PerformDBOperationTests.cs
@@ -32,7 +32,7 @@ namespace FluentMigrator.Tests.Integration
 				}
 			};
 
-			ExecuteWithSqlServer(processor => processor.Process(expression), IntegrationTestOptions.SqlServer);
+			ExecuteWithSqlServer(processor => processor.Process(expression), IntegrationTestOptions.SqlServer, true);
 		}
 	}
 }


### PR DESCRIPTION
When migrating against specific migration versions using Sql Server, the transaction was not getting committed. The call to MigrationRunner's MigrateUp() was calling MigrateUp(version) for each step, and the transaction gets committed proprly in the general call.  The transaction does not get committed if you migrate up to a specific version.

Adjusted MigrationRunner, added a few tests and edited a few others.
