### PR TITLE
Write errors from the console runner to stderr

### DIFF
--- a/src/FluentMigrator.Console/MigratorConsole.cs
+++ b/src/FluentMigrator.Console/MigratorConsole.cs
@@ -213,8 +213,8 @@ namespace FluentMigrator.Console
             }
             catch (Exception ex)
             {
-                System.Console.WriteLine("!! An error has occurred.  The error is:");
-                System.Console.WriteLine(ex);
+                System.Console.Error.WriteLine("!! An error has occurred.  The error is:");
+                System.Console.Error.WriteLine(ex);
                 Environment.ExitCode = 1;
             }
         }


### PR DESCRIPTION
Errors generated by the console migration runner should be written to the standard error output so that errors can be redirected differently than normal output.
