### PR TITLE
Fix for DateTime not being correctly formatted for countries that do not use : as a separator.

### DIFF
--- a/src/FluentMigrator.Runner/Generators/Generic/GenericQuoter.cs
+++ b/src/FluentMigrator.Runner/Generators/Generic/GenericQuoter.cs
@@ -67,7 +67,7 @@ namespace FluentMigrator.Runner.Generators.Generic
 
         public virtual string FormatDateTime(DateTime value)
         {
-            return ValueQuote + (value).ToString("yyyy-MM-ddTHH:mm:ss") + ValueQuote;
+            return ValueQuote + (value).ToString("yyyy-MM-ddTHH:mm:ss",CultureInfo.InvariantCulture) + ValueQuote;
         }
 
         public virtual string FormatEnum(object value)

--- a/src/FluentMigrator.Tests/Unit/Generators/GenericGenerator/QuoterTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/GenericGenerator/QuoterTests.cs
@@ -126,6 +126,16 @@ namespace FluentMigrator.Tests.Unit.Generators
         [Test]
         public void DateTimeIsFormattedIso8601WithQuotes()
         {
+            ChangeCulture();
+            DateTime date = new DateTime(2010, 1, 2, 18, 4, 5, 123);
+            quoter.QuoteValue(date)
+                .ShouldBe("'2010-01-02T18:04:05'");
+        } 
+        
+        [Test]
+        public void DateTimeIsFormattedIso8601WithQuotes_WithItalyAsCulture()
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("it-IT");
             DateTime date = new DateTime(2010, 1, 2, 18, 4, 5, 123);
             quoter.QuoteValue(date)
                 .ShouldBe("'2010-01-02T18:04:05'");


### PR DESCRIPTION
... DateTime to be in the wrong format.

Italy for example (See Test) has '.' as the time separator which would cause and issue.

Fixed by added CultureInfo.InvariantCulture to the ToString to ensure that the value is always returned as expected.
