### PR TITLE
Add escaping single quotes in PostgresProcessor

### DIFF
--- a/src/FluentMigrator.Tests/Helpers/PostgresTestTable.cs
+++ b/src/FluentMigrator.Tests/Helpers/PostgresTestTable.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Text;
+using FluentMigrator.Runner.Generators.Postgres;
 using FluentMigrator.Runner.Processors.Postgres;
 using Npgsql;
 
@@ -9,22 +9,37 @@ namespace FluentMigrator.Tests.Helpers
 {
     public class PostgresTestTable : IDisposable
     {
+        private readonly PostgresQuoter quoter = new PostgresQuoter();
         private readonly string _schemaName;
         public NpgsqlConnection Connection { get; private set; }
         public string Name { get; set; }
         public string NameWithSchema { get; set; }
         public NpgsqlTransaction Transaction { get; private set; }
 
-        public PostgresTestTable(PostgresProcessor processor, string schemaName, params string[] columnDefinitions)
+        public PostgresTestTable(PostgresProcessor processor, string schemaName, params string[] columnDefinitions) 
         {
             _schemaName = schemaName;
+            Name = "\"Table" + Guid.NewGuid().ToString("N") + "\"";
+            Init(processor, columnDefinitions);
+
+        }
+
+        public PostgresTestTable(string schemaName, string tableName, PostgresProcessor processor, params string[] columnDefinitions)
+        {
+            _schemaName = schemaName;
+            
+            Name = quoter.QuoteTableName(tableName);
+            Init(processor, columnDefinitions);
+        }
+
+        private void Init(PostgresProcessor processor, IEnumerable<string> columnDefinitions)
+        {      
             Connection = processor.Connection;
             Transaction = processor.Transaction;
-
-            Name = "\"Table" + Guid.NewGuid().ToString("N") + "\"";
+                
             NameWithSchema = string.IsNullOrEmpty(_schemaName) ? Name : string.Format("\"{0}\".{1}", _schemaName, Name);
             Create(columnDefinitions);
-            }
+        }
 
         public void Dispose()
         {


### PR DESCRIPTION
TableExists, ColumnExists, ConstraintExists, SchemaExists and IndexExists in PostgresProcessor do not accept single quotes in their name parameters e.g. Test'Schema. This means that the MigrationRunner integration tests do not work for Postgres and combined with my other pull request with fixes to the the MigrationRunner tests would mean no more failing tests! These methods are only really used in test code so this bug is not currently something that effects the end user.

This change adds escaping for the schema name, table name, column name, index name and constraint name parameters in the above named methods as well as the appropriate integration tests. There are some changes to PostgresTestTable as well to enable the passing of table names into the constructor.
