### PR TITLE
Fixed a SQL Server error when altering columns with default values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ src/*.vs10x
 src/FluentMigrator.Tests/FluentMigrator.VisualState.xml
 examplecommand.txt
 fluentmigrator.vssettings
+*.dotsettings

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServerColumn.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServerColumn.cs
@@ -17,7 +17,7 @@ namespace FluentMigrator.Runner.Generators.SqlServer
 
             var defaultValue = base.FormatDefaultValue(column);
 
-            if (!string.IsNullOrEmpty(defaultValue))
+            if (column.ModificationType == ColumnModificationType.Create && !string.IsNullOrEmpty(defaultValue))
                 return string.Format("CONSTRAINT DF_{0}_{1} ", column.TableName, column.Name) + defaultValue;
 
             return string.Empty;

--- a/src/FluentMigrator.SchemaDump/SchemaDumpers/SqlServerSchemaDumper.cs
+++ b/src/FluentMigrator.SchemaDump/SchemaDumpers/SqlServerSchemaDumper.cs
@@ -17,8 +17,8 @@
 //
 #endregion
 
-using System.Data;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using FluentMigrator.Builders.Execute;
 using FluentMigrator.Model;
@@ -157,7 +157,8 @@ namespace FluentMigrator.SchemaDump.SchemaDumpers
                         PrimaryKeyName = dr.IsNull("PrimaryKeyName") ? "" : dr["PrimaryKeyName"].ToString(),
                         Size = int.Parse(dr["Length"].ToString()),
                         TableName = dr["Table"].ToString(),
-                        Type = GetDbType(int.Parse(dr["TypeID"].ToString())) //TODO: set this property
+                        Type = GetDbType(int.Parse(dr["TypeID"].ToString())), //TODO: set this property
+												ModificationType = ColumnModificationType.Create
                     });
                 }
             }

--- a/src/FluentMigrator.Tests/Unit/Builders/Alter/AlterTableExpressionBuilderTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Builders/Alter/AlterTableExpressionBuilderTests.cs
@@ -231,7 +231,9 @@ namespace FluentMigrator.Tests.Unit.Builders.Alter
         {
             const int value = 42;
 
+            var expressions = new List<IMigrationExpression>();
             var contextMock = new Mock<IMigrationContext>();
+            contextMock.Setup(x => x.Expressions).Returns(expressions);
 
             var columnMock = new Mock<ColumnDefinition>();
 
@@ -242,6 +244,46 @@ namespace FluentMigrator.Tests.Unit.Builders.Alter
             builder.WithDefaultValue(42);
 
             columnMock.VerifySet(c => c.DefaultValue = value);
+        }
+
+        [Test]
+        public void CallingWithDefaultValueOnNewColumnDoesNotAddDefaultConstraintExpression() {
+            const int value = 42;
+
+            var expressions = new List<IMigrationExpression>();
+            var contextMock = new Mock<IMigrationContext>();
+            contextMock.Setup(x => x.Expressions).Returns(expressions);
+
+            var columnMock = new Mock<ColumnDefinition>();
+            columnMock.Setup(x => x.ModificationType).Returns(ColumnModificationType.Create);
+
+            var expressionMock = new Mock<AlterTableExpression>();
+
+            var builder = new AlterTableExpressionBuilder(expressionMock.Object, contextMock.Object);
+            builder.CurrentColumn = columnMock.Object;
+            builder.WithDefaultValue(42);
+
+            Assert.That(expressions.Count(), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void CallingWithDefaultValueOnAlterColumnAddsDefaultConstraintExpression() {
+            const int value = 42;
+
+            var expressions = new List<IMigrationExpression>();
+            var contextMock = new Mock<IMigrationContext>();
+            contextMock.Setup(x => x.Expressions).Returns(expressions);
+
+            var columnMock = new Mock<ColumnDefinition>();
+            columnMock.Setup(x => x.ModificationType).Returns(ColumnModificationType.Alter);
+
+            var expressionMock = new Mock<AlterTableExpression>();
+
+            var builder = new AlterTableExpressionBuilder(expressionMock.Object, contextMock.Object);
+            builder.CurrentColumn = columnMock.Object;
+            builder.WithDefaultValue(42);
+
+            Assert.That(expressions.Count(), Is.EqualTo(1));
         }
 
         [Test]

--- a/src/FluentMigrator.Tests/Unit/Generators/GeneratorTestHelper.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/GeneratorTestHelper.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using FluentMigrator.Expressions;
 using FluentMigrator.Model;
-using System.Data;
 
 namespace FluentMigrator.Tests.Unit.Generators
 {
@@ -256,6 +256,7 @@ namespace FluentMigrator.Tests.Unit.Generators
             expression.Column.Type = DbType.String;
             expression.Column.Size = 20;
             expression.Column.IsNullable = false;
+            expression.Column.ModificationType = ColumnModificationType.Alter;
 
             return expression;
         }

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2000/SqlServer2000AlterTableTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2000/SqlServer2000AlterTableTests.cs
@@ -78,6 +78,17 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer
         }
 
         [Test]
+        public void CanAlterColumnWithDefaultValue() {
+            //TODO: This will fail if there are any keys attached 
+            var expression = GeneratorTestHelper.GetAlterColumnExpression();
+            expression.Column.DefaultValue = "Foo";
+
+            var sql = _generator.Generate(expression);
+
+            sql.ShouldBe("ALTER TABLE [TestTable1] ALTER COLUMN [TestColumn1] NVARCHAR(20) NOT NULL");
+        }
+
+        [Test]
         public override void CanCreateForeignKey()
         {
             var expression = GeneratorTestHelper.GetCreateForeignKeyExpression();

--- a/src/FluentMigrator/Builders/Create/Table/CreateTableExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Create/Table/CreateTableExpressionBuilder.cs
@@ -16,12 +16,11 @@
 //
 #endregion
 
+using System;
 using System.Collections.Generic;
-using System.Data;
 using FluentMigrator.Expressions;
 using FluentMigrator.Infrastructure;
 using FluentMigrator.Model;
-using System;
 
 namespace FluentMigrator.Builders.Create.Table
 {
@@ -47,7 +46,7 @@ namespace FluentMigrator.Builders.Create.Table
 
         public ICreateTableColumnAsTypeSyntax WithColumn(string name)
         {
-            var column = new ColumnDefinition { Name = name, TableName = Expression.TableName };
+            var column = new ColumnDefinition { Name = name, TableName = Expression.TableName, ModificationType = ColumnModificationType.Create };
             Expression.Columns.Add(column);
             CurrentColumn = column;
             return this;

--- a/src/FluentMigrator/Expressions/AlterColumnExpression.cs
+++ b/src/FluentMigrator/Expressions/AlterColumnExpression.cs
@@ -31,7 +31,7 @@ namespace FluentMigrator.Expressions
 
         public AlterColumnExpression()
         {
-            Column = new ColumnDefinition();
+            Column = new ColumnDefinition() { ModificationType = ColumnModificationType.Alter };
         }
 
         public override void CollectValidationErrors(ICollection<string> errors)

--- a/src/FluentMigrator/Expressions/CreateColumnExpression.cs
+++ b/src/FluentMigrator/Expressions/CreateColumnExpression.cs
@@ -31,7 +31,7 @@ namespace FluentMigrator.Expressions
 
         public CreateColumnExpression()
         {
-            Column = new ColumnDefinition();
+            Column = new ColumnDefinition() { ModificationType = ColumnModificationType.Alter};
         }
 
         public override void ApplyConventions(IMigrationConventions conventions)

--- a/src/FluentMigrator/Model/ColumnDefinition.cs
+++ b/src/FluentMigrator/Model/ColumnDefinition.cs
@@ -44,6 +44,7 @@ namespace FluentMigrator.Model
         public virtual bool IsNullable { get; set; }
         public virtual bool IsUnique { get; set; }
         public virtual string TableName { get; set; }
+        public virtual ColumnModificationType ModificationType { get; set; }
 
         public void ApplyConventions(IMigrationConventions conventions)
         {
@@ -68,5 +69,10 @@ namespace FluentMigrator.Model
         public class UndefinedDefaultValue
         {
         }
+    }
+
+    public enum ColumnModificationType {
+        Create,
+        Alter
     }
 }


### PR DESCRIPTION
Added the ability to differentiate between a new column and a column change so that different sql can be generated if necessary.  This is needed for default constraints in SQL Server.

This commit should fix #217.
