### PR TITLE
Validate UpdateDataExpressions: enforce that they either specify AllRows...

### DIFF
--- a/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -218,6 +218,7 @@
     <Compile Include="Unit\Builders\Schema\SchemaExpressionRootTest.cs" />
     <Compile Include="Unit\Definitions\IndexDefinitionTests.cs" />
     <Compile Include="Unit\Expressions\DeleteDefaultConstraintExpressionTests.cs" />
+    <Compile Include="Unit\Expressions\UpdateDataExpressionTests.cs" />
     <Compile Include="Unit\Generators\GenericGenerator\GenericGeneratorTests.cs" />
     <Compile Include="Unit\Generators\Firebird\FirebirdGeneratorTests.cs" />
     <Compile Include="Unit\Generators\Postgres\PostgresDataTests.cs" />

--- a/src/FluentMigrator.Tests/Unit/Expressions/UpdateDataExpressionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Expressions/UpdateDataExpressionTests.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using FluentMigrator.Expressions;
+using FluentMigrator.Infrastructure;
+using FluentMigrator.Tests.Helpers;
+using NUnit.Framework;
+using NUnit.Should;
+
+namespace FluentMigrator.Tests.Unit.Expressions
+{
+    [TestFixture]
+    public class UpdateDataExpressionTests {
+        private UpdateDataExpression expression;
+
+        [SetUp]
+        public void Initialize() 
+        {
+            expression =
+                new UpdateDataExpression() 
+                {
+                    TableName = "ExampleTable",
+                    Set = new List<KeyValuePair<string, object>> 
+                    {
+                        new KeyValuePair<string, object>("Column", "value")
+                    },
+                    IsAllRows = false
+                };
+        }
+
+        [Test]
+        public void NullUpdateTargetCausesErrorMessage() 
+        {
+            // null is the default value, but it might not always be, so I'm codifying it here anyway
+            expression.Where = null;
+
+            var errors = ValidationHelper.CollectErrors(expression);
+            errors.ShouldContain(ErrorMessages.UpdateDataExpressionMustSpecifyWhereClauseOrAllRows);
+        }
+
+        [Test]
+        public void EmptyUpdateTargetCausesErrorMessage() 
+        {
+            // The same should be true for an empty list
+            expression.Where = new List<KeyValuePair<string, object>>();
+
+            var errors = ValidationHelper.CollectErrors(expression);
+            errors.ShouldContain(ErrorMessages.UpdateDataExpressionMustSpecifyWhereClauseOrAllRows);
+        }
+
+        [Test]
+        public void DoesNotRequireWhereConditionWhenIsAllRowsIsSet() 
+        {
+            expression.IsAllRows = true;
+
+            var errors = ValidationHelper.CollectErrors(expression);
+            errors.ShouldNotContain(ErrorMessages.UpdateDataExpressionMustSpecifyWhereClauseOrAllRows);
+        }
+
+        [Test]
+        public void DoesNotAllowWhereConditionWhenIsAllRowsIsSet() 
+        {
+            expression.IsAllRows = true;
+            expression.Where = new List<KeyValuePair<string, object>> {new KeyValuePair<string, object>("key", "value")};
+
+            var errors = ValidationHelper.CollectErrors(expression);
+            errors.ShouldContain(ErrorMessages.UpdateDataExpressionMustNotSpecifyBothWhereClauseAndAllRows);
+        }
+    }
+}

--- a/src/FluentMigrator/Expressions/UpdateDataExpression.cs
+++ b/src/FluentMigrator/Expressions/UpdateDataExpression.cs
@@ -35,6 +35,12 @@ namespace FluentMigrator.Expressions
         {
             if (String.IsNullOrEmpty(TableName))
                 errors.Add(ErrorMessages.TableNameCannotBeNullOrEmpty);
+
+            if (!IsAllRows && (Where == null || Where.Count == 0)) 
+                errors.Add(ErrorMessages.UpdateDataExpressionMustSpecifyWhereClauseOrAllRows);
+
+            if (IsAllRows && Where != null && Where.Count > 0)
+                errors.Add(ErrorMessages.UpdateDataExpressionMustNotSpecifyBothWhereClauseAndAllRows);
         }
 
         public override void ExecuteWith(IMigrationProcessor processor)

--- a/src/FluentMigrator/Infrastructure/ErrorMessages.cs
+++ b/src/FluentMigrator/Infrastructure/ErrorMessages.cs
@@ -43,5 +43,7 @@ namespace FluentMigrator.Infrastructure
         public const string OperationCannotBeNull = "The operation to be performed using the database connection cannot be null";
         public const string DestinationSchemaCannotBeNull = "The destination schema's name cannot be null or an empty string";
         public const string SequenceNameCannotBeNullOrEmpty = "The sequence's name cannot be null or an empty string";
+        public const string UpdateDataExpressionMustSpecifyWhereClauseOrAllRows = "Update statement is missing a condition. Specify one by calling .Where() or target all rows by calling .AllRows().";
+        public const string UpdateDataExpressionMustNotSpecifyBothWhereClauseAndAllRows = "Update statement specifies both a .Where() condition and that .AllRows() should be targeted. Specify one or the other, but not both.";
     }
 }


### PR DESCRIPTION
Enforce that UpdateDataExpressions either specify AllRows or a nonempty Where (but not both). This came up when I was first using FM to update a bunch of rows -- I didn't specify either of the above, expecting it to work like SQL, and the end result was a nasty NRE.
