### PR TITLE
Redone PrimaryKey on VersionTable

### DIFF
--- a/src/FluentMigrator.Runner/Versioning/VersionMigration.cs
+++ b/src/FluentMigrator.Runner/Versioning/VersionMigration.cs
@@ -34,7 +34,7 @@ namespace FluentMigrator.Runner.Versioning
 		{
 			Create.Table(_versionTableMetaData.TableName)
                 .InSchema(_versionTableMetaData.SchemaName)
-				.WithColumn(_versionTableMetaData.ColumnName).AsInt64().NotNullable();
+				.WithColumn(_versionTableMetaData.ColumnName).AsInt64().NotNullable().PrimaryKey();
 		}
 
 		public override void Down()

--- a/src/FluentMigrator.Tests/Integration/SchemaDump/SchemaDumpTests.cs
+++ b/src/FluentMigrator.Tests/Integration/SchemaDump/SchemaDumpTests.cs
@@ -97,7 +97,7 @@ namespace FluentMigrator.Tests.Integration.SchemaDump {
 
             SchemaTestWriter testWriter = new SchemaTestWriter();
             var output = GetOutput(testWriter, defs);
-            string expectedMessage = testWriter.GetMessage(4, 9, 3, 1);            
+            string expectedMessage = testWriter.GetMessage(4, 9, 4, 1);            
 
             runner.Down(new TestMigration());
 


### PR DESCRIPTION
Just a redo of the PrimaryKey part on the VersionTable, with 1 test alter, because there was one more index :)
