### PR TITLE
Make default versiontablemetdata overridable

### DIFF
--- a/src/FluentMigrator/VersionTableInfo/DefaultVersionTableMetaData.cs
+++ b/src/FluentMigrator/VersionTableInfo/DefaultVersionTableMetaData.cs
@@ -20,22 +20,22 @@ namespace FluentMigrator.VersionTableInfo
 {
     public class DefaultVersionTableMetaData : IVersionTableMetaData
     {
-        public string SchemaName
+        public virtual string SchemaName
         {
             get { return string.Empty; }
         }
 
-        public string TableName
+        public virtual string TableName
         {
             get { return "VersionInfo"; }
         }
 
-        public string ColumnName
+        public virtual string ColumnName
         {
             get { return "Version"; }
         }
 
-        public string UniqueIndexName
+        public virtual string UniqueIndexName
         {
             get { return "UC_Version"; }
         }


### PR DESCRIPTION
This makes it a lot easier if you want to add your own custom versiontable meta data.

Just slap the versiontablemetadataattribute on an inherited class and change only what you want
