### PR TITLE
Fix schema integration tests for SqlServer

### DIFF
--- a/src/FluentMigrator.Runner/Processors/SqlServer/SqlServerProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/SqlServer/SqlServerProcessor.cs
@@ -96,7 +96,7 @@ namespace FluentMigrator.Runner.Processors.SqlServer
 
         public override DataSet ReadTableData(string schemaName, string tableName)
 		{
-			return Read("SELECT * FROM [{0}]", tableName);
+            return Read("SELECT * FROM [{0}].[{1}]", SafeSchemaName(schemaName), tableName);
 		}
 
 		public override DataSet Read(string template, params object[] args)

--- a/src/FluentMigrator.Tests/Integration/IntegrationTestBase.cs
+++ b/src/FluentMigrator.Tests/Integration/IntegrationTestBase.cs
@@ -21,7 +21,6 @@ using System.Data.SqlClient;
 using System.Data.SQLite;
 using System.Linq;
 using FluentMigrator.Runner.Announcers;
-using FluentMigrator.Runner.Generators;
 using FluentMigrator.Runner.Generators.Postgres;
 using FluentMigrator.Runner.Processors;
 using FluentMigrator.Runner.Processors.MySql;
@@ -51,7 +50,10 @@ namespace FluentMigrator.Tests.Integration
 		public void ExecuteWithSupportedProcessors(Action<IMigrationProcessor> test, Boolean tryRollback, params Type[] exceptProcessors)
 		{
 			if (exceptProcessors.Count(t => typeof(SqlServerProcessor).IsAssignableFrom(t)) == 0)
-				ExecuteWithSqlServer(test, IntegrationTestOptions.SqlServer, tryRollback);
+			{
+                ExecuteWithSqlServer2005(test, tryRollback);
+                ExecuteWithSqlServer2008(test, tryRollback);
+			}
 			if (exceptProcessors.Count(t => typeof(SqliteProcessor).IsAssignableFrom(t)) == 0)
 				ExecuteWithSqlite(test, IntegrationTestOptions.SqlLite);
 			if (exceptProcessors.Count(t => typeof(MySqlProcessor).IsAssignableFrom(t)) == 0)
@@ -60,25 +62,50 @@ namespace FluentMigrator.Tests.Integration
 				ExecuteWithPostgres(test, IntegrationTestOptions.Postgres, tryRollback);
 		}
 
-		protected static void ExecuteWithSqlServer(Action<IMigrationProcessor> test, IntegrationTestOptions.DatabaseServerOptions serverOptions, Boolean tryRollback)
-		{
-			if (!serverOptions.IsEnabled)
-				return;
+        protected static void ExecuteWithSqlServer2008(Action<IMigrationProcessor> test, bool tryRollback)
+        {
 
-			var announcer = new TextWriterAnnouncer(System.Console.Out);
-			announcer.Heading("Testing Migration against MS SQL Server");
+            var serverOptions = IntegrationTestOptions.SqlServer2008;
 
-			using (var connection = new SqlConnection(serverOptions.ConnectionString))
-			{
-				var processor = new SqlServerProcessor(connection, new SqlServer2000Generator(), announcer, new ProcessorOptions());
-				test(processor);
+            if (!serverOptions.IsEnabled)
+                return;
 
-				if (tryRollback && !processor.WasCommitted)
-				{
-					processor.RollbackTransaction();
-				}
-			}
-		}
+            var announcer = new TextWriterAnnouncer(System.Console.Out);
+            announcer.Heading("Testing Migration against MS SQL Server 2008");
+            var generator = new SqlServer2008Generator();
+
+            ExecuteWithSqlServer(serverOptions, announcer, generator, test, tryRollback);
+        }
+
+        protected static void ExecuteWithSqlServer2005(Action<IMigrationProcessor> test, bool tryRollback)
+        {
+
+            var serverOptions = IntegrationTestOptions.SqlServer2005;
+
+            if (!serverOptions.IsEnabled)
+                return;
+
+            var announcer = new TextWriterAnnouncer(System.Console.Out);
+            announcer.Heading("Testing Migration against MS SQL Server 2005");
+            var generator = new SqlServer2005Generator();
+
+            ExecuteWithSqlServer(serverOptions, announcer, generator, test, tryRollback);
+        }
+
+        private static void ExecuteWithSqlServer(IntegrationTestOptions.DatabaseServerOptions serverOptions, TextWriterAnnouncer announcer, SqlServer2005Generator generator, Action<IMigrationProcessor> test, bool tryRollback)
+        {
+            using (var connection = new SqlConnection(serverOptions.ConnectionString))
+            {
+
+                var processor = new SqlServerProcessor(connection, generator, announcer, new ProcessorOptions());
+                test(processor);
+
+                if (tryRollback && !processor.WasCommitted)
+                {
+                    processor.RollbackTransaction();
+                }
+            }
+        }
 
 		protected static void ExecuteWithSqlite(Action<IMigrationProcessor> test, IntegrationTestOptions.DatabaseServerOptions serverOptions)
 		{

--- a/src/FluentMigrator.Tests/Integration/MigrationRunnerTests.cs
+++ b/src/FluentMigrator.Tests/Integration/MigrationRunnerTests.cs
@@ -46,9 +46,6 @@ namespace FluentMigrator.Tests.Integration
 		{
 			_runnerContext = new RunnerContext(new TextWriterAnnouncer(System.Console.Out))
 										{
-											Database = "sqlserver",
-											Target = GetType().Assembly.Location,
-											Connection = IntegrationTestOptions.SqlServer.ConnectionString,
 											Namespace = "FluentMigrator.Tests.Integration.Migrations"
 										};
 		}
@@ -119,7 +116,7 @@ namespace FluentMigrator.Tests.Integration
                     runner.Up(new TestForeignKeyNamingConventionWithSchema());
 
                     processor.ConstraintExists("TestSchema", "Users", "FK_Users_GroupId_Groups_GroupId").ShouldBeTrue();
-                    runner.Down(new TestForeignKeyNamingConvention());
+                    runner.Down(new TestForeignKeyNamingConventionWithSchema());
                 }, false, typeof(SqliteProcessor));
         }
 
@@ -153,7 +150,7 @@ namespace FluentMigrator.Tests.Integration
                     processor.IndexExists("TestSchema", "Users", "IX_Users_GroupId").ShouldBeTrue();
                     processor.TableExists("TestSchema", "Users").ShouldBeTrue();
 
-                    runner.Down(new TestIndexNamingConvention());
+                    runner.Down(new TestIndexNamingConventionWithSchema());
                     processor.IndexExists("TestSchema", "Users", "IX_Users_GroupId").ShouldBeFalse();
                     processor.TableExists("TestSchema", "Users").ShouldBeFalse();
                 });
@@ -191,18 +188,21 @@ namespace FluentMigrator.Tests.Integration
                 {
                     var runner = new MigrationRunner(Assembly.GetExecutingAssembly(), _runnerContext, processor);
 
+                    runner.Up(new TestCreateSchema());
+
                     runner.Up(new TestCreateAndDropTableMigrationWithSchema());
                     processor.IndexExists("TestSchema", "TestTable", "IX_TestTable_Name").ShouldBeFalse();
 
-                    runner.Up(new TestCreateAndDropIndexMigration());
+                    runner.Up(new TestCreateAndDropIndexMigrationWithSchema());
                     processor.IndexExists("TestSchema", "TestTable", "IX_TestTable_Name").ShouldBeTrue();
 
-                    runner.Down(new TestCreateAndDropIndexMigration());
+                    runner.Down(new TestCreateAndDropIndexMigrationWithSchema());
                     processor.IndexExists("TestSchema", "TestTable", "IX_TestTable_Name").ShouldBeFalse();
 
-                    runner.Down(new TestCreateAndDropTableMigration());
+                    runner.Down(new TestCreateAndDropTableMigrationWithSchema());
                     processor.IndexExists("TestSchema", "TestTable", "IX_TestTable_Name").ShouldBeFalse();
 
+                    runner.Down(new TestCreateSchema());
                     //processor.CommitTransaction();
                 });
         }
@@ -241,19 +241,23 @@ namespace FluentMigrator.Tests.Integration
                 {
                     var runner = new MigrationRunner(Assembly.GetExecutingAssembly(), _runnerContext, processor);
 
+                    runner.Up(new TestCreateSchema());
+
                     runner.Up(new TestCreateAndDropTableMigrationWithSchema());
                     processor.TableExists("TestSchema", "TestTable2").ShouldBeTrue();
 
-                    runner.Up(new TestRenameTableMigration());
+                    runner.Up(new TestRenameTableMigrationWithSchema());
                     processor.TableExists("TestSchema", "TestTable2").ShouldBeFalse();
                     processor.TableExists("TestSchema", "TestTable'3").ShouldBeTrue();
 
-                    runner.Down(new TestRenameTableMigration());
+                    runner.Down(new TestRenameTableMigrationWithSchema());
                     processor.TableExists("TestSchema", "TestTable'3").ShouldBeFalse();
                     processor.TableExists("TestSchema", "TestTable2").ShouldBeTrue();
 
-                    runner.Down(new TestCreateAndDropTableMigration());
+                    runner.Down(new TestCreateAndDropTableMigrationWithSchema());
                     processor.TableExists("TestSchema", "TestTable2").ShouldBeFalse();
+
+                    runner.Down(new TestCreateSchema());
 
                     //processor.CommitTransaction();
                 });
@@ -291,19 +295,23 @@ namespace FluentMigrator.Tests.Integration
                 {
                     var runner = new MigrationRunner(Assembly.GetExecutingAssembly(), _runnerContext, processor);
 
+                    runner.Up(new TestCreateSchema());
+
                     runner.Up(new TestCreateAndDropTableMigrationWithSchema());
                     processor.ColumnExists("TestSchema", "TestTable2", "Name").ShouldBeTrue();
 
-                    runner.Up(new TestRenameColumnMigration());
+                    runner.Up(new TestRenameColumnMigrationWithSchema());
                     processor.ColumnExists("TestSchema", "TestTable2", "Name").ShouldBeFalse();
                     processor.ColumnExists("TestSchema", "TestTable2", "Name'3").ShouldBeTrue();
 
-                    runner.Down(new TestRenameColumnMigration());
+                    runner.Down(new TestRenameColumnMigrationWithSchema());
                     processor.ColumnExists("TestSchema", "TestTable2", "Name'3").ShouldBeFalse();
                     processor.ColumnExists("TestSchema", "TestTable2", "Name").ShouldBeTrue();
 
-                    runner.Down(new TestCreateAndDropTableMigration());
+                    runner.Down(new TestCreateAndDropTableMigrationWithSchema());
                     processor.ColumnExists("TestSchema", "TestTable2", "Name").ShouldBeFalse();
+
+                    runner.Down(new TestCreateSchema());
 				}, true, typeof(SqliteProcessor));
         }
 
@@ -389,7 +397,7 @@ namespace FluentMigrator.Tests.Integration
 				ExecuteWithSupportedProcessors(processor =>
 				{
 					MigrationRunner testRunner = SetupMigrationRunner(processor);
-					testRunner.MigrateDown(1);
+					testRunner.MigrateDown(0);
 
 					testRunner.VersionLoader.VersionInfo.HasAppliedMigration(1).ShouldBeFalse();
 					processor.TableExists(null, "Users").ShouldBeFalse();
@@ -430,11 +438,11 @@ namespace FluentMigrator.Tests.Integration
 		[Test]
 		public void MigrateUpWithSqlServerProcessorShouldCommitItsTransaction()
 		{
-			if (!IntegrationTestOptions.SqlServer.IsEnabled)
+			if (!IntegrationTestOptions.SqlServer2008.IsEnabled)
 				return;
 
-			var connection = new SqlConnection(IntegrationTestOptions.SqlServer.ConnectionString);
-			var processor = new SqlServerProcessor(connection, new SqlServer2000Generator(), new TextWriterAnnouncer(System.Console.Out), new ProcessorOptions());
+			var connection = new SqlConnection(IntegrationTestOptions.SqlServer2008.ConnectionString);
+			var processor = new SqlServerProcessor(connection, new SqlServer2008Generator(), new TextWriterAnnouncer(System.Console.Out), new ProcessorOptions());
 
 			MigrationRunner runner = SetupMigrationRunner(processor);
 			runner.MigrateUp();
@@ -453,11 +461,11 @@ namespace FluentMigrator.Tests.Integration
 		[Test]
 		public void MigrateUpSpecificVersionWithSqlServerProcessorShouldCommitItsTransaction()
 		{
-			if (!IntegrationTestOptions.SqlServer.IsEnabled)
+			if (!IntegrationTestOptions.SqlServer2008.IsEnabled)
 				return;
 
-			var connection = new SqlConnection(IntegrationTestOptions.SqlServer.ConnectionString);
-			var processor = new SqlServerProcessor(connection, new SqlServer2000Generator(), new TextWriterAnnouncer(System.Console.Out), new ProcessorOptions());
+			var connection = new SqlConnection(IntegrationTestOptions.SqlServer2008.ConnectionString);
+			var processor = new SqlServerProcessor(connection, new SqlServer2008Generator(), new TextWriterAnnouncer(System.Console.Out), new ProcessorOptions());
 
 			MigrationRunner runner = SetupMigrationRunner(processor);
 			runner.MigrateUp(1);
@@ -491,7 +499,7 @@ namespace FluentMigrator.Tests.Integration
 			{
 				connection.Close();
 
-				var cleanupProcessor = new SqlServerProcessor(connection, new SqlServer2000Generator(), new TextWriterAnnouncer(System.Console.Out), new ProcessorOptions());
+				var cleanupProcessor = new SqlServerProcessor(connection, new SqlServer2008Generator(), new TextWriterAnnouncer(System.Console.Out), new ProcessorOptions());
 				MigrationRunner cleanupRunner = SetupMigrationRunner(cleanupProcessor);
 				cleanupRunner.RollbackToVersion(0);
 
@@ -639,6 +647,7 @@ namespace FluentMigrator.Tests.Integration
     {
         public override void Up()
         {
+            Create.Schema("TestSchema");
             Create.Table("Users")
                 .InSchema("TestSchema")
                 .WithColumn("UserId").AsInt32().Identity().PrimaryKey()
@@ -656,8 +665,9 @@ namespace FluentMigrator.Tests.Integration
 
         public override void Down()
         {
-            Delete.Table("Users");
-            Delete.Table("Groups");
+            Delete.Table("Users").InSchema("TestSchema");
+            Delete.Table("Groups").InSchema("TestSchema");
+            Delete.Schema("TestSchema");
         }
     }
 
@@ -665,6 +675,8 @@ namespace FluentMigrator.Tests.Integration
     {
         public override void Up()
         {
+            Create.Schema("TestSchema");
+
             Create.Table("Users")
                 .InSchema("TestSchema")
                 .WithColumn("UserId").AsInt32().Identity().PrimaryKey()
@@ -677,8 +689,9 @@ namespace FluentMigrator.Tests.Integration
 
         public override void Down()
         {
-            Delete.Index("IX_Users_GroupId").OnTable("Users").OnColumn("GroupId");
-            Delete.Table("Users");
+            Delete.Index("IX_Users_GroupId").OnTable("Users").InSchema("TestSchema").OnColumn("GroupId");
+            Delete.Table("Users").InSchema("TestSchema");
+            Delete.Schema("TestSchema");
         }
     }
 
@@ -745,5 +758,17 @@ namespace FluentMigrator.Tests.Integration
         }
     }
 
+    internal class TestCreateSchema : Migration
+    {
+        public override void Up()
+        {
+            Create.Schema("TestSchema");
+        }
+
+        public override void Down()
+        {
+            Delete.Schema("TestSchema");
+        }
+    }
 
 }

--- a/src/FluentMigrator.Tests/Integration/PerformDBOperationTests.cs
+++ b/src/FluentMigrator.Tests/Integration/PerformDBOperationTests.cs
@@ -32,7 +32,7 @@ namespace FluentMigrator.Tests.Integration
 				}
 			};
 
-			ExecuteWithSqlServer(processor => processor.Process(expression), IntegrationTestOptions.SqlServer, true);
+			ExecuteWithSqlServer2008(processor => processor.Process(expression), true);
 		}
 	}
 }

--- a/src/FluentMigrator.Tests/Integration/Processors/SqlServerProcessorTests.cs
+++ b/src/FluentMigrator.Tests/Integration/Processors/SqlServerProcessorTests.cs
@@ -37,8 +37,8 @@ namespace FluentMigrator.Tests.Integration.Processors
 		[SetUp]
 		public void SetUp()
 		{
-			Connection = new SqlConnection(IntegrationTestOptions.SqlServer.ConnectionString);
-			Processor = new SqlServerProcessor(Connection, new SqlServer2000Generator(), new TextWriterAnnouncer(System.Console.Out), new ProcessorOptions());
+			Connection = new SqlConnection(IntegrationTestOptions.SqlServer2008.ConnectionString);
+			Processor = new SqlServerProcessor(Connection, new SqlServer2008Generator(), new TextWriterAnnouncer(System.Console.Out), new ProcessorOptions());
 		}
 
 		[TearDown]

--- a/src/FluentMigrator.Tests/Integration/SchemaDump/SchemaDumpTests.cs
+++ b/src/FluentMigrator.Tests/Integration/SchemaDump/SchemaDumpTests.cs
@@ -30,8 +30,8 @@ namespace FluentMigrator.Tests.Integration.SchemaDump {
         
         public SchemaDumpTests() 
         {
-            Connection = new SqlConnection(IntegrationTestOptions.SqlServer.ConnectionString);
-            Processor = new SqlServerProcessor(Connection, new SqlServer2000Generator(), new TextWriterAnnouncer(System.Console.Out), new ProcessorOptions());
+            Connection = new SqlConnection(IntegrationTestOptions.SqlServer2008.ConnectionString);
+            Processor = new SqlServerProcessor(Connection, new SqlServer2008Generator(), new TextWriterAnnouncer(System.Console.Out), new ProcessorOptions());
             SchemaDumper = new SqlServerSchemaDumper(Processor, new TextWriterAnnouncer(System.Console.Out));
         }
 

--- a/src/FluentMigrator.Tests/IntegrationTestOptions.cs
+++ b/src/FluentMigrator.Tests/IntegrationTestOptions.cs
@@ -2,12 +2,19 @@
 {
 	public static class IntegrationTestOptions
 	{
-		public static DatabaseServerOptions SqlServer = new DatabaseServerOptions
-															{
-																ConnectionString =
-                                                                    @"server=.\SQLEXPRESS;uid=;pwd=;Trusted_Connection=yes;database=FluentMigrator",
-																IsEnabled = false
-															};
+        public static DatabaseServerOptions SqlServer2005 = new DatabaseServerOptions
+        {
+            ConnectionString =
+                @"server=.\SQLEXPRESS;uid=;pwd=;Trusted_Connection=yes;database=FluentMigrator",
+            IsEnabled = false
+        };
+
+        public static DatabaseServerOptions SqlServer2008 = new DatabaseServerOptions
+        {
+            ConnectionString =
+                @"server=.\SQLEXPRESS;uid=;pwd=;Trusted_Connection=yes;database=FluentMigrator",
+            IsEnabled = false
+        };
 
 		public static DatabaseServerOptions SqlLite = new DatabaseServerOptions
 															{

--- a/src/FluentMigrator.Tests/Unit/MigrationRunnerTests.cs
+++ b/src/FluentMigrator.Tests/Unit/MigrationRunnerTests.cs
@@ -62,7 +62,7 @@ namespace FluentMigrator.Tests.Unit
 			_runnerContextMock.SetupGet(x => x.Announcer).Returns(_announcer.Object);
 			_runnerContextMock.SetupGet(x => x.StopWatch).Returns(_stopWatch.Object);
 			_runnerContextMock.SetupGet(x => x.Target).Returns(Assembly.GetExecutingAssembly().ToString());
-			_runnerContextMock.SetupGet(x => x.Connection).Returns(IntegrationTestOptions.SqlServer.ConnectionString);
+			_runnerContextMock.SetupGet(x => x.Connection).Returns(IntegrationTestOptions.SqlServer2008.ConnectionString);
 			_runnerContextMock.SetupGet(x => x.Database).Returns("sqlserver");
 
 			_runner = new MigrationRunner(Assembly.GetAssembly( typeof( MigrationRunnerTests ) ), _runnerContextMock.Object, _processorMock.Object)

--- a/src/FluentMigrator.Tests/Unit/TaskExecutorTests.cs
+++ b/src/FluentMigrator.Tests/Unit/TaskExecutorTests.cs
@@ -49,7 +49,7 @@ namespace FluentMigrator.Tests.Integration
 
 			var runnerContext = new Mock<IRunnerContext>();
 			runnerContext.SetupGet(x => x.Database).Returns("sqlserver");
-			runnerContext.SetupGet(x => x.Connection).Returns(IntegrationTestOptions.SqlServer.ConnectionString);
+			runnerContext.SetupGet(x => x.Connection).Returns(IntegrationTestOptions.SqlServer2008.ConnectionString);
 			runnerContext.SetupGet(x => x.Task).Returns(task);
 			runnerContext.SetupGet(x => x.Version).Returns(version);
 			runnerContext.SetupGet(x => x.Steps).Returns(steps);


### PR DESCRIPTION
Fixed schema integration tests for Sql Server and a schema bug in
SqlServerProcessor. Started the process of removing support for
Sql Server 2000.
- MigrationRunnerTests. Fixed the tests that tested schemas. Some tests
  had bugs(wrong migration used for Down) and some migrations had
  incorrect Down actions.
- SqlServerProcessor. Method ReadTableData uses the schema parameter to
  build select statement.
- IntegrationTestBase. Added SqlServer2005 and SqlServer2008 to list of
  servers for integration tests.
- IntegrationTestOptions. Divided connection string for Sql Server into
  2 connection strings for SqlServer2005 and SqlServer2008.
- Other files. Made SqlServer2008Generator the default for
  integration tests.
