### PR TITLE
Fixes for issue #352

### DIFF
--- a/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -162,6 +162,7 @@
     <Compile Include="Helpers\PostgresTestTable.cs" />
     <Compile Include="Helpers\SqlServerCeTestTable.cs" />
     <Compile Include="IntegrationTestOptions.cs" />
+    <Compile Include="Integration\Migrations\MigrationWithDateStampVersioning.cs" />
     <Compile Include="Integration\Migrations\Tagged\1_TenantATable.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/FluentMigrator.Tests/Integration/Migrations/MigrationWithDateStampVersioning.cs
+++ b/src/FluentMigrator.Tests/Integration/Migrations/MigrationWithDateStampVersioning.cs
@@ -1,0 +1,16 @@
+namespace FluentMigrator.Tests.Integration.Migrations
+{
+    [Migration("12/23/2012 11:15 PM")]
+    public class MigrationWithDateStampVersioning : Migration
+    {
+        public override void Up()
+        {
+            
+        }
+
+        public override void Down()
+        {
+            
+        }
+    }
+}

--- a/src/FluentMigrator/MigrationAttribute.cs
+++ b/src/FluentMigrator/MigrationAttribute.cs
@@ -29,5 +29,7 @@ namespace FluentMigrator
         {
             Version = version;
         }
+
+        public MigrationAttribute(string datetimeOfMigration) : this(Convert.ToDateTime(datetimeOfMigration).Ticks){}
     }
 }


### PR DESCRIPTION
... readable versions as date time strings. Also added example migration usage in tests.
