### PR TITLE
SQL Server unicode insert support

### DIFF
--- a/src/FluentMigrator.Runner/Generators/Generic/GenericQuoter.cs
+++ b/src/FluentMigrator.Runner/Generators/Generic/GenericQuoter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using FluentMigrator.Model;
 
 namespace FluentMigrator.Runner.Generators.Generic
 {
@@ -12,6 +13,11 @@ namespace FluentMigrator.Runner.Generators.Generic
 
             string stringValue = value as string;
             if (stringValue != null) { return FormatString(stringValue); }
+
+            if (value is ExplicitUnicodeString)
+            {
+                return FormatString(value.ToString());
+            }
 
             if (value is char) { return FormatChar((char)value); }
             if (value is bool) { return FormatBool((bool)value); }

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServerQuoter.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServerQuoter.cs
@@ -1,4 +1,5 @@
-﻿using FluentMigrator.Runner.Generators.Generic;
+﻿using FluentMigrator.Model;
+using FluentMigrator.Runner.Generators.Generic;
 
 namespace FluentMigrator.Runner.Generators.SqlServer
 {
@@ -15,6 +16,16 @@ namespace FluentMigrator.Runner.Generators.SqlServer
         public override string QuoteSchemaName(string schemaName)
         {
             return (string.IsNullOrEmpty(schemaName)) ? "[dbo]" : Quote(schemaName);
+        }
+
+        public override string QuoteValue(object value)
+        {
+            if (value != null && value is ExplicitUnicodeString)
+            {
+                return string.Format("N{0}", FormatString(value.ToString()));
+            }
+            
+            return base.QuoteValue(value);
         }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Generators/GenericGenerator/QuoterTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/GenericGenerator/QuoterTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Threading;
+using FluentMigrator.Model;
 using FluentMigrator.Runner.Generators;
 using FluentMigrator.Runner.Generators.Generic;
 using FluentMigrator.Runner.Generators.Jet;
@@ -265,6 +266,18 @@ namespace FluentMigrator.Tests.Unit.Generators
         {
             quoter.QuoteValue(new byte[] { 0, 254, 13, 18, 125, 17 })
                 .ShouldBe("0x00fe0d127d11");
+        }
+
+        [Test]
+        public void ExplicitUnicodeStringIsFormattedAsNormalString()
+        {
+            quoter.QuoteValue(new ExplicitUnicodeString("Test String")).ShouldBe("'Test String'");
+        }
+
+        [Test]
+        public void ExplicitUnicodeStringIsFormattedAsNormalStringQuotes()
+        {
+            quoter.QuoteValue(new ExplicitUnicodeString("Test ' String")).ShouldBe("'Test '' String'");
         }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Generators/Postgres/PostgresGeneratorTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/Postgres/PostgresGeneratorTests.cs
@@ -456,6 +456,24 @@ namespace FluentMigrator.Tests.Unit.Generators.Postgres
         }
 
         [Test]
+        public void ExplicitUnicodeStringIgnoredForNonSqlServer()
+        {
+            var expression = new InsertDataExpression();
+            expression.TableName = "TestTable";
+            expression.Rows.Add(new InsertionDataDefinition
+                                    {
+                                        new KeyValuePair<string, object>("NormalString", "Just'in"),
+                                        new KeyValuePair<string, object>("UnicodeString", new ExplicitUnicodeString("codethinked'.com"))
+                                    });
+
+            var sql = generator.Generate(expression);
+
+            var expected = "INSERT INTO \"public\".\"TestTable\" (\"NormalString\",\"UnicodeString\") VALUES ('Just''in','codethinked''.com');";
+            
+            sql.ShouldBe(expected);
+        }
+
+        [Test]
         public void CanInsertGuidData()
         {
             var gid = Guid.NewGuid();

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2008/SqlServer2008GeneratorTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2008/SqlServer2008GeneratorTests.cs
@@ -71,5 +71,24 @@ namespace FluentMigrator.Tests.Unit.Generators
             sql.ShouldBe(expected);
         }
 
+        [Test]
+        public void ExplicitUnicodeQuotesCorrectly()
+        {
+            var expression = new InsertDataExpression();
+            expression.TableName = "TestTable";
+            expression.Rows.Add(new InsertionDataDefinition
+                                    {
+                                        new KeyValuePair<string, object>("UnicodeStringValue", new ExplicitUnicodeString("UnicodeString")),
+                                        new KeyValuePair<string, object>("StringValue", "AnsiiString")
+                                    });
+
+            var sql = generator.Generate(expression);
+
+            var expected = "INSERT INTO [dbo].[TestTable] ([UnicodeStringValue], [StringValue]) VALUES (N'UnicodeString', 'AnsiiString')";
+
+            sql.ShouldBe(expected);
+
+        }
+
     }
 }

--- a/src/FluentMigrator/FluentMigrator.csproj
+++ b/src/FluentMigrator/FluentMigrator.csproj
@@ -180,6 +180,7 @@
     <Compile Include="Builders\IfDatabase\NullIfDatabaseProcessor.cs" />
     <Compile Include="Builders\IForeignKeyCascadeSyntax.cs" />
     <Compile Include="Builders\IInSchemaSyntax.cs" />
+    <Compile Include="Model\ExplicitUnicodeString.cs" />
     <Compile Include="RawSql.cs" />
     <Compile Include="Infrastructure\ISupportAdditionalFeatures.cs" />
     <Compile Include="Builders\Insert\IInsertDataOrInSchemaSyntax.cs" />

--- a/src/FluentMigrator/Model/ExplicitUnicodeString.cs
+++ b/src/FluentMigrator/Model/ExplicitUnicodeString.cs
@@ -1,0 +1,17 @@
+﻿namespace FluentMigrator.Model
+{
+    public class ExplicitUnicodeString
+    {
+        public string Text { get; set; }
+
+        public ExplicitUnicodeString(string text)
+        {
+            Text = text;
+        }
+        
+        public override string ToString()
+        {
+            return Text;
+        }
+    }
+}


### PR DESCRIPTION
This pull request contains code + unit tests to allow SQL Server Insert commands to have the **N**'Text' prefix allowing the contents to be treated as explicit Unicode.

This is a SQL Server specific change, so tests have been added to one of the non-sql-server fixtures to ensure that the changes have no effect.

This does not take effect in users code unless they replace their strings with the ExplicitUnicodeString object.
