### PR TITLE
Error in OracleGenerator DeleteDataExpression

### DIFF
--- a/src/FluentMigrator.Runner/Generators/OracleGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/OracleGenerator.cs
@@ -200,11 +200,11 @@ namespace FluentMigrator.Runner.Generators
 						where += " AND ";
 					}
 
-                    where += String.Format("[{0}] {1} {2}", item.Key, item.Value == null ? "IS" : "=", Constant.Format(item.Value));
+                    where += String.Format("{0} {1} {2}", item.Key, item.Value == null ? "IS" : "=", Constant.Format(item.Value));
 					i++;
 				}
 
-				result.Append(String.Format("DELETE FROM {0} WHERE {1};", expression.TableName, where));
+				result.Append(String.Format("DELETE FROM {0} WHERE {1}", expression.TableName, where));
 			}
 			return result.ToString();
 		}


### PR DESCRIPTION
Oracle generator generates invalid SQL for DeleteDataExpression. The SQL Generated for a delete statement was: 
DELETE FROM TABLE where [COLUMN] = 'value';
but should be
DELETE FROM TABLE where COLUMN = 'value'

Both the brackets and the semicolon causes errors.
