### PR TITLE
Remove the public setter for VersionTableMetaData on VersionLoader

### DIFF
--- a/src/FluentMigrator.Runner/VersionLoader.cs
+++ b/src/FluentMigrator.Runner/VersionLoader.cs
@@ -31,7 +31,7 @@ namespace FluentMigrator.Runner
 	    private VersionInfo _versionInfo;
 		public IMigrationRunner Runner { get; set; }
 		protected Assembly Assembly { get; set; }
-		public IVersionTableMetaData VersionTableMetaData { get; set; }
+		public IVersionTableMetaData VersionTableMetaData { get; private set; }
 		private IMigrationConventions Conventions { get; set; }
 		private IMigrationProcessor Processor { get; set; }
 		private IMigration VersionMigration { get; set; }


### PR DESCRIPTION
- The setter gave the impression that it could be used. However, the version migrations are triggered in the constructor, so changing the metadata has no effect other than causing later confusion.
- To use something other than the default, you have to have a type in the migration assembly that matches the convention for selecting the version table metadata.
