### PR TITLE
Solution for Issue #80 Sql Server maximun decimal capacity

### DIFF
--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2000TypeMap.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2000TypeMap.cs
@@ -7,46 +7,46 @@ namespace FluentMigrator.Runner.Generators.SqlServer
     using FluentMigrator.Runner.Generators.Base;
 
     internal class SqlServer2000TypeMap : TypeMapBase
-	{
-		public const int AnsiStringCapacity = 8000;
-		public const int AnsiTextCapacity = 2147483647;
-		public const int UnicodeStringCapacity = 4000;
-		public const int UnicodeTextCapacity = 1073741823;
-		public const int ImageCapacity = 2147483647;
-		public const int DecimalCapacity = 19;
+    {
+        public const int AnsiStringCapacity = 8000;
+        public const int AnsiTextCapacity = 2147483647;
+        public const int UnicodeStringCapacity = 4000;
+        public const int UnicodeTextCapacity = 1073741823;
+        public const int ImageCapacity = 2147483647;
+        public const int DecimalCapacity = 38;
 
-		protected override void SetupTypeMaps()
-		{
-			SetTypeMap(DbType.AnsiStringFixedLength, "CHAR(255)");
-			SetTypeMap(DbType.AnsiStringFixedLength, "CHAR($size)", AnsiStringCapacity);
-			SetTypeMap(DbType.AnsiString, "VARCHAR(255)");
-			SetTypeMap(DbType.AnsiString, "VARCHAR($size)", AnsiStringCapacity);
-			SetTypeMap(DbType.AnsiString, "TEXT", AnsiTextCapacity);
-			SetTypeMap(DbType.Binary, "VARBINARY(8000)");
-			SetTypeMap(DbType.Binary, "VARBINARY($size)", AnsiStringCapacity);
-			SetTypeMap(DbType.Binary, "VARBINARY(MAX)", int.MaxValue);
-			SetTypeMap(DbType.Binary, "IMAGE", ImageCapacity);
-			SetTypeMap(DbType.Boolean, "BIT");
-			SetTypeMap(DbType.Byte, "TINYINT");
-			SetTypeMap(DbType.Currency, "MONEY");
-			SetTypeMap(DbType.Date, "DATETIME");
-			SetTypeMap(DbType.DateTime, "DATETIME");
-			SetTypeMap(DbType.Decimal, "DECIMAL(19,5)");
-			SetTypeMap(DbType.Decimal, "DECIMAL($size,$precision)", DecimalCapacity);
-			SetTypeMap(DbType.Double, "DOUBLE PRECISION");
-			SetTypeMap(DbType.Guid, "UNIQUEIDENTIFIER");
-			SetTypeMap(DbType.Int16, "SMALLINT");
-			SetTypeMap(DbType.Int32, "INT");
-			SetTypeMap(DbType.Int64, "BIGINT");
-			SetTypeMap(DbType.Single, "REAL");
-			SetTypeMap(DbType.StringFixedLength, "NCHAR(255)");
-			SetTypeMap(DbType.StringFixedLength, "NCHAR($size)", UnicodeStringCapacity);
-			SetTypeMap(DbType.String, "NVARCHAR(255)");
-			SetTypeMap(DbType.String, "NVARCHAR($size)", UnicodeStringCapacity);
-			SetTypeMap(DbType.String, "NVARCHAR(MAX)", int.MaxValue);
-			SetTypeMap(DbType.String, "NTEXT", UnicodeTextCapacity);
-			SetTypeMap(DbType.Time, "DATETIME");
-			SetTypeMap(DbType.Xml, "XML");
-		}
-	}
+        protected override void SetupTypeMaps()
+        {
+            SetTypeMap(DbType.AnsiStringFixedLength, "CHAR(255)");
+            SetTypeMap(DbType.AnsiStringFixedLength, "CHAR($size)", AnsiStringCapacity);
+            SetTypeMap(DbType.AnsiString, "VARCHAR(255)");
+            SetTypeMap(DbType.AnsiString, "VARCHAR($size)", AnsiStringCapacity);
+            SetTypeMap(DbType.AnsiString, "TEXT", AnsiTextCapacity);
+            SetTypeMap(DbType.Binary, "VARBINARY(8000)");
+            SetTypeMap(DbType.Binary, "VARBINARY($size)", AnsiStringCapacity);
+            SetTypeMap(DbType.Binary, "VARBINARY(MAX)", int.MaxValue);
+            SetTypeMap(DbType.Binary, "IMAGE", ImageCapacity);
+            SetTypeMap(DbType.Boolean, "BIT");
+            SetTypeMap(DbType.Byte, "TINYINT");
+            SetTypeMap(DbType.Currency, "MONEY");
+            SetTypeMap(DbType.Date, "DATETIME");
+            SetTypeMap(DbType.DateTime, "DATETIME");
+            SetTypeMap(DbType.Decimal, "DECIMAL(19,5)");
+            SetTypeMap(DbType.Decimal, "DECIMAL($size,$precision)", DecimalCapacity);
+            SetTypeMap(DbType.Double, "DOUBLE PRECISION");
+            SetTypeMap(DbType.Guid, "UNIQUEIDENTIFIER");
+            SetTypeMap(DbType.Int16, "SMALLINT");
+            SetTypeMap(DbType.Int32, "INT");
+            SetTypeMap(DbType.Int64, "BIGINT");
+            SetTypeMap(DbType.Single, "REAL");
+            SetTypeMap(DbType.StringFixedLength, "NCHAR(255)");
+            SetTypeMap(DbType.StringFixedLength, "NCHAR($size)", UnicodeStringCapacity);
+            SetTypeMap(DbType.String, "NVARCHAR(255)");
+            SetTypeMap(DbType.String, "NVARCHAR($size)", UnicodeStringCapacity);
+            SetTypeMap(DbType.String, "NVARCHAR(MAX)", int.MaxValue);
+            SetTypeMap(DbType.String, "NTEXT", UnicodeTextCapacity);
+            SetTypeMap(DbType.Time, "DATETIME");
+            SetTypeMap(DbType.Xml, "XML");
+        }
+    }
 }


### PR DESCRIPTION
Change Sql Server Decimal Capacity from 19 to 38. 38 is the maximum decimal capacity from Sql Server 2000 http://msdn.microsoft.com/en-us/library/aa258832(v=sql.80).aspx

Issue #80: https://github.com/schambers/fluentmigrator/issues/80
