### PR TITLE
Support SQL Azure

### DIFF
--- a/src/FluentMigrator.Runner/Versioning/VersionMigration.cs
+++ b/src/FluentMigrator.Runner/Versioning/VersionMigration.cs
@@ -34,7 +34,8 @@ namespace FluentMigrator.Runner.Versioning
 		{
 			Create.Table(_versionTableMetaData.TableName)
                 .InSchema(_versionTableMetaData.SchemaName)
-				.WithColumn(_versionTableMetaData.ColumnName).AsInt64().NotNullable();
+				.WithColumn(_versionTableMetaData.ColumnName).AsInt64().NotNullable()
+                .PrimaryKey();
 		}
 
 		public override void Down()


### PR DESCRIPTION
In order to support SQL Azure, the VersionInfo table requires a Clustered index on on each table. This has been achieved by modifying the Migration for VersionInfo to add a Primary Key on the Version column, 
