### PR TITLE
Patches/usetimeoutformysqlcommands

### DIFF
--- a/src/FluentMigrator.Runner/Processors/MySql/MySqlProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/MySql/MySqlProcessor.cs
@@ -74,6 +74,7 @@ namespace FluentMigrator.Runner.Processors.MySql
 
 			using (var command = new MySqlCommand(String.Format(template, args), Connection))
 			{
+			    command.CommandTimeout = Options.Timeout;
 				command.ExecuteNonQuery();
 			}
 		}
@@ -82,21 +83,24 @@ namespace FluentMigrator.Runner.Processors.MySql
 		{
 			if (Connection.State != ConnectionState.Open) Connection.Open();
 
-			using (var command = new MySqlCommand(String.Format(template, args), Connection))
-			using (var reader = command.ExecuteReader())
-			{
-				try
-				{
-					if (!reader.Read())
-						return false;
+            using (var command = new MySqlCommand(String.Format(template, args), Connection))
+            {
+                command.CommandTimeout = Options.Timeout;
+                using (var reader = command.ExecuteReader())
+                {
+                    try
+                    {
+                        if (!reader.Read())
+                            return false;
 
-					return true;
-				}
-				catch
-				{
-					return false;
-				}
-			}
+                        return true;
+                    }
+                    catch
+                    {
+                        return false;
+                    }
+                }
+            }
 		}
 
 		public override DataSet ReadTableData(string tableName)
@@ -109,12 +113,16 @@ namespace FluentMigrator.Runner.Processors.MySql
 			if (Connection.State != ConnectionState.Open) Connection.Open();
 
 			DataSet ds = new DataSet();
-			using (var command = new MySqlCommand(String.Format(template, args), Connection))
-			using (MySqlDataAdapter adapter = new MySqlDataAdapter(command))
-			{
-				adapter.Fill(ds);
-				return ds;
-			}
+            using (var command = new MySqlCommand(String.Format(template, args), Connection))
+            {
+                command.CommandTimeout = Options.Timeout;
+
+                using (MySqlDataAdapter adapter = new MySqlDataAdapter(command))
+                {
+                    adapter.Fill(ds);
+                    return ds;
+                }
+            }
 		}
 
 		protected override void Process(string sql)
@@ -127,8 +135,11 @@ namespace FluentMigrator.Runner.Processors.MySql
 			if (Connection.State != ConnectionState.Open)
 				Connection.Open();
 
-			using (var command = new MySqlCommand(sql, Connection))
-				command.ExecuteNonQuery();
+            using (var command = new MySqlCommand(sql, Connection))
+            {
+                command.CommandTimeout = Options.Timeout;
+                command.ExecuteNonQuery();
+            }
 		}
 
 		public override void Process(PerformDBOperationExpression expression)


### PR DESCRIPTION
I found that the Timeout setting is currently being ignored when running MySql commands, so I applied it to all the MySqlCommands.  Let me know if this was not the intention of that setting but it appeared to be the right usage from what I could tell by looking at some of the other providers.
