### PR TITLE
Allow nested namespace option to be supplied via command line, NAnt and MSBuild runners

### DIFF
--- a/src/FluentMigrator.Console/MigratorConsole.cs
+++ b/src/FluentMigrator.Console/MigratorConsole.cs
@@ -34,6 +34,7 @@ namespace FluentMigrator.Console
         public string Connection;
         public string ConnectionStringConfigPath;
         public string Namespace;
+        public bool NestedNamespaces;
         public bool Output;
         public string OutputFilename;
         public bool PreviewOnly;
@@ -88,6 +89,12 @@ namespace FluentMigrator.Console
                                             "The namespace contains the migrations you want to run. Default is all migrations found within the Target Assembly will be run."
                                             ,
                                             v => { Namespace = v; }
+                                            },
+                                        {
+                                            "nested",
+                                            "Whether migrations in nested namespaces should be included. Used in conjunction with the namespace option."
+                                            ,
+                                            v => { NestedNamespaces = true; }
                                             },
                                         {
                                             "output|out|o",
@@ -262,6 +269,7 @@ namespace FluentMigrator.Console
                 Target = TargetAssembly,
                 PreviewOnly = PreviewOnly,
                 Namespace = Namespace,
+                NestedNamespaces = NestedNamespaces,
                 Task = Task,
                 Version = Version,
                 Steps = Steps,

--- a/src/FluentMigrator.MSBuild/Migrate.cs
+++ b/src/FluentMigrator.MSBuild/Migrate.cs
@@ -68,6 +68,8 @@ namespace FluentMigrator.MSBuild
 
         public string Namespace { get; set; }
 
+        public bool Nested { get; set; }
+
         public string Task { get; set; }
 
         public long Version { get; set; }
@@ -136,6 +138,7 @@ namespace FluentMigrator.MSBuild
                 Target = Target,
                 PreviewOnly = PreviewOnly,
                 Namespace = Namespace,
+                NestedNamespaces = Nested,
                 Task = Task,
                 Version = Version,
                 Steps = Steps,

--- a/src/FluentMigrator.NAnt/MigrateTask.cs
+++ b/src/FluentMigrator.NAnt/MigrateTask.cs
@@ -45,6 +45,9 @@ namespace FluentMigrator.NAnt
         [TaskAttribute("namespace")]
         public string Namespace { get; set; }
 
+        [TaskAttribute("nested")]
+        public bool NestedNamespaces { get; set; }
+
         [TaskAttribute("task")]
         public string Task { get; set; }
 
@@ -107,6 +110,7 @@ namespace FluentMigrator.NAnt
                                         Target = Target,
                                         PreviewOnly = Preview,
                                         Namespace = Namespace,
+                                        NestedNamespaces = NestedNamespaces,
                                         Task = Task,
                                         Version = Version,
                                         Steps = Steps,

--- a/src/FluentMigrator.Runner/Initialization/IRunnerContext.cs
+++ b/src/FluentMigrator.Runner/Initialization/IRunnerContext.cs
@@ -27,6 +27,7 @@ namespace FluentMigrator.Runner.Initialization
         string Target { get; set; }
         bool PreviewOnly { get; set; }
         string Namespace { get; set; }
+        bool NestedNamespaces { get; set; }
         string Task { get; set; }
         long Version { get; set; }
         int Steps { get; set; }

--- a/src/FluentMigrator.Runner/Initialization/RunnerContext.cs
+++ b/src/FluentMigrator.Runner/Initialization/RunnerContext.cs
@@ -15,6 +15,7 @@ namespace FluentMigrator.Runner.Initialization
         public string Target { get; set; }
         public bool PreviewOnly { get; set; }
         public string Namespace { get; set; }
+        public bool NestedNamespaces { get; set; }
         public string Task { get; set; }
         public long Version { get; set; }
         public int Steps { get; set; }

--- a/src/FluentMigrator.Runner/MigrationLoader.cs
+++ b/src/FluentMigrator.Runner/MigrationLoader.cs
@@ -31,7 +31,7 @@ namespace FluentMigrator.Runner
         public string Namespace { get; private set; }
         public bool LoadNestedNamespaces { get; private set; }
         public SortedList<long, IMigration> Migrations { get; private set; }
-        public IEnumerable<string> TagsToMatch { get; set; }
+        public IEnumerable<string> TagsToMatch { get; private set; }
 
         public MigrationLoader(IMigrationConventions conventions, Assembly assembly, string @namespace, IEnumerable<string> tagsToMatch)
         {
@@ -43,13 +43,13 @@ namespace FluentMigrator.Runner
             Initialize();
         }
         
-        public MigrationLoader(IMigrationConventions conventions, Assembly assembly, string @namespace, bool loadNestedNamespaces)
+        public MigrationLoader(IMigrationConventions conventions, Assembly assembly, string @namespace, bool loadNestedNamespaces, IEnumerable<string> tagsToMatch)
         {
             Conventions = conventions;
             Assembly = assembly;
             Namespace = @namespace;
             LoadNestedNamespaces = loadNestedNamespaces;
-            TagsToMatch = new string[]{};
+            TagsToMatch = tagsToMatch ?? new string[] { };
 
             Initialize();
         }

--- a/src/FluentMigrator.Runner/MigrationRunner.cs
+++ b/src/FluentMigrator.Runner/MigrationRunner.cs
@@ -60,7 +60,7 @@ namespace FluentMigrator.Runner
                 Conventions.GetWorkingDirectory = () => runnerContext.WorkingDirectory;
 
             VersionLoader = new VersionLoader(this, _migrationAssembly, Conventions);
-            MigrationLoader = new MigrationLoader(Conventions, _migrationAssembly, runnerContext.Namespace, runnerContext.Tags);
+            MigrationLoader = new MigrationLoader(Conventions, _migrationAssembly, runnerContext.Namespace, runnerContext.NestedNamespaces, runnerContext.Tags);
             ProfileLoader = new ProfileLoader(runnerContext, this, Conventions);
         }
 

--- a/src/FluentMigrator.Tests/Unit/MigrationLoaderTests.cs
+++ b/src/FluentMigrator.Tests/Unit/MigrationLoaderTests.cs
@@ -78,7 +78,7 @@ namespace FluentMigrator.Tests.Unit
         {
             var conventions = new MigrationConventions();
             var asm = Assembly.GetExecutingAssembly();
-            var loader = new MigrationLoader(conventions, asm, "FluentMigrator.Tests.Integration.Migrations.Nested", true);
+            var loader = new MigrationLoader(conventions, asm, "FluentMigrator.Tests.Integration.Migrations.Nested", true, null);
 
             List<Type> expected = new List<Type>
                                       {
@@ -99,7 +99,7 @@ namespace FluentMigrator.Tests.Unit
         {
             var conventions = new MigrationConventions();
             var asm = Assembly.GetExecutingAssembly();
-            var loader = new MigrationLoader(conventions, asm, "FluentMigrator.Tests.Integration.Migrations.Nested", false);
+            var loader = new MigrationLoader(conventions, asm, "FluentMigrator.Tests.Integration.Migrations.Nested", false, null);
 
             List<Type> expected = new List<Type>
                                       {

--- a/src/FluentMigrator.Tests/Unit/Runners/MigratorConsoleTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Runners/MigratorConsoleTests.cs
@@ -40,11 +40,13 @@ namespace FluentMigrator.Tests.Unit.Runners
                 "/connection", connection,
                 "/target", target,
                 "/namespace", "FluentMigrator.Tests.Integration.Migrations",
+                "/nested",
                 "/task", "migrate:up",
                 "/version", "1");
 
             console.Connection.ShouldBe(connection);
             console.Namespace.ShouldBe("FluentMigrator.Tests.Integration.Migrations");
+            console.NestedNamespaces.ShouldBeTrue();
             console.Task.ShouldBe("migrate:up");
             console.Version.ShouldBe(1);
         }


### PR DESCRIPTION
Nested namespaces can be searched by supplying the /nested switch on the command line, or setting nested="true" in NAnt and MSBuild.
