### PR TITLE
Fix for Issue 73

### DIFF
--- a/src/FluentMigrator.Runner/Generators/SqliteColumn.cs
+++ b/src/FluentMigrator.Runner/Generators/SqliteColumn.cs
@@ -5,17 +5,17 @@ namespace FluentMigrator.Runner.Generators
 {
 	class SqliteColumn : ColumnBase
 	{
+        protected override bool CanSeperatePrimaryKeyAndIdentity { get { return false; } }
+
 		public SqliteColumn() : base(new SqliteTypeMap(), new ConstantFormatter())
 		{
 		}
 
 		protected override string FormatIdentity(ColumnDefinition column)
 		{
-			if (!column.IsIdentity)
-				return string.Empty;
-
-			//Assume that if its IDENTITY and PRIMARY KEY, the it should be an AUTOINCREMENT column
-			return !column.IsPrimaryKey ? "IDENTITY" : string.Empty;
+            //SQLite only supports the concept of Identity in combination with a single primary key
+            //see: http://www.sqlite.org/syntaxdiagrams.html#column-constraint syntax details
+		    return string.Empty;
 		}
 
 		protected override string FormatPrimaryKey(ColumnDefinition column)

--- a/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -178,6 +178,7 @@
     <Compile Include="Unit\Generators\MySqlGeneratorTests.cs" />
     <Compile Include="Unit\Generators\OracleGeneratorTests.cs" />
     <Compile Include="Unit\Expressions\PerformDBOperationExpressionTests.cs" />
+    <Compile Include="Unit\Generators\SqliteGeneratorWithConventionsAppliedTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2000GeneratorTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2005GeneratorTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2008GeneratorTests.cs" />

--- a/src/FluentMigrator.Tests/Unit/Generators/SqliteGeneratorTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqliteGeneratorTests.cs
@@ -16,6 +16,7 @@
 //
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Data;
 using FluentMigrator.Builders.Insert;
@@ -55,7 +56,15 @@ namespace FluentMigrator.Tests.Unit.Generators
 			sql.ShouldBe(string.Format("CREATE TABLE [{0}] (NewColumn TEXT NOT NULL)", table));
 		}
 
-		[Test]
+        [Test]
+        public void CanCreateTableWithAutoIncrement()
+        {
+            var expression = GetCreateTableWithPrimaryKeyIdentityExpression();
+            var sql = generator.Generate(expression);
+            sql.ShouldBe(string.Format("CREATE TABLE [{0}] (NewColumn INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT)", table));
+        }
+
+	    [Test]
 		public void CanRenameTable()
 		{
 			RenameTableExpression expression = new RenameTableExpression { OldName = oldTable, NewName = newTable };
@@ -178,6 +187,13 @@ namespace FluentMigrator.Tests.Unit.Generators
 			ColumnDefinition column = new ColumnDefinition { Name = newColumn, IsIdentity = true, IsPrimaryKey = true, Type = DbType.String };
 			return new CreateColumnExpression { TableName = table, Column = column };
 		}
+
+        private CreateTableExpression GetCreateTableWithPrimaryKeyIdentityExpression()
+        {
+            var expression = new CreateTableExpression {TableName = table};
+            expression.Columns.Add(new ColumnDefinition { Name = newColumn, IsIdentity = true, IsPrimaryKey = true, Type = DbType.String });
+            return expression;
+        }
 
 		private CreateTableExpression GetCreateTableExpression()
 		{

--- a/src/FluentMigrator.Tests/Unit/Generators/SqliteGeneratorWithConventionsAppliedTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqliteGeneratorWithConventionsAppliedTests.cs
@@ -1,0 +1,188 @@
+using System.Linq;
+using System.Collections.Generic;
+using System.Data;
+using FluentMigrator.Expressions;
+using FluentMigrator.Model;
+using FluentMigrator.Runner.Generators;
+using NUnit.Framework;
+using NUnit.Should;
+
+namespace FluentMigrator.Tests.Unit.Generators
+{
+    [TestFixture]
+    public class SqliteGeneratorWithConventionsAppliedTests
+    {
+        SqliteGenerator generator;
+		string table = "Table";
+		private string oldTable = "OldTable";
+		string newTable = "NewTable";
+
+		string column = "Column";
+        string newColumn = "NewColumn";
+
+		string indexName = "indexed-column";
+		string indexColumn = "IndexColumn";
+
+        public SqliteGeneratorWithConventionsAppliedTests()
+		{
+			generator = new SqliteGenerator();
+		}
+
+		[Test]
+		public void CanCreateTable()
+		{
+			var expression = GetCreateTableExpression();
+		    ApplyDefaultConventions(expression);
+			var sql = generator.Generate(expression);
+			sql.ShouldBe(string.Format("CREATE TABLE [{0}] (NewColumn TEXT NOT NULL)", table));
+		}
+
+        [Test]
+        public void CanCreateTableWithAutoIncrementPrimaryKey()
+        {
+            var expression = GetCreateTableWithPrimaryKeyIdentityExpression();
+            ApplyDefaultConventions(expression);
+            var sql = generator.Generate(expression);
+            sql.ShouldBe(string.Format("CREATE TABLE [{0}] (NewColumn INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT)", table));
+        }
+
+        [Test]
+        public void CanCreateTableWithMultipartPrimaryKey()
+        {
+            var expression = GetCreateTableExpression();
+            expression.Columns.Add(new ColumnDefinition{Name = "OtherColumn",Type = DbType.String, TableName = expression.TableName});
+            expression.Columns[0].IsPrimaryKey = true;
+            expression.Columns[1].IsPrimaryKey = true;
+
+            ApplyDefaultConventions(expression);
+
+            var sql = generator.Generate(expression);
+            sql.ShouldBe(string.Format("CREATE TABLE [{0}] (NewColumn TEXT NOT NULL, OtherColumn TEXT NOT NULL, CONSTRAINT PK_{0} PRIMARY KEY (NewColumn,OtherColumn))", table));
+        }
+
+	    [Test]
+		public void CanRenameTable()
+		{
+			var expression = new RenameTableExpression { OldName = oldTable, NewName = newTable };
+            ApplyDefaultConventions(expression);
+			var sql = generator.Generate(expression);
+			sql.ShouldBe(string.Format("ALTER TABLE [{0}] RENAME TO [{1}]", oldTable, newTable));
+		}
+
+		[Test]
+		public void CanDeleteTable()
+		{
+			var expression = new DeleteTableExpression { TableName = table };
+            ApplyDefaultConventions(expression);
+			var sql = generator.Generate(expression);
+			sql.ShouldBe(string.Format("DROP TABLE [{0}]", table));
+		}
+
+		[Test]
+		public void CanCreateColumn()
+		{
+			var expression = GetCreateColumnExpression();
+            ApplyDefaultConventions(expression);
+			var sql = generator.Generate(expression);
+			sql.ShouldBe(string.Format("ALTER TABLE [{0}] ADD COLUMN {1} TEXT NOT NULL", table, newColumn));
+		}
+
+		[Test]
+		public void CanAddDecimalColumn()
+		{
+			var tableName = "NewTable";
+			var columnDefinition = new ColumnDefinition {Name = "NewColumn", Size = 19, Precision = 2, Type = DbType.Decimal};
+		    var expression = new CreateColumnExpression {Column = columnDefinition, TableName = tableName};
+
+            ApplyDefaultConventions(expression);
+		    var sql = generator.Generate(expression);
+			sql.ShouldBe("ALTER TABLE [NewTable] ADD COLUMN NewColumn NUMERIC NOT NULL");
+		}
+
+		[Test]
+		public void CanCreateAutoIncrementColumn()
+		{
+			var expression = GetCreateAutoIncrementColumnExpression();
+            ApplyDefaultConventions(expression);
+			var sql = generator.Generate(expression);
+			sql.ShouldBe(string.Format("ALTER TABLE [{0}] ADD COLUMN {1} INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT", table, newColumn));
+		}
+
+		[Test]
+		public void CanDeleteColumn()
+		{
+			var expression = new DeleteColumnExpression { TableName = table, ColumnName = column };
+            ApplyDefaultConventions(expression);
+			var sql = generator.Generate(expression);
+			sql.ShouldBe(string.Format("ALTER TABLE [{0}] DROP COLUMN {1}", table, column));
+		}
+
+		[Test]
+		public void CanCreateBasicIndex()
+		{
+			var expression = GetCreateIndexExpression();
+            ApplyDefaultConventions(expression);
+			var sql = generator.Generate(expression);
+			sql.ShouldBe(string.Format("CREATE INDEX IF NOT EXISTS {0} ON {1} ({2})", indexName, table, indexColumn));
+		}
+
+        [Test]
+		public void CanInsertData()
+		{
+			var expression = new InsertDataExpression {TableName = "TestTable"};
+		    expression.Rows.Add(new InsertionDataDefinition { new KeyValuePair<string, object>("Id", 1), 
+													new KeyValuePair<string, object>("Name", "Justin"),
+													new KeyValuePair<string, object>("Website", "codethinked.com") });
+			expression.Rows.Add(new InsertionDataDefinition { new KeyValuePair<string, object>("Id", 2), 
+													new KeyValuePair<string, object>("Name", "Nate"),
+													new KeyValuePair<string, object>("Website", "kohari.org") });
+            
+            ApplyDefaultConventions(expression);
+			
+            var sql = generator.Generate(expression);
+
+			var expected = "INSERT INTO [TestTable] (Id,Name,Website) VALUES (1,'Justin','codethinked.com');";
+			expected += "INSERT INTO [TestTable] (Id,Name,Website) VALUES (2,'Nate','kohari.org');";
+
+			sql.ShouldBe(expected);
+		}
+        
+        private void ApplyDefaultConventions(IMigrationExpression expression)
+        {
+            expression.ApplyConventions(new MigrationConventions());
+        }
+        
+        private CreateIndexExpression GetCreateIndexExpression()
+		{
+			IndexColumnDefinition indexColumnDefinition = new IndexColumnDefinition { Name = indexColumn };
+			IndexDefinition indexDefinition = new IndexDefinition { TableName = table, Name = indexName, Columns = new List<IndexColumnDefinition> { indexColumnDefinition } };
+			return new CreateIndexExpression { Index = indexDefinition };
+		}
+
+		private CreateColumnExpression GetCreateColumnExpression()
+		{
+			ColumnDefinition column = new ColumnDefinition { Name = newColumn, Type = DbType.String };
+			return new CreateColumnExpression { TableName = table, Column = column };
+		}
+
+		private CreateColumnExpression GetCreateAutoIncrementColumnExpression()
+		{
+			var column = new ColumnDefinition { Name = newColumn, IsIdentity = true, IsPrimaryKey = true, Type = DbType.String };
+			return new CreateColumnExpression { TableName = table, Column = column };
+		}
+
+        private CreateTableExpression GetCreateTableWithPrimaryKeyIdentityExpression()
+        {
+            var expression = new CreateTableExpression {TableName = table};
+            expression.Columns.Add(new ColumnDefinition { Name = newColumn, IsIdentity = true, IsPrimaryKey = true, Type = DbType.String, TableName = table});
+            return expression;  
+        }
+
+		private CreateTableExpression GetCreateTableExpression()
+		{
+			CreateTableExpression expression = new CreateTableExpression() { TableName = table, };
+			expression.Columns.Add(new ColumnDefinition { Name = newColumn, Type = DbType.String, TableName = table});
+			return expression;
+		}
+    }
+}


### PR DESCRIPTION
Added some additional tests for the effects of applying default conventions. Fixed a syntax issue with SQLite as it does not support separating AUTOINCREMENT and PRIMARY KEY definitions.
