### PR TITLE
Oracle generators should output NULL when a column is explicitly nullable

### DIFF
--- a/src/FluentMigrator.Runner/Generators/Oracle/OracleColumn.cs
+++ b/src/FluentMigrator.Runner/Generators/Oracle/OracleColumn.cs
@@ -48,7 +48,7 @@ namespace FluentMigrator.Runner.Generators.Oracle
 
 			//alter only returns "Not Null" if IsNullable is explicitly set 
 			if (column.IsNullable.HasValue) {
-				return column.IsNullable.Value ? string.Empty : "NOT NULL";
+				return column.IsNullable.Value ? "NULL" : "NOT NULL";
 			}
 			else {
 				return String.Empty;

--- a/src/FluentMigrator.Tests/Unit/Generators/Oracle/OracleGeneratorTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/Oracle/OracleGeneratorTests.cs
@@ -28,6 +28,26 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
         }
 
         [Test]
+        public void CanAlterColumnNull()
+        {
+            var expression = GeneratorTestHelper.GetAlterColumnExpression();
+            expression.Column.IsNullable = true;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE TestTable1 MODIFY TestColumn1 NVARCHAR2(20) NULL");
+        }
+
+        [Test]
+        public void CanAlterColumnNotNull()
+        {
+            var expression = GeneratorTestHelper.GetAlterColumnExpression();
+            expression.Column.IsNullable = false;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE TestTable1 MODIFY TestColumn1 NVARCHAR2(20) NOT NULL");
+        }
+
+        [Test]
         public void CanAlterSchemaInStrictMode()
         {
             Generator.compatabilityMode = Runner.CompatabilityMode.STRICT;


### PR DESCRIPTION
Currently there is no way in Oracle to change the nullability of a not-nullable column.
If I say

```
Alter.Column("Col1").OnTable("Table1").AsString(20).Nullable();
```

I expect the Oracle generator to output:

```
ALTER TABLE Table1 MODIFY Col1 NVARCHAR2(20) NULL
```
