### PR TITLE
Culture ignorant number conversions

### DIFF
--- a/src/FluentMigrator.Runner/Generators/Generic/GenericQuoter.cs
+++ b/src/FluentMigrator.Runner/Generators/Generic/GenericQuoter.cs
@@ -1,5 +1,7 @@
 ﻿
 
+using System.Globalization;
+
 namespace FluentMigrator.Runner.Generators.Generic
 {
     using System;
@@ -18,7 +20,26 @@ namespace FluentMigrator.Runner.Generators.Generic
             if (value is Guid) { return FormatGuid((Guid)value); }
             if (value is DateTime) { return FormatDateTime((DateTime)value); }
             if (value.GetType().IsEnum) { return FormatEnum(value); }
+            if (value is double) {return FormatDouble((double)value);}
+            if (value is float) {return FormatFloat((float)value);}
+            if (value is decimal) { return FormatDecimal((decimal)value); }
+            
             return value.ToString();
+        }
+
+        private string FormatDecimal(decimal value)
+        {
+            return value.ToString(CultureInfo.InvariantCulture);
+        }
+
+        private string FormatFloat(float value)
+        {
+            return value.ToString(CultureInfo.InvariantCulture);
+        }
+
+        private string FormatDouble(double value)
+        {
+            return value.ToString(CultureInfo.InvariantCulture);
         }
 
         public virtual string FormatNull()

--- a/src/FluentMigrator.Tests/Unit/Generators/GenericGenerator/QuoterTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/GenericGenerator/QuoterTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Globalization;
+using System.Threading;
 using FluentMigrator.Runner.Generators;
 using NUnit.Framework;
 using NUnit.Should;
@@ -15,7 +17,9 @@ namespace FluentMigrator.Tests.Unit.Generators
 	[TestFixture]
 	public class ConstantFormatterTests
 	{
+        
 		private IQuoter quoter = default(GenericQuoter);
+	    private CultureInfo currentCulture = Thread.CurrentThread.CurrentCulture;
 
 		[SetUp]
 		public void SetUp()
@@ -200,7 +204,42 @@ namespace FluentMigrator.Tests.Unit.Generators
             quoter.Quote("Table'name").ShouldBe("'Table''name'");
         }
 
-        private enum Foo
+        [Test]
+        public void ShouldHandleDoubleToStringConversionInAnyCulture()
+        {
+            ChangeCulture();
+            quoter.QuoteValue(123.4d).ShouldBe("123.4");
+            RestoreCulture();
+        }
+
+        [Test]
+        public void ShouldHandleFloatToStringConversionInAnyCulture()
+        {
+            ChangeCulture();
+            quoter.QuoteValue(123.4f).ShouldBe("123.4");
+            RestoreCulture();
+        }
+
+        [Test]
+        public void ShouldHandleDecimalToStringConversionInAnyCulture()
+        {           
+            ChangeCulture();
+            quoter.QuoteValue(new Decimal(123.4d)).ShouldBe("123.4");
+            RestoreCulture();
+        }
+
+	    private void RestoreCulture()
+	    {
+	        Thread.CurrentThread.CurrentCulture = currentCulture;
+	    }
+
+	    private void ChangeCulture()
+	    {
+	        Thread.CurrentThread.CurrentCulture = new CultureInfo("nb-NO");
+	    }
+
+
+	    private enum Foo
         {
             Bar,
             Baz


### PR DESCRIPTION
I've made the string conversion for colomn values culture ignorant for decimal, float and doubles, to support cultures that uses comma instead of period as decimal separator. I've also included tests that demostrates the problem and verifies the solution.
