### PR TITLE
Firebird processor already has SequenceExists, and can handle sequences.

### DIFF
--- a/src/FluentMigrator.Runner/Processors/Firebird/FirebirdProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/Firebird/FirebirdProcessor.cs
@@ -48,11 +48,6 @@ namespace FluentMigrator.Runner.Processors.Firebird
 
         #region Schema checks
 
-        public override bool SequenceExists(string schemaName, string sequenceName)
-        {
-            return false;
-        }
-
         public override bool SchemaExists(string schemaName)
         {
             //No schema support in firebird
@@ -84,9 +79,8 @@ namespace FluentMigrator.Runner.Processors.Firebird
             return Exists("select rdb$index_name from rdb$indices where (rdb$relation_name = '{0}') and (rdb$index_name = '{1}') and (rdb$unique_flag IS NULL) and (rdb$foreign_key IS NULL)", FormatToSafeName(tableName), FormatToSafeName(indexName));
         }
 
-        public virtual bool SequenceExists(string schemaName, string tableName, string sequenceName)
+        public override bool SequenceExists(string schemaName, string sequenceName)
         {
-            CheckTable(tableName);
             return Exists("select rdb$generator_name from rdb$generators where rdb$generator_name = '{0}'", FormatToSafeName(sequenceName));
         }
 
@@ -481,7 +475,7 @@ namespace FluentMigrator.Runner.Processors.Firebird
                 InternalProcess((Generator as FirebirdGenerator).GenerateSetType(expression.Column));
             }
 
-            bool identitySequenceExists = SequenceExists(String.Empty, expression.TableName, GetSequenceName(expression.TableName, expression.Column.Name));
+            bool identitySequenceExists = SequenceExists(String.Empty, GetSequenceName(expression.TableName, expression.Column.Name));
             
             //Adjust identity generators
             if (expression.Column.IsIdentity)
@@ -515,7 +509,7 @@ namespace FluentMigrator.Runner.Processors.Firebird
             LockColumn(expression.TableName, expression.ColumnNames);
             foreach (string columnName in expression.ColumnNames)
             {
-                if (SequenceExists(String.Empty, expression.TableName, GetSequenceName(expression.TableName, columnName)))
+                if (SequenceExists(String.Empty, GetSequenceName(expression.TableName, columnName)))
                 {
                     DeleteSequenceForIdentity(expression.TableName, columnName);
                 }
@@ -619,7 +613,7 @@ namespace FluentMigrator.Runner.Processors.Firebird
             TableDefinition table = schema.GetTableDefinition(expression.TableName);
             foreach (ColumnDefinition colDef in table.Columns)
             {
-                if (SequenceExists(String.Empty, expression.TableName, GetSequenceName(expression.TableName, colDef.Name)))
+                if (SequenceExists(String.Empty, GetSequenceName(expression.TableName, colDef.Name)))
                 {
                     DeleteSequenceForIdentity(expression.TableName, colDef.Name);
                 }
@@ -876,7 +870,7 @@ namespace FluentMigrator.Runner.Processors.Firebird
             CheckTable(tableName);
             LockTable(tableName);
             string sequenceName = GetSequenceName(tableName, columnName);
-            if (!SequenceExists(String.Empty, tableName, sequenceName))
+            if (!SequenceExists(String.Empty, sequenceName))
             {
                 CreateSequenceExpression sequence = new CreateSequenceExpression()
                 {
@@ -901,7 +895,7 @@ namespace FluentMigrator.Runner.Processors.Firebird
             LockTable(tableName);
             string sequenceName = GetSequenceName(tableName, columnName);
             DeleteSequenceExpression deleteSequence = null;
-            if (SequenceExists(String.Empty, tableName, sequenceName))
+            if (SequenceExists(String.Empty, sequenceName))
             {
                 deleteSequence = new DeleteSequenceExpression() { SchemaName = String.Empty, SequenceName = sequenceName };
             }

--- a/src/FluentMigrator.Tests/Integration/Processors/FirebirdProcessorTests.cs
+++ b/src/FluentMigrator.Tests/Integration/Processors/FirebirdProcessorTests.cs
@@ -414,11 +414,11 @@ namespace FluentMigrator.Tests.Integration.Processors
                     Sequence = { Name = "Sequence" }
                 });
 
-                Processor.SequenceExists("", "", "Sequence").ShouldBeTrue();
+                Processor.SequenceExists("", "Sequence").ShouldBeTrue();
                 
                 Processor.Process(new DeleteSequenceExpression() { SequenceName = "Sequence" });
 
-                Processor.SequenceExists("", "", "Sequence").ShouldBeFalse();
+                Processor.SequenceExists("", "Sequence").ShouldBeFalse();
             }
         }
 
@@ -441,14 +441,14 @@ namespace FluentMigrator.Tests.Integration.Processors
 
                 Processor.Process(new DeleteSequenceExpression() { SequenceName = "Sequence" });
 
-                Processor.SequenceExists(String.Empty, table.Name, "Sequence").ShouldBeFalse();
+                Processor.SequenceExists(String.Empty, "Sequence").ShouldBeFalse();
             }
         }
 
         [Test]
         public void CallingSequenceExistsReturnsFalseIfSequenceNotExist()
         {
-            Processor.SequenceExists("", "", "DoesNotExist").ShouldBeFalse();
+            Processor.SequenceExists("", "DoesNotExist").ShouldBeFalse();
         }
 
         [Test]
@@ -485,7 +485,7 @@ namespace FluentMigrator.Tests.Integration.Processors
                     Column = { Name = "id", IsIdentity = true, Type = DbType.Int64 }
                 });
                 Processor.ColumnExists(String.Empty, table.Name, "id").ShouldBeTrue();
-                Processor.SequenceExists(String.Empty, table.Name, String.Format("gen_{0}_id", table.Name)).ShouldBeTrue();
+                Processor.SequenceExists(String.Empty, String.Format("gen_{0}_id", table.Name)).ShouldBeTrue();
                 Processor.TriggerExists(String.Empty, table.Name, String.Format("gen_id_{0}_id", table.Name)).ShouldBeTrue();
             }
         }
@@ -501,7 +501,7 @@ namespace FluentMigrator.Tests.Integration.Processors
                     Column = { Name = "id", IsIdentity = true, Type = DbType.Int64 }
                 });
                 Processor.ColumnExists(String.Empty, table.Name, "id").ShouldBeTrue();
-                Processor.SequenceExists(String.Empty, table.Name, String.Format("gen_{0}_id", table.Name)).ShouldBeTrue();
+                Processor.SequenceExists(String.Empty, String.Format("gen_{0}_id", table.Name)).ShouldBeTrue();
                 Processor.TriggerExists(String.Empty, table.Name, String.Format("gen_id_{0}_id", table.Name)).ShouldBeTrue();
 
                 Processor.Process(new DeleteColumnExpression()
@@ -510,7 +510,7 @@ namespace FluentMigrator.Tests.Integration.Processors
                     ColumnNames = { "id" }
                 });
                 Processor.ColumnExists(String.Empty, table.Name, "id").ShouldBeFalse();
-                Processor.SequenceExists(String.Empty, table.Name, String.Format("gen_{0}_id", table.Name)).ShouldBeFalse();
+                Processor.SequenceExists(String.Empty, String.Format("gen_{0}_id", table.Name)).ShouldBeFalse();
                 Processor.TriggerExists(String.Empty, table.Name, String.Format("gen_id_{0}_id", table.Name)).ShouldBeFalse();
             }
         }
@@ -526,7 +526,7 @@ namespace FluentMigrator.Tests.Integration.Processors
                     Column = { Name = "id", IsIdentity = false, Type = DbType.Int64 }
                 });
                 Processor.ColumnExists(String.Empty, table.Name, "id").ShouldBeTrue();
-                Processor.SequenceExists(String.Empty, table.Name, String.Format("gen_{0}_id", table.Name)).ShouldBeFalse();
+                Processor.SequenceExists(String.Empty, String.Format("gen_{0}_id", table.Name)).ShouldBeFalse();
                 Processor.TriggerExists(String.Empty, table.Name, String.Format("gen_id_{0}_id", table.Name)).ShouldBeFalse();
 
                 Processor.Process(new AlterColumnExpression()
@@ -535,7 +535,7 @@ namespace FluentMigrator.Tests.Integration.Processors
                     Column = { Name = "id", IsIdentity = true, Type = DbType.Int64 }
                 });
                 Processor.ColumnExists(String.Empty, table.Name, "id").ShouldBeTrue();
-                Processor.SequenceExists(String.Empty, table.Name, String.Format("gen_{0}_id", table.Name)).ShouldBeTrue();
+                Processor.SequenceExists(String.Empty, String.Format("gen_{0}_id", table.Name)).ShouldBeTrue();
                 Processor.TriggerExists(String.Empty, table.Name, String.Format("gen_id_{0}_id", table.Name)).ShouldBeTrue();
             }
         }
@@ -551,7 +551,7 @@ namespace FluentMigrator.Tests.Integration.Processors
                     Column = { Name = "id", IsIdentity = true, Type = DbType.Int64 }
                 });
                 Processor.ColumnExists(String.Empty, table.Name, "id").ShouldBeTrue();
-                Processor.SequenceExists(String.Empty, table.Name, String.Format("gen_{0}_id", table.Name)).ShouldBeTrue();
+                Processor.SequenceExists(String.Empty, String.Format("gen_{0}_id", table.Name)).ShouldBeTrue();
                 Processor.TriggerExists(String.Empty, table.Name, String.Format("gen_id_{0}_id", table.Name)).ShouldBeTrue();
 
                 Processor.Process(new AlterColumnExpression()
@@ -560,7 +560,7 @@ namespace FluentMigrator.Tests.Integration.Processors
                     Column = { Name = "id", IsIdentity = false, Type = DbType.Int64 }
                 });
                 Processor.ColumnExists(String.Empty, table.Name, "id").ShouldBeTrue();
-                Processor.SequenceExists(String.Empty, table.Name, String.Format("gen_{0}_id", table.Name)).ShouldBeFalse();
+                Processor.SequenceExists(String.Empty, String.Format("gen_{0}_id", table.Name)).ShouldBeFalse();
                 Processor.TriggerExists(String.Empty, table.Name, String.Format("gen_id_{0}_id", table.Name)).ShouldBeFalse();
             }
         }


### PR DESCRIPTION
Hy!

The recent refactoring of the ProcessorBase introduced SequenceExists for IQuerySchema.
The FirebirdProcessor already has it implemented. But it had one extra argument, with no real impact, just a double check... I removed it, to comply to the interface.
