### PR TITLE
Migrations output to file invalid due to use of single line comments

### DIFF
--- a/src/FluentMigrator.Runner/Announcers/TextWriterAnnouncer.cs
+++ b/src/FluentMigrator.Runner/Announcers/TextWriterAnnouncer.cs
@@ -34,7 +34,7 @@ namespace FluentMigrator.Runner.Announcers
             : base(write)
         {
             NonSqlPrefix = "/* ";
-			NonSqlWrapper = sql => string.Format("{0}{1} */", NonSqlPrefix, sql);
+            NonSqlWrapper = sql => string.Format("{0}{1} */", NonSqlPrefix, sql);
         }
 
 
@@ -51,7 +51,7 @@ namespace FluentMigrator.Runner.Announcers
 
         public override void Say(string message)
         {
-			Info(NonSqlWrapper(message));
+            Info(NonSqlWrapper(message));
         }
 
         public override void Sql(string sql)

--- a/src/FluentMigrator.Tests/Unit/AnnouncerTests.cs
+++ b/src/FluentMigrator.Tests/Unit/AnnouncerTests.cs
@@ -24,57 +24,57 @@ using NUnit.Should;
 
 namespace FluentMigrator.Tests.Unit
 {
-	[TestFixture]
-	public class AnnouncerTests
-	{
-		private TextWriterAnnouncer _announcer;
-		private StringWriter _stringWriter;
+    [TestFixture]
+    public class AnnouncerTests
+    {
+        private TextWriterAnnouncer _announcer;
+        private StringWriter _stringWriter;
 
-		[SetUp]
-		public void SetUp()
-		{
-			_stringWriter = new StringWriter();
-			_announcer = new TextWriterAnnouncer(_stringWriter)
-							{
-								ShowElapsedTime = true,
-								ShowSql = true
-							};
-		}
+        [SetUp]
+        public void SetUp()
+        {
+            _stringWriter = new StringWriter();
+            _announcer = new TextWriterAnnouncer(_stringWriter)
+                            {
+                                ShowElapsedTime = true,
+                                ShowSql = true
+                            };
+        }
 
-		public string Output
-		{
-			get
-			{
-				return _stringWriter.GetStringBuilder().ToString();
-			}
-		}
+        public string Output
+        {
+            get
+            {
+                return _stringWriter.GetStringBuilder().ToString();
+            }
+        }
 
-		[Test]
-		public void CanAnnounceAndPadWithEquals()
-		{
-			_announcer.Heading("Test");
-			Output.ShouldBe("/* Test ====================================================================== */" + Environment.NewLine + Environment.NewLine);
-		}
+        [Test]
+        public void CanAnnounceAndPadWithEquals()
+        {
+            _announcer.Heading("Test");
+            Output.ShouldBe("/* Test ====================================================================== */" + Environment.NewLine + Environment.NewLine);
+        }
 
-		[Test]
-		public void CanSay()
-		{
-			_announcer.Say("Create table");
+        [Test]
+        public void CanSay()
+        {
+            _announcer.Say("Create table");
             Output.ShouldBe("/* Create table */" + Environment.NewLine);
-		}
+        }
 
-		[Test]
-		public void CanSayTimeSpan()
-		{
-			_announcer.ElapsedTime(new TimeSpan(0, 0, 5));
-			Output.ShouldBe("/* -> 5s */" + Environment.NewLine + Environment.NewLine);
-		}
+        [Test]
+        public void CanSayTimeSpan()
+        {
+            _announcer.ElapsedTime(new TimeSpan(0, 0, 5));
+            Output.ShouldBe("/* -> 5s */" + Environment.NewLine + Environment.NewLine);
+        }
 
-		[Test]
-		public void CanSaySql()
-		{
-			_announcer.Sql("DELETE Blah");
-			Output.ShouldBe("DELETE Blah" + Environment.NewLine);
-		}
-	}
+        [Test]
+        public void CanSaySql()
+        {
+            _announcer.Sql("DELETE Blah");
+            Output.ShouldBe("DELETE Blah" + Environment.NewLine);
+        }
+    }
 }


### PR DESCRIPTION
When a migration calls Execute.Sql with a multi line string, invalid SQL will be generated when the migration is output to a file. However the migration will run successfully when applied directly to the database using the runner .

For example

``` java
Execute.Sql(@"
 INSERT INTO TestTable (Id, Value)
 VALUES (1, 'Test value')");
```

will produce the following SQL in a file

``` sql
-- ExecuteSqlStatement
 INSERT INTO TestTable (Id, Value)
 VALUES (1, 'Test value')

 INSERT INTO TestTable (Id, Value)
 VALUES (1, 'Test value')
```

If TestTable has a primary key constraint on the Id column an error will be thrown.

Modified TextWriterAnnouncer to use multi-line comments which are supported by all database engines that FM services. So the above statement should read:

``` sql
/* ExecuteSqlStatement
 INSERT INTO TestTable (Id, Value)
 VALUES (1, 'Test value') */

 INSERT INTO TestTable (Id, Value)
 VALUES (1, 'Test value')
```
