### PR TITLE
Set application context from FluentMigrator.Console via --context

### DIFF
--- a/src/FluentMigrator.Console/MigratorConsole.cs
+++ b/src/FluentMigrator.Console/MigratorConsole.cs
@@ -162,7 +162,7 @@ namespace FluentMigrator.Console
                         v => { Profile = v; }
                     },
                     {
-                        "context=|c=",
+                        "context=",
                         "Set ApplicationContext to the given string.",
                         var => { ApplicationContext = var; }
                     },


### PR DESCRIPTION
This will set the ApplicationContext to mystring if you pass --context=mystring into migrate.exe.
