### PR TITLE
T4 template generates all columns of type uniqueidentifier as string

### DIFF
--- a/src/FluentMigrator.T4/FM.Core.ttinclude
+++ b/src/FluentMigrator.T4/FM.Core.ttinclude
@@ -581,7 +581,7 @@ public string GetMigrationTypeFunctionForType(string type, int size,int precisio
 			case "int":
                 sysType= "AsInt32()";
                 break;							
-            case "Guid":
+            case "guid":
                 sysType=  "AsGuid()";
                  break;
             case "datetime":


### PR DESCRIPTION
Fixed a casing issue in a switch statement with the T4 template generating all uniqueidentifier columns as string. 

There was a switch with a ToLower(type.ToLower()) but still contained a Pascal cased case statement:
 case "Guid":
   sysType=  "AsGuid()";
