### PR TITLE
Invalid date format when generating DateTime values for Jet

### DIFF
--- a/src/FluentMigrator.Runner/Generators/Jet/JetQuoter.cs
+++ b/src/FluentMigrator.Runner/Generators/Jet/JetQuoter.cs
@@ -15,7 +15,7 @@ namespace FluentMigrator.Runner.Generators.Jet
 
         public override string FormatDateTime(DateTime value)
         {
-            return ValueQuote + (value).ToString("YYYY-MM-DD HH:mm:ss") + ValueQuote;
+            return ValueQuote + (value).ToString("yyyy-MM-dd HH:mm:ss") + ValueQuote;
         }
     }
 }


### PR DESCRIPTION
In addition, this sure was hard to write around in my application (I'd been on FluentMigrator 1.0.1.0 and just upgraded). Could ColumnBase and TypeMapBase (and their derived classes) be made public instead of internal?
