### PR TITLE
Adds Support For Indexes With Include Columns using SqlServerExtensions

### DIFF
--- a/src/FluentMigrator.Runner/Extensions/SqlServerExtensions.cs
+++ b/src/FluentMigrator.Runner/Extensions/SqlServerExtensions.cs
@@ -5,8 +5,10 @@ using FluentMigrator.Builders.Alter.Table;
 using FluentMigrator.Builders.Create.Column;
 using FluentMigrator.Builders.Create.Constraint;
 using FluentMigrator.Builders.Create.Table;
+using FluentMigrator.Builders.Create.Index;
 using FluentMigrator.Builders.Insert;
 using FluentMigrator.Infrastructure;
+using FluentMigrator.Model;
 
 namespace FluentMigrator.Runner.Extensions
 {
@@ -73,6 +75,14 @@ namespace FluentMigrator.Runner.Extensions
         public static void NonClustered(this ICreateConstraintOptionsSyntax expression)
         {
             SetConstraintType(expression, SqlServerConstraintType.NonClustered);
+        }
+
+        public static ICreateIndexOptionsSyntax Include(this ICreateIndexOptionsSyntax expression, string columnName)
+        {
+            CreateIndexExpressionBuilder castIndex = expression as CreateIndexExpressionBuilder;
+            if(castIndex == null) throw new InvalidOperationException("The seeded identity method can only be called on a valid object.");
+            castIndex.Expression.Index.Includes.Add(new IndexIncludeDefinition { Name = columnName }); ;
+            return expression;
         }
 
         private static ISupportAdditionalFeatures GetColumn<TNext, TNextFk>(IColumnOptionSyntax<TNext, TNextFk> expression) where TNext : IFluentSyntax where TNextFk : IFluentSyntax 

--- a/src/FluentMigrator.Tests/Unit/Builders/Create/CreateIndexExpressionBuilderTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Builders/Create/CreateIndexExpressionBuilderTests.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using FluentMigrator.Builders.Create.Index;
 using FluentMigrator.Expressions;
 using FluentMigrator.Model;
+using FluentMigrator.Runner.Extensions;
 using Moq;
 using NUnit.Framework;
 
@@ -89,6 +90,25 @@ namespace FluentMigrator.Tests.Unit.Builders.Create
             builder.Descending();
 
             columnMock.VerifySet(c => c.Direction = Direction.Descending);
+        }
+
+        [Test]
+        public void CallingIncludeAddsNewIncludeToExpression()
+        {
+            var collectionMock = new Mock<IList<IndexIncludeDefinition>>();
+
+            var indexMock = new Mock<IndexDefinition>();
+            indexMock.Setup(x => x.Includes).Returns(collectionMock.Object);
+
+            var expressionMock = new Mock<CreateIndexExpression>();
+            expressionMock.SetupGet(e => e.Index).Returns(indexMock.Object);
+
+            var builder = new CreateIndexExpressionBuilder(expressionMock.Object);
+            builder.Include("BaconId");
+
+            collectionMock.Verify(x => x.Add(It.Is<IndexIncludeDefinition>(c => c.Name.Equals("BaconId"))));
+            indexMock.VerifyGet(x => x.Includes);
+            expressionMock.VerifyGet(e => e.Index);
         }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Definitions/IndexColumnDefinitionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Definitions/IndexColumnDefinitionTests.cs
@@ -58,5 +58,29 @@ namespace FluentMigrator.Tests.Unit.Definitions
             var errors = ValidationHelper.CollectErrors(column);
             errors.ShouldNotContain(ErrorMessages.ColumnNameCannotBeNullOrEmpty);
         }
+
+        [Test]
+        public void ErrorIsReturnedWhenIncludeNameIsNull()
+        {
+            var column = new IndexIncludeDefinition { Name = null };
+            var errors = ValidationHelper.CollectErrors(column);
+            errors.ShouldContain(ErrorMessages.ColumnNameCannotBeNullOrEmpty);
+        }
+
+        [Test]
+        public void ErrorIsReturnedWhenIncludeNameIsEmptyString()
+        {
+            var column = new IndexIncludeDefinition { Name = String.Empty };
+            var errors = ValidationHelper.CollectErrors(column);
+            errors.ShouldContain(ErrorMessages.ColumnNameCannotBeNullOrEmpty);
+        }
+
+        [Test]
+        public void ErrorIsNotReturnedWhenIncludeNameIsNotNullOrEmptyString()
+        {
+            var column = new IndexIncludeDefinition { Name = "Bacon" };
+            var errors = ValidationHelper.CollectErrors(column);
+            errors.ShouldNotContain(ErrorMessages.ColumnNameCannotBeNullOrEmpty);
+        }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Generators/GeneratorTestHelper.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/GeneratorTestHelper.cs
@@ -13,6 +13,7 @@ namespace FluentMigrator.Tests.Unit.Generators
         public static string TestTableName2 = "TestTable2";
         public static string TestColumnName1 = "TestColumn1";
         public static string TestColumnName2 = "TestColumn2";
+        public static string TestColumnName3 = "TestColumn3";
         public static string TestIndexName = "TestIndex";
         public static Guid TestGuid = Guid.NewGuid();
 
@@ -121,6 +122,29 @@ namespace FluentMigrator.Tests.Unit.Generators
             expression.Index.IsUnique = true;
             expression.Index.Columns.Add(new IndexColumnDefinition { Direction = Direction.Ascending, Name = TestColumnName1 });
             expression.Index.Columns.Add(new IndexColumnDefinition { Direction = Direction.Descending, Name = TestColumnName2 });
+            return expression;
+        }
+
+        public static CreateIndexExpression GetCreateIncludeIndexExpression()
+        {
+            var expression = new CreateIndexExpression();
+            expression.Index.Name = TestIndexName;
+            expression.Index.TableName = TestTableName1;
+            expression.Index.IsUnique = false;
+            expression.Index.Columns.Add(new IndexColumnDefinition { Direction = Direction.Ascending, Name = TestColumnName1 });
+            expression.Index.Includes.Add(new IndexIncludeDefinition { Name = TestColumnName2 });
+            return expression;
+        }
+
+        public static CreateIndexExpression GetCreateMultiIncludeIndexExpression()
+        {
+            var expression = new CreateIndexExpression();
+            expression.Index.Name = TestIndexName;
+            expression.Index.TableName = TestTableName1;
+            expression.Index.IsUnique = false;
+            expression.Index.Columns.Add(new IndexColumnDefinition { Direction = Direction.Ascending, Name = TestColumnName1 });
+            expression.Index.Includes.Add(new IndexIncludeDefinition { Name = TestColumnName2 });
+            expression.Index.Includes.Add(new IndexIncludeDefinition { Name = TestColumnName3 });
             return expression;
         }
 

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005CreateTableTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005CreateTableTests.cs
@@ -324,6 +324,40 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer
         }
 
         [Test]
+        public void CanCreateIncludeIndexWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateIncludeIndexExpression();
+            var sql = generator.Generate(expression);
+            sql.ShouldBe("CREATE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC) INCLUDE ([TestColumn2])");
+        }
+
+        [Test]
+        public void CanCreateIncludeIndexWithCustomSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateIncludeIndexExpression();
+            expression.Index.SchemaName = "TestSchema";
+            var sql = generator.Generate(expression);
+            sql.ShouldBe("CREATE INDEX [TestIndex] ON [TestSchema].[TestTable1] ([TestColumn1] ASC) INCLUDE ([TestColumn2])");
+        }
+
+        [Test]
+        public void CanCreateMultiIncludeIndexWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateMultiIncludeIndexExpression();
+            var sql = generator.Generate(expression);
+            sql.ShouldBe("CREATE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC) INCLUDE ([TestColumn2], [TestColumn3])");
+        }
+
+        [Test]
+        public void CanCreateMultiIncludeIndexWithCustomSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateMultiIncludeIndexExpression();
+            expression.Index.SchemaName = "TestSchema";
+            var sql = generator.Generate(expression);
+            sql.ShouldBe("CREATE INDEX [TestIndex] ON [TestSchema].[TestTable1] ([TestColumn1] ASC) INCLUDE ([TestColumn2], [TestColumn3])");
+        }
+
+        [Test]
         public void CanCreateTableWithMultiColumnPrimaryKeyWithDefaultSchema()
         {
             var expression = GeneratorTestHelper.GetCreateTableWithMultiColumnPrimaryKeyExpression();

--- a/src/FluentMigrator/FluentMigrator.csproj
+++ b/src/FluentMigrator/FluentMigrator.csproj
@@ -223,6 +223,7 @@
     <Compile Include="ForwardOnlyMigration.cs" />
     <Compile Include="MigrationBase.cs" />
     <Compile Include="Model\ConstraintDefinition.cs" />
+    <Compile Include="Model\IndexIncludeDefinition.cs" />
     <Compile Include="Model\DeletionDataDefinition.cs" />
     <Compile Include="Model\InsertionDataDefinition.cs" />
     <Compile Include="Builders\Rename\Column\IRenameColumnToSyntax.cs" />

--- a/src/FluentMigrator/Model/IndexDefinition.cs
+++ b/src/FluentMigrator/Model/IndexDefinition.cs
@@ -32,10 +32,12 @@ namespace FluentMigrator.Model
         public virtual bool IsUnique { get; set; }
         public bool IsClustered { get; set; }
         public virtual ICollection<IndexColumnDefinition> Columns { get; set; }
+        public virtual ICollection<IndexIncludeDefinition> Includes { get; set; }
 
         public IndexDefinition()
         {
             Columns = new List<IndexColumnDefinition>();
+            Includes = new List<IndexIncludeDefinition>();
         }
 
         public virtual void ApplyConventions(IMigrationConventions conventions)
@@ -57,6 +59,9 @@ namespace FluentMigrator.Model
 
             foreach (IndexColumnDefinition column in Columns)
                 column.CollectValidationErrors(errors);
+
+            foreach (IndexIncludeDefinition include in Includes)
+                include.CollectValidationErrors(errors);
         }
 
         public object Clone()
@@ -68,7 +73,8 @@ namespace FluentMigrator.Model
                 TableName = TableName,
                 IsUnique = IsUnique,
                 IsClustered = IsClustered,
-                Columns = Columns.CloneAll().ToList()
+                Columns = Columns.CloneAll().ToList(),
+                Includes = Includes.CloneAll().ToList()
             };
         }
     }

--- a/src/FluentMigrator/Model/IndexIncludeDefinition.cs
+++ b/src/FluentMigrator/Model/IndexIncludeDefinition.cs
@@ -1,0 +1,40 @@
+#region License
+// 
+// Copyright (c) 2007-2009, Sean Chambers <schambers80@gmail.com>
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+using System;
+using System.Collections.Generic;
+using FluentMigrator.Infrastructure;
+
+namespace FluentMigrator.Model
+{
+    public class IndexIncludeDefinition : ICloneable, ICanBeValidated
+    {
+        public virtual string Name { get; set; }
+
+        public virtual void CollectValidationErrors(ICollection<string> errors)
+        {
+            if (String.IsNullOrEmpty(Name))
+                errors.Add(ErrorMessages.ColumnNameCannotBeNullOrEmpty);
+        }
+
+        public object Clone()
+        {
+            return MemberwiseClone();
+        }
+    }
+}


### PR DESCRIPTION
When creating indexes for SQL Server that require include columns, you are forced to execute raw SQL.  This code is intended to allow indexes with include columns using the following syntax:

```
Create.Index("IX").OnTable("TestTable").OnColumn("Id").Ascending().WithOptions().Include("Name");
```

This code shoould also support indexes with multiple include columns:

```
Create.Index("IX").OnTable("TestTable").OnColumn("Id").Ascending().WithOptions().Include("Name").Include("DOB");
```
### Notes

It is worth noting, since this is an SQL Server specific feature it is only accessible as part of the [SQL Server Specific Extensions](https://github.com/schambers/fluentmigrator/wiki/Sql-Server-Specific-Extensions).

I have done my best to come up with a minimal set of unit tests to verify behaviour of this code.
