### PR TITLE
Split Migration classes and marked methods as obsolete

### DIFF
--- a/src/FluentMigrator/AutoReversingMigration.cs
+++ b/src/FluentMigrator/AutoReversingMigration.cs
@@ -16,12 +16,16 @@
 //
 #endregion
 
+using System;
 using System.Linq;
+using FluentMigrator.Builders.Delete;
+using FluentMigrator.Builders.Execute;
+using FluentMigrator.Builders.Update;
 using FluentMigrator.Infrastructure;
 
 namespace FluentMigrator
 {
-    public abstract class AutoReversingMigration : Migration
+    public abstract class AutoReversingMigration : MigrationBase
     {
         public sealed override void Down()
         {
@@ -31,6 +35,24 @@ namespace FluentMigrator
         {
             GetUpExpressions(context);
             context.Expressions = context.Expressions.Select(e => e.Reverse()).Reverse().ToList();
+        }
+
+        [Obsolete("Delete cannot auto-reversed and will no longer be available for auto-reversing migrations.", false)]
+        public IDeleteExpressionRoot Delete
+        {
+            get { return new DeleteExpressionRoot(_context); }
+        }
+
+        [Obsolete("Execute cannot auto-reversed and will no longer be available for auto-reversing migrations.", false)]
+        public IExecuteExpressionRoot Execute
+        {
+            get { return new ExecuteExpressionRoot(_context); }
+        }
+
+        [Obsolete("Update cannot auto-reversed and will no longer be available for auto-reversing migrations.", false)]
+        public IUpdateExpressionRoot Update
+        {
+            get { return new UpdateExpressionRoot(_context); }
         }
     }
 }

--- a/src/FluentMigrator/FluentMigrator.csproj
+++ b/src/FluentMigrator/FluentMigrator.csproj
@@ -199,6 +199,7 @@
     <Compile Include="Builders\Insert\InsertExpressionRoot.cs" />
     <Compile Include="Expressions\UpdateDataExpression.cs" />
     <Compile Include="ForwardOnlyMigration.cs" />
+    <Compile Include="MigrationBase.cs" />
     <Compile Include="Model\ConstraintDefinition.cs" />
     <Compile Include="Model\DeletionDataDefinition.cs" />
     <Compile Include="Model\InsertionDataDefinition.cs" />

--- a/src/FluentMigrator/Migration.cs
+++ b/src/FluentMigrator/Migration.cs
@@ -16,76 +16,17 @@
 //
 #endregion
 
-using FluentMigrator.Builders.Alter;
-using FluentMigrator.Builders.Create;
 using FluentMigrator.Builders.Delete;
-using FluentMigrator.Builders.IfDatabase;
-using FluentMigrator.Builders.Insert;
-using FluentMigrator.Builders.Rename;
-using FluentMigrator.Builders.Schema;
-using FluentMigrator.Infrastructure;
 using FluentMigrator.Builders.Execute;
 using FluentMigrator.Builders.Update;
 
 namespace FluentMigrator
 {
-    public abstract class Migration : IMigration
+    public abstract class Migration : MigrationBase
     {
-        private IMigrationContext _context;
-        private readonly object _mutex = new object();
-
-        public abstract void Up();
-        public abstract void Down();
-
-        public void ApplyConventions(IMigrationContext context)
-        {
-            foreach (var expression in context.Expressions)
-                expression.ApplyConventions(context.Conventions);
-        }
-
-        public virtual void GetUpExpressions(IMigrationContext context)
-        {
-            lock (_mutex)
-            {
-                _context = context;
-                Up();
-                _context = null;
-            }
-        }
-
-        public virtual void GetDownExpressions(IMigrationContext context)
-        {
-            lock (_mutex)
-            {
-                _context = context;
-                Down();
-                _context = null;
-            }
-        }
-
-        public IAlterExpressionRoot Alter
-        {
-            get { return new AlterExpressionRoot(_context); }
-        }
-
-        public ICreateExpressionRoot Create
-        {
-            get { return new CreateExpressionRoot(_context); }
-        }
-
         public IDeleteExpressionRoot Delete
         {
             get { return new DeleteExpressionRoot(_context); }
-        }
-
-        public IRenameExpressionRoot Rename
-        {
-            get { return new RenameExpressionRoot(_context); }
-        }
-
-        public IInsertExpressionRoot Insert
-        {
-            get { return new InsertExpressionRoot(_context); }
         }
 
         public IExecuteExpressionRoot Execute
@@ -93,19 +34,9 @@ namespace FluentMigrator
             get { return new ExecuteExpressionRoot(_context); }
         }
 
-        public ISchemaExpressionRoot Schema
-        {
-            get { return new SchemaExpressionRoot(_context); }
-        }
-
         public IUpdateExpressionRoot Update
         {
             get { return new UpdateExpressionRoot(_context); }
-        }
-
-        public IIfDatabaseExpressionRoot IfDatabase(params string[] databaseType)
-        {
-            return new IfDatabaseExpressionRoot(_context, databaseType);
         }
     }
 }

--- a/src/FluentMigrator/MigrationBase.cs
+++ b/src/FluentMigrator/MigrationBase.cs
@@ -1,0 +1,93 @@
+﻿#region License
+// 
+// Copyright (c) 2007-2009, Sean Chambers <schambers80@gmail.com>
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+using FluentMigrator.Builders.Alter;
+using FluentMigrator.Builders.Create;
+using FluentMigrator.Builders.IfDatabase;
+using FluentMigrator.Builders.Insert;
+using FluentMigrator.Builders.Rename;
+using FluentMigrator.Builders.Schema;
+using FluentMigrator.Infrastructure;
+
+namespace FluentMigrator
+{
+    public abstract class MigrationBase : IMigration
+    {
+        internal IMigrationContext _context;
+        private readonly object _mutex = new object();
+
+        public abstract void Up();
+        public abstract void Down();
+
+        public void ApplyConventions(IMigrationContext context)
+        {
+            foreach (var expression in context.Expressions)
+                expression.ApplyConventions(context.Conventions);
+        }
+
+        public virtual void GetUpExpressions(IMigrationContext context)
+        {
+            lock (_mutex)
+            {
+                _context = context;
+                Up();
+                _context = null;
+            }
+        }
+
+        public virtual void GetDownExpressions(IMigrationContext context)
+        {
+            lock (_mutex)
+            {
+                _context = context;
+                Down();
+                _context = null;
+            }
+        }
+
+        public IAlterExpressionRoot Alter
+        {
+            get { return new AlterExpressionRoot(_context); }
+        }
+
+        public ICreateExpressionRoot Create
+        {
+            get { return new CreateExpressionRoot(_context); }
+        }
+
+        public IRenameExpressionRoot Rename
+        {
+            get { return new RenameExpressionRoot(_context); }
+        }
+
+        public IInsertExpressionRoot Insert
+        {
+            get { return new InsertExpressionRoot(_context); }
+        }
+
+        public ISchemaExpressionRoot Schema
+        {
+            get { return new SchemaExpressionRoot(_context); }
+        }
+
+        public IIfDatabaseExpressionRoot IfDatabase(params string[] databaseType)
+        {
+            return new IfDatabaseExpressionRoot(_context, databaseType);
+        }
+    }
+}


### PR DESCRIPTION
I've marked Delete, Update, and Execute as obsolete in the AutoReversingMigration class.  The only issue I have with this implementation is that MigrationBase is available to the outside world.  fiixes #213
