### PR TITLE
Remove incorrect override for SQLite identifer quotes

### DIFF
--- a/src/FluentMigrator.Runner/Generators/SQLite/SQLiteQuoter.cs
+++ b/src/FluentMigrator.Runner/Generators/SQLite/SQLiteQuoter.cs
@@ -4,7 +4,5 @@ namespace FluentMigrator.Runner.Generators.SQLite
 {
     public class SqliteQuoter : GenericQuoter
     {
-        public override string OpenQuote { get { return "'"; } }
-        public override string CloseQuote { get { return "'"; } }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Generators/GenericGenerator/QuoterTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/GenericGenerator/QuoterTests.cs
@@ -212,7 +212,7 @@ namespace FluentMigrator.Tests.Unit.Generators
         public void ShouldEscapeSqliteObjectNames()
         {
             SqliteQuoter quoter = new SqliteQuoter();
-            quoter.Quote("Table'name").ShouldBe("'Table''name'");
+            quoter.Quote("Table\"Name").ShouldBe("\"Table\"\"Name\"");
         }
 
         [Test]

--- a/src/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteAlterTableTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteAlterTableTests.cs
@@ -21,7 +21,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetCreateColumnExpression();
             string sql = _generator.Generate(expression);
-            sql.ShouldBe("ALTER TABLE 'TestTable1' ADD COLUMN 'TestColumn1' TEXT NOT NULL");
+            sql.ShouldBe("ALTER TABLE \"TestTable1\" ADD COLUMN \"TestColumn1\" TEXT NOT NULL");
         }
 
         [Test]
@@ -29,7 +29,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetCreateDecimalColumnExpression();
             string sql = _generator.Generate(expression);
-            sql.ShouldBe("ALTER TABLE 'TestTable1' ADD COLUMN 'TestColumn1' NUMERIC NOT NULL");
+            sql.ShouldBe("ALTER TABLE \"TestTable1\" ADD COLUMN \"TestColumn1\" NUMERIC NOT NULL");
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetRenameTableExpression();
             string sql = _generator.Generate(expression);
-            sql.ShouldBe("ALTER TABLE 'TestTable1' RENAME TO 'TestTable2'");
+            sql.ShouldBe("ALTER TABLE \"TestTable1\" RENAME TO \"TestTable2\"");
         }
 
         [Test]
@@ -108,7 +108,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.Column.IsPrimaryKey = true;
 
             string sql = _generator.Generate(expression);
-            sql.ShouldBe("ALTER TABLE 'TestTable1' ADD COLUMN 'TestColumn1' INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT");
+            sql.ShouldBe("ALTER TABLE \"TestTable1\" ADD COLUMN \"TestColumn1\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT");
         }
 
         [Test]

--- a/src/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteCreateTableTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteCreateTableTests.cs
@@ -23,7 +23,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetCreateTableExpression();
             string sql = _generator.Generate(expression);
-            sql.ShouldBe("CREATE TABLE 'TestTable1' ('TestColumn1' TEXT NOT NULL, 'TestColumn2' INTEGER NOT NULL)");
+            sql.ShouldBe("CREATE TABLE \"TestTable1\" (\"TestColumn1\" TEXT NOT NULL, \"TestColumn2\" INTEGER NOT NULL)");
         }
 
         [Test]
@@ -37,7 +37,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetCreateTableWithPrimaryKeyExpression();
             var sql = _generator.Generate(expression);
-            sql.ShouldBe("CREATE TABLE 'TestTable1' ('TestColumn1' TEXT NOT NULL, 'TestColumn2' INTEGER NOT NULL, PRIMARY KEY ('TestColumn1'))");
+            sql.ShouldBe("CREATE TABLE \"TestTable1\" (\"TestColumn1\" TEXT NOT NULL, \"TestColumn2\" INTEGER NOT NULL, PRIMARY KEY (\"TestColumn1\"))");
         }
 
         [Test]
@@ -46,7 +46,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             //Should work. I think from the docs
             var expression = GeneratorTestHelper.GetCreateTableWithNamedPrimaryKeyExpression();
             string sql = _generator.Generate(expression);
-            sql.ShouldBe("CREATE TABLE 'TestTable1' ('TestColumn1' TEXT NOT NULL, 'TestColumn2' INTEGER NOT NULL, CONSTRAINT 'TestKey' PRIMARY KEY ('TestColumn1'))");
+            sql.ShouldBe("CREATE TABLE \"TestTable1\" (\"TestColumn1\" TEXT NOT NULL, \"TestColumn2\" INTEGER NOT NULL, CONSTRAINT \"TestKey\" PRIMARY KEY (\"TestColumn1\"))");
         }
 
         [Test]
@@ -55,7 +55,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             //Should work. I think from the docs
             var expression = GeneratorTestHelper.GetCreateTableWithMultiColumNamedPrimaryKeyExpression();
             string sql = _generator.Generate(expression);
-            sql.ShouldBe("CREATE TABLE 'TestTable1' ('TestColumn1' TEXT NOT NULL, 'TestColumn2' INTEGER NOT NULL, CONSTRAINT 'TestKey' PRIMARY KEY ('TestColumn1', 'TestColumn2'))");
+            sql.ShouldBe("CREATE TABLE \"TestTable1\" (\"TestColumn1\" TEXT NOT NULL, \"TestColumn2\" INTEGER NOT NULL, CONSTRAINT \"TestKey\" PRIMARY KEY (\"TestColumn1\", \"TestColumn2\"))");
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.Columns[0].IsPrimaryKey = true;
 
             var sql = _generator.Generate(expression);
-            sql.ShouldBe("CREATE TABLE 'TestTable1' ('TestColumn1' INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, 'TestColumn2' INTEGER NOT NULL)");
+            sql.ShouldBe("CREATE TABLE \"TestTable1\" (\"TestColumn1\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, \"TestColumn2\" INTEGER NOT NULL)");
         }
 
         [Test]
@@ -77,7 +77,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var result = _generator.Generate(expression);
 
             result.ShouldBe(
-                "CREATE TABLE 'TestTable1' ('TestColumn1' TEXT, 'TestColumn2' INTEGER NOT NULL)");
+                "CREATE TABLE \"TestTable1\" (\"TestColumn1\" TEXT, \"TestColumn2\" INTEGER NOT NULL)");
         }
 
         [Test]
@@ -88,7 +88,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var result = _generator.Generate(expression);
 
             result.ShouldBe(
-                "CREATE TABLE 'TestTable1' ('TestColumn1' TEXT NOT NULL DEFAULT 'Default', 'TestColumn2' INTEGER NOT NULL DEFAULT 0)");
+                "CREATE TABLE \"TestTable1\" (\"TestColumn1\" TEXT NOT NULL DEFAULT 'Default', \"TestColumn2\" INTEGER NOT NULL DEFAULT 0)");
         }
 
         [Test]
@@ -100,7 +100,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var result = _generator.Generate(expression);
 
             result.ShouldBe(
-                "CREATE TABLE 'TestTable1' ('TestColumn1' TEXT NOT NULL DEFAULT NULL, 'TestColumn2' INTEGER NOT NULL DEFAULT 0)");
+                "CREATE TABLE \"TestTable1\" (\"TestColumn1\" TEXT NOT NULL DEFAULT NULL, \"TestColumn2\" INTEGER NOT NULL DEFAULT 0)");
         }
 
         [Test]
@@ -108,7 +108,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetCreateIndexExpression();
             string sql = _generator.Generate(expression);
-            sql.ShouldBe("CREATE INDEX 'TestIndex' ON 'TestTable1' ('TestColumn1' ASC)");
+            sql.ShouldBe("CREATE INDEX \"TestIndex\" ON \"TestTable1\" (\"TestColumn1\" ASC)");
         }
 
         [Test]
@@ -116,7 +116,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetCreateMultiColumnCreateIndexExpression();
             string sql = _generator.Generate(expression);
-            sql.ShouldBe("CREATE INDEX 'TestIndex' ON 'TestTable1' ('TestColumn1' ASC, 'TestColumn2' DESC)");
+            sql.ShouldBe("CREATE INDEX \"TestIndex\" ON \"TestTable1\" (\"TestColumn1\" ASC, \"TestColumn2\" DESC)");
         }
 
         [Test]
@@ -124,7 +124,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetCreateTableWithMultiColumnPrimaryKeyExpression();
             var result = _generator.Generate(expression);
-            result.ShouldBe("CREATE TABLE 'TestTable1' ('TestColumn1' TEXT NOT NULL, 'TestColumn2' INTEGER NOT NULL, PRIMARY KEY ('TestColumn1', 'TestColumn2'))");
+            result.ShouldBe("CREATE TABLE \"TestTable1\" (\"TestColumn1\" TEXT NOT NULL, \"TestColumn2\" INTEGER NOT NULL, PRIMARY KEY (\"TestColumn1\", \"TestColumn2\"))");
         }
 
         [Test]
@@ -132,7 +132,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetCreateUniqueIndexExpression();
             var sql = _generator.Generate(expression);
-            sql.ShouldBe("CREATE UNIQUE INDEX 'TestIndex' ON 'TestTable1' ('TestColumn1' ASC)");
+            sql.ShouldBe("CREATE UNIQUE INDEX \"TestIndex\" ON \"TestTable1\" (\"TestColumn1\" ASC)");
         }
 
         [Test]
@@ -141,7 +141,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetCreateUniqueMultiColumnIndexExpression();
 
             var sql = _generator.Generate(expression);
-            sql.ShouldBe("CREATE UNIQUE INDEX 'TestIndex' ON 'TestTable1' ('TestColumn1' ASC, 'TestColumn2' DESC)");
+            sql.ShouldBe("CREATE UNIQUE INDEX \"TestIndex\" ON \"TestTable1\" (\"TestColumn1\" ASC, \"TestColumn2\" DESC)");
         }
 
         [Test]
@@ -168,7 +168,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.Columns[0].AdditionalFeatures.Add(SqlServerExtensions.IdentityIncrement, 3);
             _generator.compatabilityMode = CompatabilityMode.LOOSE;
             var sql = _generator.Generate(expression);
-            sql.ShouldBe("CREATE TABLE 'TestTable1' ('TestColumn1' INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, 'TestColumn2' INTEGER NOT NULL)");
+            sql.ShouldBe("CREATE TABLE \"TestTable1\" (\"TestColumn1\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, \"TestColumn2\" INTEGER NOT NULL)");
         }
 
         [Test]

--- a/src/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteDataTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteDataTests.cs
@@ -24,8 +24,8 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetInsertDataExpression();
             string sql = generator.Generate(expression);
 
-            string expected = "INSERT INTO 'TestTable1' ('Id', 'Name', 'Website') VALUES (1, 'Just''in', 'codethinked.com');";
-            expected += @" INSERT INTO 'TestTable1' ('Id', 'Name', 'Website') VALUES (2, 'Na\te', 'kohari.org')";
+            string expected = "INSERT INTO \"TestTable1\" (\"Id\", \"Name\", \"Website\") VALUES (1, 'Just''in', 'codethinked.com');";
+            expected += " INSERT INTO \"TestTable1\" (\"Id\", \"Name\", \"Website\") VALUES (2, 'Na\\te', 'kohari.org')";
 
             sql.ShouldBe(expected);
         }
@@ -38,8 +38,8 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             generator.compatabilityMode = Runner.CompatabilityMode.LOOSE;
             string sql = generator.Generate(expression);
 
-            string expected = "INSERT INTO 'TestTable1' ('Id', 'Name', 'Website') VALUES (1, 'Just''in', 'codethinked.com');";
-            expected += @" INSERT INTO 'TestTable1' ('Id', 'Name', 'Website') VALUES (2, 'Na\te', 'kohari.org')";
+            string expected = "INSERT INTO \"TestTable1\" (\"Id\", \"Name\", \"Website\") VALUES (1, 'Just''in', 'codethinked.com');";
+            expected += " INSERT INTO \"TestTable1\" (\"Id\", \"Name\", \"Website\") VALUES (2, 'Na\\te', 'kohari.org')";
 
             sql.ShouldBe(expected);
         }
@@ -60,7 +60,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
 
             var sql = generator.Generate(expression);
 
-            sql.ShouldBe("DELETE FROM 'TestTable1' WHERE 'Name' = 'Just''in' AND 'Website' IS NULL");
+            sql.ShouldBe("DELETE FROM \"TestTable1\" WHERE \"Name\" = 'Just''in' AND \"Website\" IS NULL");
         }
 
         [Test]
@@ -70,7 +70,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
 
             var sql = generator.Generate(expression);
 
-            sql.ShouldBe("DELETE FROM 'TestTable1' WHERE 1 = 1");
+            sql.ShouldBe("DELETE FROM \"TestTable1\" WHERE 1 = 1");
         }
 
         [Test]
@@ -80,7 +80,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
 
             var sql = generator.Generate(expression);
 
-            sql.ShouldBe("DELETE FROM 'TestTable1' WHERE 'Name' = 'Just''in' AND 'Website' IS NULL; DELETE FROM 'TestTable1' WHERE 'Website' = 'github.com'");
+            sql.ShouldBe("DELETE FROM \"TestTable1\" WHERE \"Name\" = 'Just''in' AND \"Website\" IS NULL; DELETE FROM \"TestTable1\" WHERE \"Website\" = 'github.com'");
         }
 
         [Test]
@@ -90,7 +90,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
 
             var sql = generator.Generate(expression);
 
-            var expected = String.Format("INSERT INTO 'TestTable1' ('guid') VALUES ('{0}')", GeneratorTestHelper.TestGuid.ToString());
+            var expected = String.Format("INSERT INTO \"TestTable1\" (\"guid\") VALUES ('{0}')", GeneratorTestHelper.TestGuid.ToString());
 
             sql.ShouldBe(expected);
         }
@@ -101,7 +101,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetUpdateDataExpression();
 
             var sql = generator.Generate(expression);
-            sql.ShouldBe("UPDATE 'TestTable1' SET 'Name' = 'Just''in', 'Age' = 25 WHERE 'Id' = 9 AND 'Homepage' IS NULL");
+            sql.ShouldBe("UPDATE \"TestTable1\" SET \"Name\" = 'Just''in', \"Age\" = 25 WHERE \"Id\" = 9 AND \"Homepage\" IS NULL");
         }
 
         [Test]
@@ -110,7 +110,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetUpdateDataExpressionWithAllRows();
 
             var sql = generator.Generate(expression);
-            sql.ShouldBe("UPDATE 'TestTable1' SET 'Name' = 'Just''in', 'Age' = 25 WHERE 1 = 1");
+            sql.ShouldBe("UPDATE \"TestTable1\" SET \"Name\" = 'Just''in', \"Age\" = 25 WHERE 1 = 1");
         }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteDropTableTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteDropTableTests.cs
@@ -54,7 +54,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetDeleteTableExpression();
             string sql = _generator.Generate(expression);
-            sql.ShouldBe("DROP TABLE 'TestTable1'");
+            sql.ShouldBe("DROP TABLE \"TestTable1\"");
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetDeleteIndexExpression();
             string sql = _generator.Generate(expression);
-            sql.ShouldBe("DROP INDEX 'TestIndex'");
+            sql.ShouldBe("DROP INDEX \"TestIndex\"");
         }
 
         [Test]


### PR DESCRIPTION
Strictly speaking, SQLite uses single quotes around string literals and double quotes around identifiers. Unfortunately, it's pretty lenient about letting you get it wrong - if it can work out which one you meant, it accepts the wrong one without complaint.

However, the one place where they do clash is in WHERE clauses. Specifically, I was having problems rolling back my last FluentMigrator migration - it would seem to execute the rollback fine, but when I tried to reapply the migration, it didn't recognise it. Attempting to rollback again revealed the problem - it was still trying to apply the same rollback (and failing), because it hadn't recorded that the last one had been run.

The problem was with the query to delete the rolled back migration from the VersionInfo table. Specifially, the query being executed was 
`DELETE FROM 'VersionInfo' WHERE 'Version' = 201301082150`
The problem is that we're using single quotes to escape what ought to be an identifier. SQLite interprets it as a string literal, finds that there is no row in the VersionInfo table for which the string "Version" equals the integer 201301082150, and so deletes nothing. It lets FluentMigrator get away with the single quotes around VersionInfo, because it knows you can't have a string literal there and so it must be an identifier. The correct query is in fact
`DELETE FROM "VersionInfo" WHERE "Version" = 201301082150`

The fix is to simply remove the override in SqliteQuoter that changes the default OpenQuote and CloseQuote properties from double quotes (which are correct!) to single quotes (which aren't). This means that SqliteQuoter is actually now just GenericQuoter with no overrides. I've also updated all the tests that are affected (as far as I can tell).
