### PR TITLE
MySql statement being executed despite /preview command line argument 

### DIFF
--- a/src/FluentMigrator.Runner/Processors/MySql/MySqlProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/MySql/MySqlProcessor.cs
@@ -76,6 +76,11 @@ namespace FluentMigrator.Runner.Processors.MySql
 
         public override void Execute(string template, params object[] args)
         {
+            if(Options.PreviewOnly) 
+            {
+                return;
+            }
+
             if (Connection.State != ConnectionState.Open) Connection.Open();
 
             using (var command = factory.CreateCommand(String.Format(template, args), Connection))


### PR DESCRIPTION
MySql scripts specified using Execute.EmbeddedScript() are being executed despite /preview command line argument being passed.

Not sure if this is the ideal way to fix this..
