### PR TITLE
Updated OracleTypeMap based on Oracle Documentation

### DIFF
--- a/src/FluentMigrator.Runner/Generators/Oracle/OracleTypeMap.cs
+++ b/src/FluentMigrator.Runner/Generators/Oracle/OracleTypeMap.cs
@@ -53,7 +53,7 @@ namespace FluentMigrator.Runner.Generators.Oracle
             SetTypeMap(DbType.Guid, "RAW(16)");
             SetTypeMap(DbType.Int16, "NUMBER(5,0)");
             SetTypeMap(DbType.Int32, "NUMBER(10,0)");
-            SetTypeMap(DbType.Int64, "NUMBER(20,0)");
+            SetTypeMap(DbType.Int64, "NUMBER(19,0)");
             SetTypeMap(DbType.Single, "FLOAT(24)");
             SetTypeMap(DbType.StringFixedLength, "NCHAR(255)");
             SetTypeMap(DbType.StringFixedLength, "NCHAR($size)", UnicodeStringCapacity);


### PR DESCRIPTION
Updated the default mapping of Int64 to NUMBER(19,0) to match the default type mapping used by Oracle.

See Table 3-4: Mapping of Oracle Data Types and EDM Types (http://docs.oracle.com/cd/E11882_01/win.112/e18754/featLINQ.htm)
