### PR TITLE
Fix for issue #121

### DIFF
--- a/src/FluentMigrator/Builders/IColumnTypeSyntax.cs
+++ b/src/FluentMigrator/Builders/IColumnTypeSyntax.cs
@@ -26,6 +26,7 @@ namespace FluentMigrator.Builders
 	{
 		TNext AsAnsiString();
 		TNext AsAnsiString(int size);
+	    TNext AsBinary();
 		TNext AsBinary(int size);
 		TNext AsBoolean();
 		TNext AsByte();


### PR DESCRIPTION
Added AsBinary(), so that binary columns can be created without type modifiers. This fixes a bug with PostgreSQL provider (issue #121), postgres does not allow specifying size of bytea columns.

I was unable to run the unit tests, looks like I need some test databases. This is really a quick fix which adds a method declaration to an interface because it was unusable from migrations previously.
