### PR TITLE
Allow FluentMigrator to be invoked by an application in medium trust

### DIFF
--- a/src/FluentMigrator.Runner/Properties/AssemblyInfo.cs
+++ b/src/FluentMigrator.Runner/Properties/AssemblyInfo.cs
@@ -18,6 +18,8 @@
 
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Security;
 
 [assembly: AssemblyTitle("FluentMigrator")]
 [assembly: AssemblyDescription("FluentMigrator")]
+[assembly: AllowPartiallyTrustedCallers]

--- a/src/FluentMigrator/Properties/AssemblyInfo.cs
+++ b/src/FluentMigrator/Properties/AssemblyInfo.cs
@@ -18,6 +18,8 @@
 
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Security;
 
 [assembly: AssemblyTitle("FluentMigrator")]
 [assembly: AssemblyDescription("FluentMigrator")]
+[assembly: AllowPartiallyTrustedCallers]


### PR DESCRIPTION
The [AllowPartiallyTrustedCallers](http://msdn.microsoft.com/en-us/library/system.security.allowpartiallytrustedcallersattribute.aspx) assembly attribute lets FluentMigrator be invoked from an application running in medium trust.
