### PR TITLE
Added .editorconfig for sharing formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://EditorConfig.org
+
+root = true
+
+[*]
+end_of_line = CRLF
+
+[*.cs]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
EditorConfig (see http://editorconfig.org/) is a way of sharing
Visual Studio settings for a solution. If you have the plugin installed
then it will enforce the rules in the .editorconfig file. We need this
so that new pull requests will be formatted with spaces instead of
tabs. It doesn't work if the committer does not install the plugin and
isn't meant as a requirement for submitting pull requests. It is more
intended to help those switching between projects with different tab
settings (for example me).

This will also work for Sublime Text, Emacs, Vim and Notepad++.
