### PR TITLE
Added description support for tables and columns on MS Sql Server and Oracle

### DIFF
--- a/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
+++ b/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
@@ -139,11 +139,17 @@
     <Compile Include="Extensions\TypeExtensions.cs" />
     <Compile Include="Generators\Base\ColumnBase.cs" />
     <Compile Include="Extensions\CompatabilityModeExtension.cs" />
+    <Compile Include="Generators\EmptyDescriptionGenerator.cs" />
     <Compile Include="Generators\Firebird\FirebirdColumn.cs" />
     <Compile Include="Generators\Firebird\FirebirdGenerator.cs" />
     <Compile Include="Generators\Firebird\FirebirdTruncator.cs" />
+    <Compile Include="Generators\Generic\GenericDescriptionGenerator.cs" />
+    <Compile Include="Generators\IDescriptionGenerator.cs" />
+    <Compile Include="Generators\Oracle\OracleDescriptionGenerator.cs" />
     <Compile Include="Generators\Oracle\OracleQuoter.cs" />
+    <Compile Include="Generators\SqlServer\SqlServer2005DescriptionGenerator.cs" />
     <Compile Include="Generators\SqlServer\SqlServer2012Generator.cs" />
+    <Compile Include="Helpers\FormatHelper.cs" />
     <Compile Include="IMigrationInformationLoader.cs" />
     <Compile Include="IMigrationScope.cs" />
     <Compile Include="IMigrationScopeStarter.cs" />

--- a/src/FluentMigrator.Runner/Generators/Base/GeneratorBase.cs
+++ b/src/FluentMigrator.Runner/Generators/Base/GeneratorBase.cs
@@ -24,11 +24,13 @@ namespace FluentMigrator.Runner.Generators.Base
     {
         private readonly IColumn _column;
         private readonly IQuoter _quoter;
+        private readonly IDescriptionGenerator _descriptionGenerator;
 
-        public GeneratorBase(IColumn column, IQuoter quoter)
+        public GeneratorBase(IColumn column, IQuoter quoter, IDescriptionGenerator descriptionGenerator)
         {
             _column = column;
             _quoter = quoter;
+            _descriptionGenerator = descriptionGenerator;
         }
 
         public abstract string Generate(CreateSchemaExpression expression);
@@ -60,7 +62,7 @@ namespace FluentMigrator.Runner.Generators.Base
             return false;
         }
 
-        public string Generate(AlterTableExpression expression)
+        public virtual string Generate(AlterTableExpression expression)
         {
             // returns nothing because the individual AddColumn and AlterColumn calls
             //  create CreateColumnExpression and AlterColumnExpression respectively
@@ -75,6 +77,11 @@ namespace FluentMigrator.Runner.Generators.Base
         public IQuoter Quoter
         {
             get { return _quoter; }
+        }
+
+        protected IDescriptionGenerator DescriptionGenerator
+        {
+            get { return _descriptionGenerator; }
         }
     }
 }

--- a/src/FluentMigrator.Runner/Generators/EmptyDescriptionGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/EmptyDescriptionGenerator.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FluentMigrator.Expressions;
+
+namespace FluentMigrator.Runner.Generators
+{
+    class EmptyDescriptionGenerator : IDescriptionGenerator
+    {
+        public IEnumerable<string> GenerateDescriptionStatements(CreateTableExpression expression)
+        {
+            return Enumerable.Empty<string>();
+        }
+
+        public string GenerateDescriptionStatement(AlterTableExpression expression)
+        {
+            return string.Empty;
+        }
+
+        public string GenerateDescriptionStatement(CreateColumnExpression expression)
+        {
+            return string.Empty;
+        }
+
+        public string GenerateDescriptionStatement(AlterColumnExpression expression)
+        {
+            return string.Empty;
+        }
+    }
+}

--- a/src/FluentMigrator.Runner/Generators/Firebird/FirebirdGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/Firebird/FirebirdGenerator.cs
@@ -15,7 +15,7 @@ namespace FluentMigrator.Runner.Generators.Firebird
         protected readonly FirebirdTruncator truncator;
         protected Processors.Firebird.FirebirdOptions FBOptions { get; private set; }
 
-        public FirebirdGenerator(Processors.Firebird.FirebirdOptions fbOptions) : base(new FirebirdColumn(fbOptions), new FirebirdQuoter()) 
+        public FirebirdGenerator(Processors.Firebird.FirebirdOptions fbOptions) : base(new FirebirdColumn(fbOptions), new FirebirdQuoter(), new EmptyDescriptionGenerator()) 
         {
             if (fbOptions == null)
                 throw new ArgumentNullException("fbOptions");

--- a/src/FluentMigrator.Runner/Generators/Generic/GenericDescriptionGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/Generic/GenericDescriptionGenerator.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FluentMigrator.Runner.Generators.Generic
+{
+    public abstract class GenericDescriptionGenerator : IDescriptionGenerator
+    {
+        protected abstract string GenerateTableDescription(
+            string schemaName, string tableName, string tableDescription);
+        protected abstract string GenerateColumnDescription(
+            string schemaName, string tableName, string columnName, string columnDescription);
+
+        public virtual IEnumerable<string> GenerateDescriptionStatements(Expressions.CreateTableExpression expression)
+        {
+            var statements = new List<string>();
+
+            if (!string.IsNullOrEmpty(expression.TableDescription))
+                statements.Add(GenerateTableDescription(expression.SchemaName, expression.TableName, expression.TableDescription));
+
+            foreach (var column in expression.Columns)
+            {
+                if (string.IsNullOrEmpty(column.ColumnDescription))
+                    continue;
+
+                statements.Add(GenerateColumnDescription(
+                    expression.SchemaName,
+                    expression.TableName,
+                    column.Name,
+                    column.ColumnDescription));
+            }
+
+            return statements;
+        }
+
+        public virtual string GenerateDescriptionStatement(Expressions.AlterTableExpression expression)
+        {
+            if (string.IsNullOrEmpty(expression.TableDescription))
+                return string.Empty;
+
+            return GenerateTableDescription(
+                expression.SchemaName, expression.TableName, expression.TableDescription);
+        }
+
+        public virtual string GenerateDescriptionStatement(Expressions.CreateColumnExpression expression)
+        {
+            if (string.IsNullOrEmpty(expression.Column.ColumnDescription))
+                return string.Empty;
+
+            return GenerateColumnDescription(
+                expression.SchemaName, expression.TableName, expression.Column.Name, expression.Column.ColumnDescription);
+        }
+
+        public virtual string GenerateDescriptionStatement(Expressions.AlterColumnExpression expression)
+        {
+            if (string.IsNullOrEmpty(expression.Column.ColumnDescription))
+                return string.Empty;
+
+            return GenerateColumnDescription(expression.SchemaName, expression.TableName, expression.Column.Name, expression.Column.ColumnDescription);
+        }
+    }
+}

--- a/src/FluentMigrator.Runner/Generators/Generic/GenericGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/Generic/GenericGenerator.cs
@@ -13,8 +13,8 @@ namespace FluentMigrator.Runner.Generators.Generic
     {
         public CompatabilityMode compatabilityMode;
 
-        public GenericGenerator(IColumn column, IQuoter quoter)
-            : base(column, quoter)
+        public GenericGenerator(IColumn column, IQuoter quoter, IDescriptionGenerator descriptionGenerator)
+            : base(column, quoter, descriptionGenerator)
         {
             compatabilityMode = CompatabilityMode.LOOSE;
         }

--- a/src/FluentMigrator.Runner/Generators/IDescriptionGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/IDescriptionGenerator.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using FluentMigrator.Expressions;
+
+namespace FluentMigrator.Runner.Generators
+{
+    public interface IDescriptionGenerator
+    {
+        IEnumerable<string> GenerateDescriptionStatements(CreateTableExpression expression);
+        string GenerateDescriptionStatement(AlterTableExpression expression);
+        string GenerateDescriptionStatement(CreateColumnExpression expression);
+        string GenerateDescriptionStatement(AlterColumnExpression expression);
+    }
+}

--- a/src/FluentMigrator.Runner/Generators/Jet/JetGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/Jet/JetGenerator.cs
@@ -6,7 +6,7 @@ namespace FluentMigrator.Runner.Generators.Jet
     public class JetGenerator : GenericGenerator
     {
         public JetGenerator()
-            : base(new JetColumn(), new JetQuoter())
+            : base(new JetColumn(), new JetQuoter(), new EmptyDescriptionGenerator())
         {
         }
 

--- a/src/FluentMigrator.Runner/Generators/MySql/MySqlGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/MySql/MySqlGenerator.cs
@@ -24,7 +24,7 @@ namespace FluentMigrator.Runner.Generators.MySql
     public class MySqlGenerator : GenericGenerator
     {
         public MySqlGenerator()
-            : base(new MySqlColumn(), new MySqlQuoter())
+            : base(new MySqlColumn(), new MySqlQuoter(), new EmptyDescriptionGenerator())
         {
         }
 

--- a/src/FluentMigrator.Runner/Generators/Oracle/OracleDescriptionGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/Oracle/OracleDescriptionGenerator.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using FluentMigrator.Expressions;
+using FluentMigrator.Runner.Generators.Generic;
+
+namespace FluentMigrator.Runner.Generators.Oracle
+{
+    public class OracleDescriptionGenerator : GenericDescriptionGenerator
+    {
+        #region Constants
+
+        private const string TableDescriptionTemplate = "COMMENT ON TABLE {0} IS '{1}'";
+        private const string ColumnDescriptionTemplate = "COMMENT ON COLUMN {0}.{1} IS '{2}'";
+
+        #endregion
+
+        private string GetFullTableName(string schemaName, string tableName)
+        {
+            return string.IsNullOrEmpty(schemaName)
+               ? tableName
+               : string.Format("{0}.{1}", schemaName, tableName);
+        }
+
+        protected override string GenerateTableDescription(
+            string schemaName, string tableName, string tableDescription)
+        {
+            if (string.IsNullOrEmpty(tableDescription))
+                return string.Empty;
+
+            return string.Format(TableDescriptionTemplate, GetFullTableName(schemaName, tableName), tableDescription);
+        }
+
+        protected override string GenerateColumnDescription(
+            string schemaName, string tableName, string columnName, string columnDescription)
+        {
+            if (string.IsNullOrEmpty(columnDescription))
+                return string.Empty;
+
+            return string.Format(
+                ColumnDescriptionTemplate,
+                GetFullTableName(schemaName, tableName),
+                columnName,
+                columnDescription);
+        }
+    }
+}

--- a/src/FluentMigrator.Runner/Generators/Oracle/OracleGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/Oracle/OracleGenerator.cs
@@ -1,29 +1,32 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using FluentMigrator.Expressions;
 using FluentMigrator.Model;
 using FluentMigrator.Runner.Generators.Generic;
+using FluentMigrator.Runner.Helpers;
 
 namespace FluentMigrator.Runner.Generators.Oracle
 {
     public class OracleGenerator : GenericGenerator
     {
         public OracleGenerator()
-			: base(new OracleColumn(new OracleQuoter()), new OracleQuoter())
+            : base(new OracleColumn(new OracleQuoter()), new OracleQuoter(), new OracleDescriptionGenerator())
         {
         }
 
-		public OracleGenerator(bool useQuotedIdentifiers)
-			: base(new OracleColumn(GetQuoter(useQuotedIdentifiers)), GetQuoter(useQuotedIdentifiers))
-		{
-		}
+        public OracleGenerator(bool useQuotedIdentifiers)
+            : base(new OracleColumn(GetQuoter(useQuotedIdentifiers)), GetQuoter(useQuotedIdentifiers), new OracleDescriptionGenerator())
+        {
+        }
 
-	    private static IQuoter GetQuoter(bool useQuotedIdentifiers)
-	    {
-			return useQuotedIdentifiers ? (IQuoter) new OracleQuoterQuotedIdentifier() : (IQuoter) new OracleQuoter();
-	    }
+        private static IQuoter GetQuoter(bool useQuotedIdentifiers)
+        {
+            return useQuotedIdentifiers ? (IQuoter)new OracleQuoterQuotedIdentifier() : (IQuoter)new OracleQuoter();
+        }
 
-	    public override string AddColumn
+        public override string AddColumn
         {
             get { return "ALTER TABLE {0} ADD {1}"; }
         }
@@ -41,6 +44,69 @@ namespace FluentMigrator.Runner.Generators.Oracle
         public override string InsertData
         {
             get { return "INTO {0} ({1}) VALUES ({2})"; }
+        }
+
+        public override string Generate(CreateTableExpression expression)
+        {
+            var descriptionStatements = DescriptionGenerator.GenerateDescriptionStatements(expression);
+            var statements = descriptionStatements as string[] ?? descriptionStatements.ToArray();
+
+            if (!statements.Any())
+                return base.Generate(expression);
+
+            var wrappedCreateTableStatement = WrapStatementInExecuteImmediateBlock(base.Generate(expression));
+            var createTableWithDescriptionsBuilder = new StringBuilder(wrappedCreateTableStatement);
+
+            foreach (var descriptionStatement in statements)
+            {
+                if (!string.IsNullOrEmpty(descriptionStatement))
+                {
+                    var wrappedStatement = WrapStatementInExecuteImmediateBlock(descriptionStatement);
+                    createTableWithDescriptionsBuilder.Append(wrappedStatement);
+                }
+            }
+
+            return WrapInBlock(createTableWithDescriptionsBuilder.ToString());
+        }
+
+        public override string Generate(AlterTableExpression expression)
+        {
+            var descriptionStatement = DescriptionGenerator.GenerateDescriptionStatement(expression);
+
+            if (string.IsNullOrEmpty(descriptionStatement))
+                return base.Generate(expression);
+
+            return descriptionStatement;
+        }
+
+        public override string Generate(CreateColumnExpression expression)
+        {
+            var descriptionStatement = DescriptionGenerator.GenerateDescriptionStatement(expression);
+
+            if (string.IsNullOrEmpty(descriptionStatement))
+                return base.Generate(expression);
+
+            var wrappedCreateColumnStatement = WrapStatementInExecuteImmediateBlock(base.Generate(expression));
+
+            var createColumnWithDescriptionBuilder = new StringBuilder(wrappedCreateColumnStatement);
+            createColumnWithDescriptionBuilder.Append(WrapStatementInExecuteImmediateBlock(descriptionStatement));
+
+            return WrapInBlock(createColumnWithDescriptionBuilder.ToString());
+        }
+
+        public override string Generate(AlterColumnExpression expression)
+        {
+            var descriptionStatement = DescriptionGenerator.GenerateDescriptionStatement(expression);
+
+            if (string.IsNullOrEmpty(descriptionStatement))
+                return base.Generate(expression);
+
+            var wrappedAlterColumnStatement = WrapStatementInExecuteImmediateBlock(base.Generate(expression));
+
+            var alterColumnWithDescriptionBuilder = new StringBuilder(wrappedAlterColumnStatement);
+            alterColumnWithDescriptionBuilder.Append(WrapStatementInExecuteImmediateBlock(descriptionStatement));
+
+            return WrapInBlock(alterColumnWithDescriptionBuilder.ToString());
         }
 
         public override string Generate(InsertDataExpression expression)
@@ -74,6 +140,22 @@ namespace FluentMigrator.Runner.Generators.Oracle
         public override string Generate(DeleteDefaultConstraintExpression expression)
         {
             return compatabilityMode.HandleCompatabilty("Default constraints are not supported");
+        }
+
+        private string WrapStatementInExecuteImmediateBlock(string statement)
+        {
+            if (string.IsNullOrEmpty(statement))
+                return string.Empty;
+
+            return string.Format("EXECUTE IMMEDIATE '{0}';", FormatHelper.FormatSqlEscape(statement));
+        }
+
+        private string WrapInBlock(string sql)
+        {
+            if (string.IsNullOrEmpty(sql))
+                return string.Empty;
+
+            return string.Format("BEGIN {0} END;", sql);
         }
     }
 }

--- a/src/FluentMigrator.Runner/Generators/Postgres/PostgresGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/Postgres/PostgresGenerator.cs
@@ -10,7 +10,7 @@ namespace FluentMigrator.Runner.Generators.Postgres
 {
     public class PostgresGenerator : GenericGenerator
     {
-        public PostgresGenerator() : base(new PostgresColumn(), new PostgresQuoter()) { }
+        public PostgresGenerator() : base(new PostgresColumn(), new PostgresQuoter(), new EmptyDescriptionGenerator()) { }
 
         public override string Generate(CreateSchemaExpression expression)
         {

--- a/src/FluentMigrator.Runner/Generators/SQLite/SqliteGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/SQLite/SqliteGenerator.cs
@@ -25,7 +25,7 @@ namespace FluentMigrator.Runner.Generators.SQLite
     public class SqliteGenerator : GenericGenerator
     {
         public SqliteGenerator()
-            : base(new SqliteColumn(), new SqliteQuoter())
+            : base(new SqliteColumn(), new SqliteQuoter(), new EmptyDescriptionGenerator())
         {
         }
 

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2000Generator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2000Generator.cs
@@ -29,12 +29,12 @@ namespace FluentMigrator.Runner.Generators.SqlServer
     public class SqlServer2000Generator : GenericGenerator
     {
         public SqlServer2000Generator()
-            : base(new SqlServerColumn(new SqlServer2000TypeMap()), new SqlServerQuoter())
+            : base(new SqlServerColumn(new SqlServer2000TypeMap()), new SqlServerQuoter(), new EmptyDescriptionGenerator())
         {
         }
 
-        protected SqlServer2000Generator(IColumn column)
-            : base(column, new SqlServerQuoter())
+        protected SqlServer2000Generator(IColumn column, IDescriptionGenerator descriptionGenerator)
+            : base(column, new SqlServerQuoter(), descriptionGenerator)
         {
         }
 

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2005DescriptionGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2005DescriptionGenerator.cs
@@ -1,0 +1,90 @@
+﻿using System.Collections.Generic;
+using FluentMigrator.Expressions;
+using FluentMigrator.Runner.Generators.Generic;
+
+namespace FluentMigrator.Runner.Generators.SqlServer
+{
+    public class SqlServer2005DescriptionGenerator : GenericDescriptionGenerator
+    {
+        #region Constants
+
+        private const string TableDescriptionTemplate =
+            "EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'{0}', @level0type=N'SCHEMA', @level0name='{1}', @level1type=N'TABLE', @level1name='{2}'";
+        private const string ColumnDescriptionTemplate =
+            "EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'{0}', @level0type = N'SCHEMA', @level0name = '{1}', @level1type = N'Table', @level1name = '{2}', @level2type = N'Column',  @level2name = '{3}'";
+        private const string RemoveTableDescriptionTemplate = "EXEC sys.sp_dropextendedproperty @name=N'MS_Description', @level0type=N'SCHEMA', @level0name='{0}', @level1type=N'TABLE', @level1name='{1}'";
+        private const string RemoveColumnDescriptionTemplate = "EXEC sys.sp_dropextendedproperty @name=N'MS_Description', @level0type = N'SCHEMA', @level0name = '{0}', @level1type = N'Table', @level1name = '{1}', @level2type = N'Column',  @level2name = '{2}'";
+        private const string TableDescriptionVerificationTemplate = "IF EXISTS ( SELECT * FROM fn_listextendedproperty(N'MS_Description', N'SCHEMA', N'{0}', N'TABLE', N'{1}', NULL, NULL))";
+        private const string ColumnDescriptionVerificationTemplate = "IF EXISTS (SELECT * FROM fn_listextendedproperty(N'MS_Description', N'SCHEMA', N'{0}', N'TABLE', N'{1}', N'Column', N'{2}' ))";
+
+        #endregion
+
+        public override string GenerateDescriptionStatement(AlterTableExpression expression)
+        {
+            if (string.IsNullOrEmpty(expression.TableDescription))
+                return string.Empty;
+
+            var formattedSchemaName = FormatSchemaName(expression.SchemaName);
+
+            // For this, we need to remove the extended property first if exists (or implement verification and use sp_updateextendedproperty)
+            var tableVerificationStatement = string.Format(TableDescriptionVerificationTemplate, formattedSchemaName, expression.TableName);
+            var removalStatement = string.Format("{0} {1}", tableVerificationStatement, GenerateTableDescriptionRemoval(formattedSchemaName, expression.TableName));
+            var newDescriptionStatement = GenerateTableDescription(formattedSchemaName, expression.TableName, expression.TableDescription);
+
+            return string.Join(";", new[] { removalStatement, newDescriptionStatement });
+        }
+
+        public override string GenerateDescriptionStatement(AlterColumnExpression expression)
+        {
+            if (string.IsNullOrEmpty(expression.Column.ColumnDescription))
+                return string.Empty;
+
+            var formattedSchemaName = FormatSchemaName(expression.SchemaName);
+
+            // For this, we need to remove the extended property first if exists (or implement verification and use sp_updateextendedproperty)
+            var columnVerificationStatement = string.Format(ColumnDescriptionVerificationTemplate, formattedSchemaName, expression.TableName, expression.Column.Name);
+            var removalStatement = string.Format("{0} {1}", columnVerificationStatement, GenerateColumnDescriptionRemoval(formattedSchemaName, expression.TableName, expression.Column.Name));
+            var newDescriptionStatement = GenerateColumnDescription(formattedSchemaName, expression.TableName, expression.Column.Name, expression.Column.ColumnDescription);
+
+            return string.Join(";", new[] { removalStatement, newDescriptionStatement });
+        }
+
+        protected override string GenerateTableDescription(string schemaName, string tableName, string tableDescription)
+        {
+            if (string.IsNullOrEmpty(tableDescription))
+                return string.Empty;
+
+            var formattedSchemaName = FormatSchemaName(schemaName);
+
+            return string.Format(TableDescriptionTemplate,
+                tableDescription,
+                formattedSchemaName,
+                tableName);
+        }
+
+        protected override string GenerateColumnDescription(string schemaName, string tableName, string columnName, string columnDescription)
+        {
+            if (string.IsNullOrEmpty(columnDescription))
+                return string.Empty;
+
+            var formattedSchemaName = FormatSchemaName(schemaName);
+
+            return string.Format(ColumnDescriptionTemplate, columnDescription, formattedSchemaName, tableName, columnName);
+        }
+
+        private string GenerateTableDescriptionRemoval(string schemaName, string tableName)
+        {
+            return string.Format(RemoveTableDescriptionTemplate, schemaName, tableName);
+        }
+
+        private string GenerateColumnDescriptionRemoval(string schemaName, string tableName, string columnName)
+        {
+            return string.Format(RemoveColumnDescriptionTemplate, schemaName, tableName, columnName);
+        }
+
+        private string FormatSchemaName(string schemaName)
+        {
+            return (string.IsNullOrEmpty(schemaName)) ? "dbo" : schemaName;
+        }
+    }
+}

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2008Generator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2008Generator.cs
@@ -21,12 +21,12 @@ namespace FluentMigrator.Runner.Generators.SqlServer
     public class SqlServer2008Generator : SqlServer2005Generator
     {
         public SqlServer2008Generator()
-            : base(new SqlServerColumn(new SqlServer2008TypeMap()))
+            : base(new SqlServerColumn(new SqlServer2008TypeMap()), new SqlServer2005DescriptionGenerator())
         {
         }
 
-        public SqlServer2008Generator(IColumn column)
-            :base(column)
+        public SqlServer2008Generator(IColumn column, IDescriptionGenerator descriptionGenerator)
+            :base(column, descriptionGenerator)
         {
         }
     }

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2012Generator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2012Generator.cs
@@ -24,7 +24,7 @@ namespace FluentMigrator.Runner.Generators.SqlServer
     public class SqlServer2012Generator : SqlServer2008Generator
     {
         public SqlServer2012Generator()
-            :base(new SqlServerColumn(new SqlServer2008TypeMap()))
+            :base(new SqlServerColumn(new SqlServer2008TypeMap()), new SqlServer2005DescriptionGenerator())
         {
         }
 

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServerCeGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServerCeGenerator.cs
@@ -27,7 +27,7 @@ namespace FluentMigrator.Runner.Generators.SqlServer
     public class SqlServerCeGenerator : SqlServer2000Generator
     {
         public SqlServerCeGenerator()
-            : base(new SqlServerColumn(new SqlServerCeTypeMap()))
+            : base(new SqlServerColumn(new SqlServerCeTypeMap()), new EmptyDescriptionGenerator())
         {
         }
 

--- a/src/FluentMigrator.Runner/Helpers/FormatHelper.cs
+++ b/src/FluentMigrator.Runner/Helpers/FormatHelper.cs
@@ -1,0 +1,11 @@
+﻿
+namespace FluentMigrator.Runner.Helpers
+{
+    public class FormatHelper
+    {
+        public static string FormatSqlEscape(string sql)
+        {
+            return sql.Replace("'", "''");
+        }
+    }
+}

--- a/src/FluentMigrator.Runner/Processors/Firebird/FirebirdProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/Firebird/FirebirdProcessor.cs
@@ -7,6 +7,7 @@ using FluentMigrator.Runner.Generators.Firebird;
 using System.Collections.Generic;
 using FluentMigrator.Expressions;
 using FluentMigrator.Model;
+using FluentMigrator.Runner.Helpers;
 
 namespace FluentMigrator.Runner.Processors.Firebird
 {
@@ -100,7 +101,7 @@ namespace FluentMigrator.Runner.Processors.Firebird
         public override DataSet Read(string template, params object[] args)
         {
             EnsureConnectionIsOpen();
-            
+
             //Announcer.Sql(String.Format(template,args));
 
             var ds = new DataSet();
@@ -225,7 +226,7 @@ namespace FluentMigrator.Runner.Processors.Firebird
         {
             return DDLCreatedTables.Contains(tableName);
         }
-        
+
         protected bool IsColumnCreated(string tableName, string columnName)
         {
             return DDLCreatedColumns.ContainsKey(tableName) && DDLCreatedColumns[tableName].Contains(columnName);
@@ -258,7 +259,7 @@ namespace FluentMigrator.Runner.Processors.Firebird
             {
                 DDLTouchedColumns.Add(tableName, new List<string>() { columnName });
             }
-            else if(!DDLTouchedColumns[tableName].Contains(columnName))
+            else if (!DDLTouchedColumns[tableName].Contains(columnName))
             {
                 DDLTouchedColumns[tableName].Add(columnName);
             }
@@ -309,12 +310,12 @@ namespace FluentMigrator.Runner.Processors.Firebird
             processedExpressions = new Stack<Stack<FirebirdProcessedExpressionBase>>();
             processedExpressions.Push(new Stack<FirebirdProcessedExpressionBase>());
         }
-        
+
         protected void RegisterExpression(IMigrationExpression expression, Type expressionType)
         {
             RegisterExpression(new FirebirdProcessedExpression(expression, expressionType, this) as FirebirdProcessedExpressionBase);
         }
-        protected void RegisterExpression<T>(T expression) where T: IMigrationExpression, new()
+        protected void RegisterExpression<T>(T expression) where T : IMigrationExpression, new()
         {
             RegisterExpression(new FirebirdProcessedExpression<T>(expression, this) as FirebirdProcessedExpressionBase);
         }
@@ -350,7 +351,7 @@ namespace FluentMigrator.Runner.Processors.Firebird
             {
                 CreateSequenceForIdentity(expression.TableName, expression.Column.Name);
             }
-            
+
             /*if (FBOptions.TransactionModel == FirebirdTransactionModel.AutoCommitOnCheckFail)
                 CommitRetaining();*/
             if (FBOptions.TransactionModel != FirebirdTransactionModel.None)
@@ -384,9 +385,9 @@ namespace FluentMigrator.Runner.Processors.Firebird
                 RegisterExpression(fbExpression);
                 InternalProcess((Generator as FirebirdGenerator).GenerateSetNull(expression.Column));
             }
-            
+
             //Change default value
-            if(!FirebirdGenerator.DefaultValuesMatch(colDef, expression.Column))
+            if (!FirebirdGenerator.DefaultValuesMatch(colDef, expression.Column))
             {
                 IMigrationExpression defaultConstraint;
                 IMigrationExpression unsetDefaultConstraint;
@@ -448,7 +449,7 @@ namespace FluentMigrator.Runner.Processors.Firebird
             }
 
             //Change type
-            if(!FirebirdGenerator.ColumnTypesMatch(colDef, expression.Column))
+            if (!FirebirdGenerator.ColumnTypesMatch(colDef, expression.Column))
             {
                 PerformDBOperationExpression unSet = new PerformDBOperationExpression();
                 unSet.Operation = (connection, transaction) =>
@@ -468,7 +469,7 @@ namespace FluentMigrator.Runner.Processors.Firebird
             }
 
             bool identitySequenceExists = SequenceExists(String.Empty, GetSequenceName(expression.TableName, expression.Column.Name));
-            
+
             //Adjust identity generators
             if (expression.Column.IsIdentity)
             {
@@ -480,7 +481,7 @@ namespace FluentMigrator.Runner.Processors.Firebird
                 if (identitySequenceExists)
                     DeleteSequenceForIdentity(expression.TableName, expression.Column.Name);
             }
-            
+
         }
 
         public override void Process(Expressions.RenameColumnExpression expression)
@@ -568,7 +569,7 @@ namespace FluentMigrator.Runner.Processors.Firebird
                 Type = x.Type,
                 CustomType = x.CustomType
             }));
-            
+
             Process(createNew);
 
             int columnCount = tableDef.Columns.Count;
@@ -579,7 +580,7 @@ namespace FluentMigrator.Runner.Processors.Firebird
                 foreach (DataRow dr in ds.Tables[0].Rows)
                 {
                     InsertionDataDefinition insert = new InsertionDataDefinition();
-                    for(int i = 0; i < columnCount; i++)
+                    for (int i = 0; i < columnCount; i++)
                     {
                         insert.Add(new KeyValuePair<string, object>(columns[i], dr.ItemArray[i]));
                     }
@@ -651,7 +652,7 @@ namespace FluentMigrator.Runner.Processors.Firebird
             RegisterExpression<DeleteIndexExpression>(expression);
             InternalProcess(Generator.Generate(expression));
         }
-        
+
         public override void Process(CreateSchemaExpression expression)
         {
             truncator.Truncate(expression);
@@ -721,9 +722,9 @@ namespace FluentMigrator.Runner.Processors.Firebird
 
         #endregion
 
-        
+
         #region DML expressions
-        
+
         public override void Process(Expressions.InsertDataExpression expression)
         {
             truncator.Truncate(expression);
@@ -732,7 +733,7 @@ namespace FluentMigrator.Runner.Processors.Firebird
             RegisterExpression(expression, typeof(InsertDataExpression));
             InternalProcess(Generator.Generate(expression));
         }
-        
+
         public override void Process(Expressions.DeleteDataExpression expression)
         {
             truncator.Truncate(expression);
@@ -748,7 +749,7 @@ namespace FluentMigrator.Runner.Processors.Firebird
             RegisterExpression<UpdateDataExpression>(expression);
             InternalProcess(Generator.Generate(expression));
         }
-        
+
         #endregion
 
 
@@ -774,7 +775,7 @@ namespace FluentMigrator.Runner.Processors.Firebird
             {
                 expression.Operation(Connection, Transaction);
 
-                if(FBOptions.TransactionModel == FirebirdTransactionModel.AutoCommit)
+                if (FBOptions.TransactionModel == FirebirdTransactionModel.AutoCommit)
                     CommitRetaining();
 
             }
@@ -821,17 +822,12 @@ namespace FluentMigrator.Runner.Processors.Firebird
 
         #endregion
 
-        
+
         #region Helpers
-        
+
         private string FormatToSafeName(string sqlName)
         {
-            return FormatSqlEscape(quoter.UnQuote(sqlName));
-        }
-
-        private static string FormatSqlEscape(string sql)
-        {
-            return sql.Replace("'", "''");
+            return FormatHelper.FormatSqlEscape(quoter.UnQuote(sqlName));
         }
 
         private string GetSequenceName(string tableName, string columnName)
@@ -895,9 +891,9 @@ namespace FluentMigrator.Runner.Processors.Firebird
             RegisterExpression(fbExpression);
             Process(deleteTrigger);
 
-            if(deleteSequence != null)
+            if (deleteSequence != null)
                 Process(deleteSequence);
-            
+
         }
 
         public PerformDBOperationExpression CreateTriggerExpression(string tableName, TriggerInfo trigger)
@@ -949,7 +945,7 @@ namespace FluentMigrator.Runner.Processors.Firebird
             };
             return deleteTrigger;
         }
-        
+
         #endregion
 
 

--- a/src/FluentMigrator.Runner/Processors/MySql/MySqlProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/MySql/MySqlProcessor.cs
@@ -1,3 +1,5 @@
+using FluentMigrator.Runner.Helpers;
+
 #region License
 // 
 // Copyright (c) 2007-2009, Sean Chambers <schambers80@gmail.com>
@@ -42,7 +44,7 @@ namespace FluentMigrator.Runner.Processors.MySql
         public override bool TableExists(string schemaName, string tableName)
         {
             return Exists(@"select table_name from information_schema.tables 
-                            where table_schema = SCHEMA() and table_name='{0}'", FormatSqlEscape(tableName));
+                            where table_schema = SCHEMA() and table_name='{0}'", FormatHelper.FormatSqlEscape(tableName));
         }
 
         public override bool ColumnExists(string schemaName, string tableName, string columnName)
@@ -50,7 +52,7 @@ namespace FluentMigrator.Runner.Processors.MySql
             const string sql = @"select column_name from information_schema.columns
                             where table_schema = SCHEMA() and table_name='{0}'
                             and column_name='{1}'";
-            return Exists(sql, FormatSqlEscape(tableName), FormatSqlEscape(columnName));
+            return Exists(sql, FormatHelper.FormatSqlEscape(tableName), FormatHelper.FormatSqlEscape(columnName));
         }
 
         public override bool ConstraintExists(string schemaName, string tableName, string constraintName)
@@ -58,7 +60,7 @@ namespace FluentMigrator.Runner.Processors.MySql
             const string sql = @"select constraint_name from information_schema.table_constraints
                             where table_schema = SCHEMA() and table_name='{0}'
                             and constraint_name='{1}'";
-            return Exists(sql, FormatSqlEscape(tableName), FormatSqlEscape(constraintName));
+            return Exists(sql, FormatHelper.FormatSqlEscape(tableName), FormatHelper.FormatSqlEscape(constraintName));
         }
 
         public override bool IndexExists(string schemaName, string tableName, string indexName)
@@ -66,7 +68,7 @@ namespace FluentMigrator.Runner.Processors.MySql
             const string sql = @"select index_name from information_schema.statistics
                             where table_schema = SCHEMA() and table_name='{0}'
                             and index_name='{1}'";
-            return Exists(sql, FormatSqlEscape(tableName), FormatSqlEscape(indexName));
+            return Exists(sql, FormatHelper.FormatSqlEscape(tableName), FormatHelper.FormatSqlEscape(indexName));
         }
 
         public override bool SequenceExists(string schemaName, string sequenceName)
@@ -76,13 +78,14 @@ namespace FluentMigrator.Runner.Processors.MySql
 
         public override bool DefaultValueExists(string schemaName, string tableName, string columnName, object defaultValue)
         {
-            string defaultValueAsString = string.Format("%{0}%", FormatSqlEscape(defaultValue.ToString()));
-            return Exists("SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = SCHEMA() AND TABLE_NAME = '{0}' AND COLUMN_NAME = '{1}' AND COLUMN_DEFAULT LIKE '{2}'", FormatSqlEscape(tableName), FormatSqlEscape(columnName), defaultValueAsString);
+            string defaultValueAsString = string.Format("%{0}%", FormatHelper.FormatSqlEscape(defaultValue.ToString()));
+            return Exists("SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = SCHEMA() AND TABLE_NAME = '{0}' AND COLUMN_NAME = '{1}' AND COLUMN_DEFAULT LIKE '{2}'",
+               FormatHelper.FormatSqlEscape(tableName), FormatHelper.FormatSqlEscape(columnName), defaultValueAsString);
         }
 
         public override void Execute(string template, params object[] args)
         {
-            if(Options.PreviewOnly) 
+            if (Options.PreviewOnly)
             {
                 return;
             }
@@ -159,7 +162,7 @@ namespace FluentMigrator.Runner.Processors.MySql
 
             if (Options.PreviewOnly)
                 return;
-            
+
             EnsureConnectionIsOpen();
 
             if (expression.Operation != null)
@@ -184,16 +187,11 @@ SELECT CONCAT(
              CONCAT('DEFAULT ', QUOTE(COLUMN_DEFAULT), ' ')),
           UPPER(extra))
   FROM INFORMATION_SCHEMA.COLUMNS
- WHERE TABLE_NAME = '{0}' AND COLUMN_NAME = '{1}'", FormatSqlEscape(expression.TableName), FormatSqlEscape(expression.OldName));
+ WHERE TABLE_NAME = '{0}' AND COLUMN_NAME = '{1}'", FormatHelper.FormatSqlEscape(expression.TableName), FormatHelper.FormatSqlEscape(expression.OldName));
 
             var columnDefinition = Read(columnDefinitionSql).Tables[0].Rows[0].Field<string>(0);
 
             Process(Generator.Generate(expression) + columnDefinition);
-        }
-
-        private static string FormatSqlEscape(string value)
-        {
-            return value.Replace("'", "''");
         }
     }
 }

--- a/src/FluentMigrator.Runner/Processors/Oracle/OracleProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/Oracle/OracleProcessor.cs
@@ -1,3 +1,5 @@
+using FluentMigrator.Runner.Helpers;
+
 #region License
 // 
 // Copyright (c) 2007-2009, Sean Chambers <schambers80@gmail.com>
@@ -36,10 +38,10 @@ namespace FluentMigrator.Runner.Processors.Oracle
         {
         }
 
-		public IQuoter Quoter
-	    {
-			get { return ((OracleGenerator)this.Generator).Quoter; }
-	    }
+        public IQuoter Quoter
+        {
+            get { return ((OracleGenerator)this.Generator).Quoter; }
+        }
 
         public override bool SchemaExists(string schemaName)
         {
@@ -61,9 +63,9 @@ namespace FluentMigrator.Runner.Processors.Oracle
                 return false;
 
             if (string.IsNullOrEmpty(schemaName))
-				return Exists("SELECT 1 FROM USER_TABLES WHERE upper(TABLE_NAME) = '{0}'", FormatSqlEscape(tableName.ToUpper()));
+                return Exists("SELECT 1 FROM USER_TABLES WHERE upper(TABLE_NAME) = '{0}'", FormatHelper.FormatSqlEscape(tableName.ToUpper()));
 
-			return Exists("SELECT 1 FROM ALL_TABLES WHERE upper(OWNER) = '{0}' AND upper(TABLE_NAME) = '{1}'", schemaName.ToUpper(), FormatSqlEscape(tableName.ToUpper()));
+            return Exists("SELECT 1 FROM ALL_TABLES WHERE upper(OWNER) = '{0}' AND upper(TABLE_NAME) = '{1}'", schemaName.ToUpper(), FormatHelper.FormatSqlEscape(tableName.ToUpper()));
         }
 
         public override bool ColumnExists(string schemaName, string tableName, string columnName)
@@ -77,10 +79,12 @@ namespace FluentMigrator.Runner.Processors.Oracle
                 return false;
 
             if (string.IsNullOrEmpty(schemaName))
-                return Exists("SELECT 1 FROM USER_TAB_COLUMNS WHERE upper(TABLE_NAME) = '{0}' AND upper(COLUMN_NAME) = '{1}'", FormatSqlEscape(tableName.ToUpper()), FormatSqlEscape(columnName.ToUpper()));
+                return Exists("SELECT 1 FROM USER_TAB_COLUMNS WHERE upper(TABLE_NAME) = '{0}' AND upper(COLUMN_NAME) = '{1}'",
+                    FormatHelper.FormatSqlEscape(tableName.ToUpper()),
+                    FormatHelper.FormatSqlEscape(columnName.ToUpper()));
 
-			return Exists("SELECT 1 FROM ALL_TAB_COLUMNS WHERE upper(OWNER) = '{0}' AND upper(TABLE_NAME) = '{1}' AND upper(COLUMN_NAME) = '{2}'",
-				schemaName.ToUpper(), FormatSqlEscape(tableName.ToUpper()), FormatSqlEscape(columnName.ToUpper()));
+            return Exists("SELECT 1 FROM ALL_TAB_COLUMNS WHERE upper(OWNER) = '{0}' AND upper(TABLE_NAME) = '{1}' AND upper(COLUMN_NAME) = '{2}'",
+                schemaName.ToUpper(), FormatHelper.FormatSqlEscape(tableName.ToUpper()), FormatHelper.FormatSqlEscape(columnName.ToUpper()));
         }
 
         public override bool ConstraintExists(string schemaName, string tableName, string constraintName)
@@ -96,9 +100,10 @@ namespace FluentMigrator.Runner.Processors.Oracle
                 return false;
 
             if (String.IsNullOrEmpty(schemaName))
-				return Exists("SELECT 1 FROM USER_CONSTRAINTS WHERE upper(CONSTRAINT_NAME) = '{0}'", FormatSqlEscape(constraintName.ToUpper()));
+                return Exists("SELECT 1 FROM USER_CONSTRAINTS WHERE upper(CONSTRAINT_NAME) = '{0}'", FormatHelper.FormatSqlEscape(constraintName.ToUpper()));
 
-			return Exists("SELECT 1 FROM ALL_CONSTRAINTS WHERE upper(OWNER) = '{0}' AND upper(CONSTRAINT_NAME) = '{1}'", schemaName.ToUpper(), FormatSqlEscape(constraintName.ToUpper()));
+            return Exists("SELECT 1 FROM ALL_CONSTRAINTS WHERE upper(OWNER) = '{0}' AND upper(CONSTRAINT_NAME) = '{1}'", schemaName.ToUpper(), 
+                FormatHelper.FormatSqlEscape(constraintName.ToUpper()));
         }
 
         public override bool IndexExists(string schemaName, string tableName, string indexName)
@@ -114,9 +119,9 @@ namespace FluentMigrator.Runner.Processors.Oracle
                 return false;
 
             if (String.IsNullOrEmpty(schemaName))
-				return Exists("SELECT 1 FROM USER_INDEXES WHERE upper(INDEX_NAME) = '{0}'", FormatSqlEscape(indexName.ToUpper()));
+                return Exists("SELECT 1 FROM USER_INDEXES WHERE upper(INDEX_NAME) = '{0}'", FormatHelper.FormatSqlEscape(indexName.ToUpper()));
 
-			return Exists("SELECT 1 FROM ALL_INDEXES WHERE upper(OWNER) = '{0}' AND upper(INDEX_NAME) = '{1}'", schemaName.ToUpper(), FormatSqlEscape(indexName.ToUpper()));
+            return Exists("SELECT 1 FROM ALL_INDEXES WHERE upper(OWNER) = '{0}' AND upper(INDEX_NAME) = '{1}'", schemaName.ToUpper(), FormatHelper.FormatSqlEscape(indexName.ToUpper()));
         }
 
         public override bool SequenceExists(string schemaName, string sequenceName)
@@ -141,7 +146,7 @@ namespace FluentMigrator.Runner.Processors.Oracle
 
             EnsureConnectionIsOpen();
 
-			Announcer.Sql(String.Format(template, args));
+            Announcer.Sql(String.Format(template, args));
             using (var command = Factory.CreateCommand(String.Format(template, args), Connection))
             using (var reader = command.ExecuteReader())
             {
@@ -192,14 +197,9 @@ namespace FluentMigrator.Runner.Processors.Oracle
                 return;
 
             EnsureConnectionIsOpen();
-            
+
             using (var command = Factory.CreateCommand(sql, Connection))
                 command.ExecuteNonQuery();
-        }
-
-        private static string FormatSqlEscape(string sql)
-        {
-            return sql.Replace("'", "''");
         }
     }
 }

--- a/src/FluentMigrator.Runner/Processors/Postgres/PostgresProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/Postgres/PostgresProcessor.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.IO;
 using FluentMigrator.Builders.Execute;
 using FluentMigrator.Runner.Generators.Postgres;
+using FluentMigrator.Runner.Helpers;
 
 namespace FluentMigrator.Runner.Processors.Postgres
 {
@@ -70,7 +71,7 @@ namespace FluentMigrator.Runner.Processors.Postgres
 
         public override bool DefaultValueExists(string schemaName, string tableName, string columnName, object defaultValue)
         {
-            string defaultValueAsString = string.Format("%{0}%", FormatSqlEscape(defaultValue.ToString()));
+            string defaultValueAsString = string.Format("%{0}%", FormatHelper.FormatSqlEscape(defaultValue.ToString()));
             return Exists("select * from information_schema.columns where table_schema = '{0}' and table_name = '{1}' and column_name = '{2}' and column_default like '{3}'", FormatToSafeSchemaName(schemaName), FormatToSafeName(tableName), FormatToSafeName(columnName), defaultValueAsString);
         }
 
@@ -143,17 +144,12 @@ namespace FluentMigrator.Runner.Processors.Postgres
 
         private string FormatToSafeSchemaName(string schemaName)
         {
-            return FormatSqlEscape(quoter.UnQuoteSchemaName(schemaName));
+            return FormatHelper.FormatSqlEscape(quoter.UnQuoteSchemaName(schemaName));
         }
 
         private string FormatToSafeName(string sqlName)
         {
-            return FormatSqlEscape(quoter.UnQuote(sqlName));
-        }
-
-        private static string FormatSqlEscape(string sql)
-        {
-            return sql.Replace("'", "''");
+            return FormatHelper.FormatSqlEscape(quoter.UnQuote(sqlName));
         }
     }
 }

--- a/src/FluentMigrator.Runner/Processors/SqlServer/SqlServer2000Processor.cs
+++ b/src/FluentMigrator.Runner/Processors/SqlServer/SqlServer2000Processor.cs
@@ -1,4 +1,6 @@
-﻿#region License
+﻿using FluentMigrator.Runner.Helpers;
+
+#region License
 // 
 // Copyright (c) 2007-2009, Sean Chambers <schambers80@gmail.com>
 // Copyright (c) 2010, Nathan Brown
@@ -53,7 +55,7 @@ namespace FluentMigrator.Runner.Processors.SqlServer
         {
             try
             {
-                return Exists("SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = '{0}'", FormatSqlEscape(tableName));
+                return Exists("SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = '{0}'", FormatHelper.FormatSqlEscape(tableName));
             }
             catch (Exception e)
             {
@@ -64,17 +66,20 @@ namespace FluentMigrator.Runner.Processors.SqlServer
 
         public override bool ColumnExists(string schemaName, string tableName, string columnName)
         {
-            return Exists("SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{1}' AND COLUMN_NAME = '{2}'", FormatSqlEscape(tableName), FormatSqlEscape(columnName));
+            return Exists("SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{1}' AND COLUMN_NAME = '{2}'", 
+                FormatHelper.FormatSqlEscape(tableName),
+                FormatHelper.FormatSqlEscape(columnName));
         }
 
         public override bool ConstraintExists(string schemaName, string tableName, string constraintName)
         {
-            return Exists("SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_CATALOG = DB_NAME() AND TABLE_NAME = '{1}' AND CONSTRAINT_NAME = '{2}'", FormatSqlEscape(tableName), FormatSqlEscape(constraintName));
+            return Exists("SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_CATALOG = DB_NAME() AND TABLE_NAME = '{1}' AND CONSTRAINT_NAME = '{2}'",
+                FormatHelper.FormatSqlEscape(tableName), FormatHelper.FormatSqlEscape(constraintName));
         }
 
         public override bool IndexExists(string schemaName, string tableName, string indexName)
         {
-            return Exists("SELECT NULL FROM sysindexes WHERE name = '{0}'", FormatSqlEscape(indexName));
+            return Exists("SELECT NULL FROM sysindexes WHERE name = '{0}'", FormatHelper.FormatSqlEscape(indexName));
         }
 
         public override bool SequenceExists(string schemaName, string sequenceName)
@@ -210,11 +215,6 @@ namespace FluentMigrator.Runner.Processors.SqlServer
 
             if (expression.Operation != null)
                 expression.Operation(Connection, Transaction);
-        }
-
-        private static string FormatSqlEscape(string sql)
-        {
-            return sql.Replace("'", "''");
         }
     }
 }

--- a/src/FluentMigrator.Runner/Processors/SqlServer/SqlServerCeProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/SqlServer/SqlServerCeProcessor.cs
@@ -1,3 +1,5 @@
+using FluentMigrator.Runner.Helpers;
+
 #region License
 // 
 // Copyright (c) 2007-2009, Sean Chambers <schambers80@gmail.com>
@@ -53,22 +55,24 @@ namespace FluentMigrator.Runner.Processors.SqlServer
 
         public override bool TableExists(string schemaName, string tableName)
         {
-            return Exists("SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = '{0}'", FormatSqlEscape(tableName));
+            return Exists("SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = '{0}'", FormatHelper.FormatSqlEscape(tableName));
         }
 
         public override bool ColumnExists(string schemaName, string tableName, string columnName)
         {
-            return Exists("SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{0}' AND COLUMN_NAME = '{1}'", FormatSqlEscape(tableName), FormatSqlEscape(columnName));
+            return Exists("SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{0}' AND COLUMN_NAME = '{1}'",
+                FormatHelper.FormatSqlEscape(tableName), FormatHelper.FormatSqlEscape(columnName));
         }
 
         public override bool ConstraintExists(string schemaName, string tableName, string constraintName)
         {
-            return Exists("SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_NAME = '{0}' AND CONSTRAINT_NAME = '{1}'", FormatSqlEscape(tableName), FormatSqlEscape(constraintName));
+            return Exists("SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_NAME = '{0}' AND CONSTRAINT_NAME = '{1}'",
+                FormatHelper.FormatSqlEscape(tableName), FormatHelper.FormatSqlEscape(constraintName));
         }
 
         public override bool IndexExists(string schemaName, string tableName, string indexName)
         {
-            return Exists("SELECT NULL FROM INFORMATION_SCHEMA.INDEXES WHERE INDEX_NAME = '{0}'", FormatSqlEscape(indexName));
+            return Exists("SELECT NULL FROM INFORMATION_SCHEMA.INDEXES WHERE INDEX_NAME = '{0}'", FormatHelper.FormatSqlEscape(indexName));
         }
 
         public override bool SequenceExists(string schemaName, string sequenceName)
@@ -173,7 +177,7 @@ namespace FluentMigrator.Runner.Processors.SqlServer
             {
                 yield return builder.ToString();
             }
-        } 
+        }
 
         public override void Process(PerformDBOperationExpression expression)
         {
@@ -181,11 +185,6 @@ namespace FluentMigrator.Runner.Processors.SqlServer
 
             if (expression.Operation != null)
                 expression.Operation(Connection, Transaction);
-        }
-
-        private static string FormatSqlEscape(string sql)
-        {
-            return sql.Replace("'", "''");
         }
     }
 }

--- a/src/FluentMigrator.Runner/Processors/SqlServer/SqlServerProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/SqlServer/SqlServerProcessor.cs
@@ -1,3 +1,5 @@
+using FluentMigrator.Runner.Helpers;
+
 #region License
 // 
 // Copyright (c) 2007-2009, Sean Chambers <schambers80@gmail.com>
@@ -46,7 +48,7 @@ namespace FluentMigrator.Runner.Processors.SqlServer
 
         private static string SafeSchemaName(string schemaName)
         {
-            return string.IsNullOrEmpty(schemaName) ? "dbo" : FormatSqlEscape(schemaName);
+            return string.IsNullOrEmpty(schemaName) ? "dbo" : FormatHelper.FormatSqlEscape(schemaName);
         }
 
         public override bool SchemaExists(string schemaName)
@@ -58,7 +60,8 @@ namespace FluentMigrator.Runner.Processors.SqlServer
         {
             try
             {
-                return Exists("SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{0}' AND TABLE_NAME = '{1}'", SafeSchemaName(schemaName), FormatSqlEscape(tableName));
+                return Exists("SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{0}' AND TABLE_NAME = '{1}'", SafeSchemaName(schemaName),
+                    FormatHelper.FormatSqlEscape(tableName));
             }
             catch (Exception e)
             {
@@ -69,28 +72,34 @@ namespace FluentMigrator.Runner.Processors.SqlServer
 
         public override bool ColumnExists(string schemaName, string tableName, string columnName)
         {
-            return Exists("SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '{0}' AND TABLE_NAME = '{1}' AND COLUMN_NAME = '{2}'", SafeSchemaName(schemaName), FormatSqlEscape(tableName), FormatSqlEscape(columnName));
+            return Exists("SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '{0}' AND TABLE_NAME = '{1}' AND COLUMN_NAME = '{2}'", SafeSchemaName(schemaName),
+                FormatHelper.FormatSqlEscape(tableName), FormatHelper.FormatSqlEscape(columnName));
         }
 
         public override bool ConstraintExists(string schemaName, string tableName, string constraintName)
         {
-            return Exists("SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_CATALOG = DB_NAME() AND TABLE_SCHEMA = '{0}' AND TABLE_NAME = '{1}' AND CONSTRAINT_NAME = '{2}'", SafeSchemaName(schemaName), FormatSqlEscape(tableName), FormatSqlEscape(constraintName));
+            return Exists("SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_CATALOG = DB_NAME() AND TABLE_SCHEMA = '{0}' AND TABLE_NAME = '{1}' AND CONSTRAINT_NAME = '{2}'", SafeSchemaName(schemaName),
+                FormatHelper.FormatSqlEscape(tableName), FormatHelper.FormatSqlEscape(constraintName));
         }
 
         public override bool IndexExists(string schemaName, string tableName, string indexName)
         {
-            return Exists("SELECT * FROM sys.indexes WHERE name = '{0}' and object_id=OBJECT_ID('{1}.{2}')", FormatSqlEscape(indexName), SafeSchemaName(schemaName), FormatSqlEscape(tableName));
+            return Exists("SELECT * FROM sys.indexes WHERE name = '{0}' and object_id=OBJECT_ID('{1}.{2}')",
+                FormatHelper.FormatSqlEscape(indexName), SafeSchemaName(schemaName), FormatHelper.FormatSqlEscape(tableName));
         }
 
         public override bool SequenceExists(string schemaName, string sequenceName)
         {
-            return Exists("SELECT * FROM INFORMATION_SCHEMA.SEQUENCES WHERE SEQUENCE_SCHEMA = '{0}' AND SEQUENCE_NAME = '{1}'", SafeSchemaName(schemaName), FormatSqlEscape(sequenceName));
+            return Exists("SELECT * FROM INFORMATION_SCHEMA.SEQUENCES WHERE SEQUENCE_SCHEMA = '{0}' AND SEQUENCE_NAME = '{1}'", SafeSchemaName(schemaName),
+                FormatHelper.FormatSqlEscape(sequenceName));
         }
 
         public override bool DefaultValueExists(string schemaName, string tableName, string columnName, object defaultValue)
         {
-            string defaultValueAsString = string.Format("%{0}%", FormatSqlEscape(defaultValue.ToString()));
-            return Exists("SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '{0}' AND TABLE_NAME = '{1}' AND COLUMN_NAME = '{2}' AND COLUMN_DEFAULT LIKE '{3}'", SafeSchemaName(schemaName), FormatSqlEscape(tableName), FormatSqlEscape(columnName), defaultValueAsString);
+            string defaultValueAsString = string.Format("%{0}%", FormatHelper.FormatSqlEscape(defaultValue.ToString()));
+            return Exists("SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '{0}' AND TABLE_NAME = '{1}' AND COLUMN_NAME = '{2}' AND COLUMN_DEFAULT LIKE '{3}'", SafeSchemaName(schemaName),
+                FormatHelper.FormatSqlEscape(tableName),
+                FormatHelper.FormatSqlEscape(columnName), defaultValueAsString);
         }
 
         public override void Execute(string template, params object[] args)
@@ -222,11 +231,6 @@ namespace FluentMigrator.Runner.Processors.SqlServer
 
             if (expression.Operation != null)
                 expression.Operation(Connection, Transaction);
-        }
-
-        private static string FormatSqlEscape(string sql)
-        {
-            return sql.Replace("'", "''");
         }
     }
 }

--- a/src/FluentMigrator.SchemaDump/SchemaDumpers/SqlServerSchemaDumper.cs
+++ b/src/FluentMigrator.SchemaDump/SchemaDumpers/SqlServerSchemaDumper.cs
@@ -63,11 +63,6 @@ namespace FluentMigrator.SchemaDump.SchemaDumpers
             Processor.Process(expression);
         }
 
-        protected string FormatSqlEscape(string sql)
-        {
-            return sql.Replace("'", "''");
-        }
-
         public virtual IList<TableDefinition> ReadDbSchema()
         {
             IList<TableDefinition> tables = ReadTables();

--- a/src/FluentMigrator.SchemaDump/SchemaDumpers/SqliteSchemaDumper.cs
+++ b/src/FluentMigrator.SchemaDump/SchemaDumpers/SqliteSchemaDumper.cs
@@ -61,12 +61,7 @@ namespace FluentMigrator.SchemaDump.SchemaDumpers
         {
             Processor.Process(expression);
         }
-
-        protected string FormatSqlEscape(string sql)
-        {
-            return sql.Replace("'", "''");
-        }
-
+        
         protected virtual IList<TableDefinition> ReadTables()
         {
             var dtTable = GetTableNamesAndDDL();

--- a/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -299,6 +299,7 @@
     <Compile Include="Unit\Generators\BaseColumnTests.cs" />
     <Compile Include="Unit\Generators\BaseConstraintsTests.cs" />
     <Compile Include="Unit\Generators\BaseDataTests.cs" />
+    <Compile Include="Unit\Generators\BaseDescriptionGeneratorTests.cs" />
     <Compile Include="Unit\Generators\BaseIndexTests.cs" />
     <Compile Include="Unit\Generators\BaseSchemaTests.cs" />
     <Compile Include="Unit\Generators\BaseSequenceTests.cs" />
@@ -338,6 +339,7 @@
     <Compile Include="Unit\Generators\Oracle\OracleColumnTests.cs" />
     <Compile Include="Unit\Generators\Oracle\OracleConstraintsTests.cs" />
     <Compile Include="Unit\Generators\Oracle\OracleDataTests.cs" />
+    <Compile Include="Unit\Generators\Oracle\OracleDescriptionGeneratorTests.cs" />
     <Compile Include="Unit\Generators\Oracle\OracleGeneratorTests.cs" />
     <Compile Include="Unit\Generators\Oracle\OracleIndexTests.cs" />
     <Compile Include="Unit\Generators\Oracle\OracleSchemaTests.cs" />
@@ -370,6 +372,7 @@
     <Compile Include="Unit\Generators\SqlServer2005\SqlServer2005ColumnTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2005\SqlServer2005ConstraintsTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2005\SqlServer2005DataTests.cs" />
+    <Compile Include="Unit\Generators\SqlServer2005\SqlServer2005DescriptionGeneratorTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2005\SqlServer2005GeneratorTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2005\SqlServer2005IndexTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2005\SqlServer2005SchemaTests.cs" />

--- a/src/FluentMigrator.Tests/Unit/Generators/BaseDescriptionGeneratorTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/BaseDescriptionGeneratorTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using FluentMigrator.Runner.Generators;
+using NUnit.Framework;
+using NUnit.Should;
+
+namespace FluentMigrator.Tests.Unit.Generators
+{
+    public abstract class BaseDescriptionGeneratorTests
+    {
+        protected IDescriptionGenerator descriptionGenerator;
+
+        public abstract void GenerateDescriptionStatementsForCreateTableReturnTableDescriptionStatement();
+        public abstract void GenerateDescriptionStatementsForCreateTableReturnTableDescriptionAndColumnDescriptionsStatements();
+        public abstract void GenerateDescriptionStatementForAlterTableReturnTableDescriptionStatement();
+        public abstract void GenerateDescriptionStatementForCreateColumnReturnColumnDescriptionStatement();
+        public abstract void GenerateDescriptionStatementForAlterColumnReturnColumnDescriptionStatement();
+
+        [Test]
+        public void GenerateDescriptionStatementsReturnEmptyForNoDescriptionsOnCreateTable()
+        {
+            var createTableExpression = GeneratorTestHelper.GetCreateTableExpression();
+            var result = descriptionGenerator.GenerateDescriptionStatements(createTableExpression);
+
+            result.ShouldBe(Enumerable.Empty<string>());
+        }
+
+        [Test]
+        public void GenerateDescriptionStatementReturnEmptyForNoDescriptionOnAlterTable()
+        {
+            var alterTableExpression = GeneratorTestHelper.GetAlterTableAutoIncrementColumnExpression();
+            var result = descriptionGenerator.GenerateDescriptionStatement(alterTableExpression);
+
+            result.ShouldBe(string.Empty);
+        }
+
+        [Test]
+        public void GenerateDescriptionStatementReturnEmptyForNoDescriptionOnCreateColumn()
+        {
+            var createColumnExpression = GeneratorTestHelper.GetCreateColumnExpression();
+            var result = descriptionGenerator.GenerateDescriptionStatement(createColumnExpression);
+
+            result.ShouldBe(string.Empty);
+        }
+
+        [Test]
+        public void GenerateDescriptionStatementReturnEmptyForNoDescriptionOnAlterColumn()
+        {
+            var alterColumnExpression = GeneratorTestHelper.GetAlterColumnExpression();
+            var result = descriptionGenerator.GenerateDescriptionStatement(alterColumnExpression);
+
+            result.ShouldBe(string.Empty);
+        }
+
+        [Test]
+        public void GenerateDescriptionStatementsHaveSingleStatementForDescriptionOnCreate()
+        {
+            var createTableExpression = GeneratorTestHelper.GetCreateTableWithTableDescription();
+            var result = descriptionGenerator.GenerateDescriptionStatements(createTableExpression);
+
+            result.Count().ShouldBe(1);
+        }
+    }
+}

--- a/src/FluentMigrator.Tests/Unit/Generators/GeneratorTestHelper.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/GeneratorTestHelper.cs
@@ -15,6 +15,9 @@ namespace FluentMigrator.Tests.Unit.Generators
         public static string TestColumnName2 = "TestColumn2";
         public static string TestColumnName3 = "TestColumn3";
         public static string TestIndexName = "TestIndex";
+        public static string TestTableDescription = "TestDescription";
+        public static string TestColumn1Description = "TestColumn1Description";
+        public static string TestColumn2Description = "TestColumn2Description";
         public static Guid TestGuid = Guid.NewGuid();
 
         public static CreateTableExpression GetCreateTableExpression()
@@ -82,6 +85,33 @@ namespace FluentMigrator.Tests.Unit.Generators
             return expression;
         }
 
+        public static CreateTableExpression GetCreateTableWithTableDescription()
+        {
+            var expression = new CreateTableExpression { TableName = TestTableName1, TableDescription = TestTableDescription };
+
+            return expression;
+        }
+
+        public static CreateTableExpression GetCreateTableWithTableDescriptionAndColumnDescriptions()
+        {
+            var expression = new CreateTableExpression { TableName = TestTableName1, TableDescription = TestTableDescription };
+            expression.Columns.Add(new ColumnDefinition
+            {
+                Name = TestColumnName1,
+                IsNullable = true,
+                Type = DbType.String,
+                ColumnDescription = TestColumn1Description
+            });
+            expression.Columns.Add(new ColumnDefinition
+            {
+                Name = TestColumnName2,
+                Type = DbType.Int32,
+                ColumnDescription = TestColumn2Description
+            });
+
+            return expression;
+        }
+
         public static CreateIndexExpression GetCreateIndexExpression()
         {
             var expression = new CreateIndexExpression();
@@ -99,8 +129,10 @@ namespace FluentMigrator.Tests.Unit.Generators
 
         public static CreateSequenceExpression GetCreateSequenceExpression()
         {
-            return new CreateSequenceExpression {
-                Sequence = {
+            return new CreateSequenceExpression
+            {
+                Sequence =
+                {
                     Cache = 10,
                     Cycle = true,
                     Increment = 2,
@@ -282,7 +314,7 @@ namespace FluentMigrator.Tests.Unit.Generators
 
         public static CreateColumnExpression GetCreateCurrencyColumnExpression()
         {
-            ColumnDefinition column = new ColumnDefinition { Name = TestColumnName1, Type = DbType.Currency};
+            ColumnDefinition column = new ColumnDefinition { Name = TestColumnName1, Type = DbType.Currency };
             return new CreateColumnExpression { TableName = TestTableName1, Column = column };
         }
 
@@ -292,10 +324,26 @@ namespace FluentMigrator.Tests.Unit.Generators
             return new CreateColumnExpression { TableName = TestTableName1, Column = column };
         }
 
+        public static CreateColumnExpression GetCreateColumnExpressionWithDescription()
+        {
+            ColumnDefinition column = new ColumnDefinition { Name = TestColumnName1, Type = DbType.String, Size = 5, ColumnDescription = TestColumn1Description };
+            return new CreateColumnExpression { TableName = TestTableName1, Column = column };
+        }
+
         public static CreateColumnExpression GetAlterTableAutoIncrementColumnExpression()
         {
             ColumnDefinition column = new ColumnDefinition { Name = TestColumnName1, IsIdentity = true, Type = DbType.Int32 };
             return new CreateColumnExpression { TableName = TestTableName1, Column = column };
+        }
+
+        public static AlterTableExpression GetAlterTableWithDescriptionExpression()
+        {
+            return new AlterTableExpression() { TableName = TestTableName1, TableDescription = TestTableDescription };
+        }
+
+        public static AlterTableExpression GetAlterTable()
+        {
+            return new AlterTableExpression() {TableName = TestTableName1 };
         }
 
         public static AlterColumnExpression GetAlterColumnAddAutoIncrementExpression()
@@ -327,9 +375,17 @@ namespace FluentMigrator.Tests.Unit.Generators
             return expression;
         }
 
+        public static AlterColumnExpression GetAlterColumnExpressionWithDescription()
+        {
+            var columnExpression = GetAlterColumnExpression();
+            columnExpression.Column.ColumnDescription = TestColumn1Description;
+
+            return columnExpression;
+        }
+
         public static AlterSchemaExpression GetAlterSchemaExpression()
         {
-            return new AlterSchemaExpression{ DestinationSchemaName = "TestSchema2", SourceSchemaName = "TestSchema1", TableName = "TestTable" };
+            return new AlterSchemaExpression { DestinationSchemaName = "TestSchema2", SourceSchemaName = "TestSchema1", TableName = "TestTable" };
         }
 
         public static CreateForeignKeyExpression GetCreateForeignKeyExpression()
@@ -387,7 +443,7 @@ namespace FluentMigrator.Tests.Unit.Generators
 
         public static DeleteColumnExpression GetDeleteColumnExpression()
         {
-            return GetDeleteColumnExpression(new [] {TestColumnName1});
+            return GetDeleteColumnExpression(new[] { TestColumnName1 });
         }
 
         public static DeleteColumnExpression GetDeleteColumnExpression(string[] columns)

--- a/src/FluentMigrator.Tests/Unit/Generators/Oracle/OracleDescriptionGeneratorTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/Oracle/OracleDescriptionGeneratorTests.cs
@@ -1,0 +1,64 @@
+﻿using System.Linq;
+using FluentMigrator.Runner.Generators.Oracle;
+using NUnit.Framework;
+using NUnit.Should;
+
+namespace FluentMigrator.Tests.Unit.Generators.Oracle
+{
+    [TestFixture]
+    public class OracleDescriptionGeneratorTests : BaseDescriptionGeneratorTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            descriptionGenerator = new OracleDescriptionGenerator();
+        }
+
+        [Test]
+        public override void GenerateDescriptionStatementsForCreateTableReturnTableDescriptionStatement()
+        {
+            var createTableExpression = GeneratorTestHelper.GetCreateTableWithTableDescription();
+            var statements = descriptionGenerator.GenerateDescriptionStatements(createTableExpression);
+
+            var result = statements.First();
+            result.ShouldBe("COMMENT ON TABLE TestTable1 IS 'TestDescription'");
+        }
+
+        [Test]
+        public override void GenerateDescriptionStatementsForCreateTableReturnTableDescriptionAndColumnDescriptionsStatements()
+        {
+            var createTableExpression = GeneratorTestHelper.GetCreateTableWithTableDescriptionAndColumnDescriptions();
+            var statements = descriptionGenerator.GenerateDescriptionStatements(createTableExpression).ToArray();
+
+            var result = string.Join(";", statements);
+            result.ShouldBe("COMMENT ON TABLE TestTable1 IS 'TestDescription';COMMENT ON COLUMN TestTable1.TestColumn1 IS 'TestColumn1Description';COMMENT ON COLUMN TestTable1.TestColumn2 IS 'TestColumn2Description'");
+        }
+
+        [Test]
+        public override void GenerateDescriptionStatementForAlterTableReturnTableDescriptionStatement()
+        {
+            var alterTableExpression = GeneratorTestHelper.GetAlterTableWithDescriptionExpression();
+            var statement = descriptionGenerator.GenerateDescriptionStatement(alterTableExpression);
+
+            statement.ShouldBe("COMMENT ON TABLE TestTable1 IS 'TestDescription'");
+        }
+
+        [Test]
+        public override void GenerateDescriptionStatementForCreateColumnReturnColumnDescriptionStatement()
+        {
+            var createColumnExpression = GeneratorTestHelper.GetCreateColumnExpressionWithDescription();
+            var statement = descriptionGenerator.GenerateDescriptionStatement(createColumnExpression);
+
+            statement.ShouldBe("COMMENT ON COLUMN TestTable1.TestColumn1 IS 'TestColumn1Description'");
+        }
+
+        [Test]
+        public override void GenerateDescriptionStatementForAlterColumnReturnColumnDescriptionStatement()
+        {
+            var alterColumnExpression = GeneratorTestHelper.GetAlterColumnExpressionWithDescription();
+            var statement = descriptionGenerator.GenerateDescriptionStatement(alterColumnExpression);
+
+            statement.ShouldBe("COMMENT ON COLUMN TestTable1.TestColumn1 IS 'TestColumn1Description'");
+        }
+    }
+}

--- a/src/FluentMigrator.Tests/Unit/Generators/Oracle/OracleGeneratorTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/Oracle/OracleGeneratorTests.cs
@@ -70,5 +70,85 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
 
             Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(new DeleteSchemaExpression()));
         }
+
+        [Test]
+        public void CanCreateTableWithoutAnyDescriptions()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableExpression();
+
+            var result = Generator.Generate(expression);
+
+            result.ShouldBe("CREATE TABLE TestTable1 (TestColumn1 NVARCHAR2(255) NOT NULL, TestColumn2 NUMBER(10,0) NOT NULL)");
+        }
+
+        [Test]
+        public void CanCreateTableWithDescriptionAndColumnDescription()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableWithTableDescriptionAndColumnDescriptions();
+
+            var result = Generator.Generate(expression);
+
+            result.ShouldBe("BEGIN EXECUTE IMMEDIATE 'CREATE TABLE TestTable1 (TestColumn1 NVARCHAR2(255), TestColumn2 NUMBER(10,0) NOT NULL)';EXECUTE IMMEDIATE 'COMMENT ON TABLE TestTable1 IS ''TestDescription''';EXECUTE IMMEDIATE 'COMMENT ON COLUMN TestTable1.TestColumn1 IS ''TestColumn1Description''';EXECUTE IMMEDIATE 'COMMENT ON COLUMN TestTable1.TestColumn2 IS ''TestColumn2Description'''; END;");
+        }
+
+        [Test]
+        public void CanAlterTableWithDescription()
+        {
+            var expression = GeneratorTestHelper.GetAlterTableWithDescriptionExpression();
+
+            var result = Generator.Generate(expression);
+
+            result.ShouldBe("COMMENT ON TABLE TestTable1 IS 'TestDescription'");
+        }
+
+        [Test]
+        public void CanAlterTableWithoutAnyDescripion()
+        {
+            var expression = GeneratorTestHelper.GetAlterTable();
+
+            var result = Generator.Generate(expression);
+
+            result.ShouldBe(string.Empty);
+        }
+
+        [Test]
+        public void CanCreateColumnWithDescription()
+        {
+            var expression = GeneratorTestHelper.GetCreateColumnExpressionWithDescription();
+
+            var result = Generator.Generate(expression);
+
+            result.ShouldBe("BEGIN EXECUTE IMMEDIATE 'ALTER TABLE TestTable1 ADD TestColumn1 NVARCHAR2(5) NOT NULL';EXECUTE IMMEDIATE 'COMMENT ON COLUMN TestTable1.TestColumn1 IS ''TestColumn1Description'''; END;");
+        }
+
+        [Test]
+        public void CanCreateColumnWithoutDescription()
+        {
+            var expression = GeneratorTestHelper.GetCreateColumnExpression();
+
+            var result = Generator.Generate(expression);
+
+            result.ShouldBe("ALTER TABLE TestTable1 ADD TestColumn1 NVARCHAR2(5) NOT NULL");
+        }
+
+        [Test]
+        public void CanAlterColumnWithDescription()
+        {
+            var expression = GeneratorTestHelper.GetAlterColumnExpressionWithDescription();
+
+            var result = Generator.Generate(expression);
+
+            result.ShouldBe("BEGIN EXECUTE IMMEDIATE 'ALTER TABLE TestTable1 MODIFY TestColumn1 NVARCHAR2(20) NOT NULL';EXECUTE IMMEDIATE 'COMMENT ON COLUMN TestTable1.TestColumn1 IS ''TestColumn1Description'''; END;");
+        }
+
+        [Test]
+        public void CanAlterColumnWithoutDescription()
+        {
+            var expression = GeneratorTestHelper.GetAlterColumnExpression();
+
+            var result = Generator.Generate(expression);
+
+            result.ShouldBe("ALTER TABLE TestTable1 MODIFY TestColumn1 NVARCHAR2(20) NOT NULL");
+        }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Generators/Oracle/OracleTableTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/Oracle/OracleTableTests.cs
@@ -249,5 +249,6 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
             var result = Generator.Generate(expression);
             result.ShouldBe("ALTER TABLE TestTable1 RENAME TO TestTable2");
         }
+
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005DescriptionGeneratorTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005DescriptionGeneratorTests.cs
@@ -1,0 +1,64 @@
+﻿using System.Linq;
+using FluentMigrator.Runner.Generators.SqlServer;
+using NUnit.Framework;
+using NUnit.Should;
+
+namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
+{
+    [TestFixture]
+    public class SqlServer2005DescriptionGeneratorTests : BaseDescriptionGeneratorTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            descriptionGenerator = new SqlServer2005DescriptionGenerator();
+        }
+
+        [Test]
+        public override void GenerateDescriptionStatementsForCreateTableReturnTableDescriptionStatement()
+        {
+            var createTableExpression = GeneratorTestHelper.GetCreateTableWithTableDescription();
+            var statements = descriptionGenerator.GenerateDescriptionStatements(createTableExpression);
+
+            var result = statements.First();
+            result.ShouldBe("EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'TestDescription', @level0type=N'SCHEMA', @level0name='dbo', @level1type=N'TABLE', @level1name='TestTable1'");
+        }
+
+        [Test]
+        public override void GenerateDescriptionStatementsForCreateTableReturnTableDescriptionAndColumnDescriptionsStatements()
+        {
+            var createTableExpression = GeneratorTestHelper.GetCreateTableWithTableDescriptionAndColumnDescriptions();
+            var statements = descriptionGenerator.GenerateDescriptionStatements(createTableExpression).ToArray();
+
+            var result = string.Join(";", statements);
+            result.ShouldBe("EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'TestDescription', @level0type=N'SCHEMA', @level0name='dbo', @level1type=N'TABLE', @level1name='TestTable1';EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'TestColumn1Description', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn1';EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'TestColumn2Description', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn2'");
+        }
+
+        [Test]
+        public override void GenerateDescriptionStatementForAlterTableReturnTableDescriptionStatement()
+        {
+            var alterTableExpression = GeneratorTestHelper.GetAlterTableWithDescriptionExpression();
+            var statement = descriptionGenerator.GenerateDescriptionStatement(alterTableExpression);
+
+            statement.ShouldBe("IF EXISTS ( SELECT * FROM fn_listextendedproperty(N'MS_Description', N'SCHEMA', N'dbo', N'TABLE', N'TestTable1', NULL, NULL)) EXEC sys.sp_dropextendedproperty @name=N'MS_Description', @level0type=N'SCHEMA', @level0name='dbo', @level1type=N'TABLE', @level1name='TestTable1';EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'TestDescription', @level0type=N'SCHEMA', @level0name='dbo', @level1type=N'TABLE', @level1name='TestTable1'");
+        }
+
+        [Test]
+        public override void GenerateDescriptionStatementForCreateColumnReturnColumnDescriptionStatement()
+        {
+            var createColumnExpression = GeneratorTestHelper.GetCreateColumnExpressionWithDescription();
+            var statement = descriptionGenerator.GenerateDescriptionStatement(createColumnExpression);
+
+            statement.ShouldBe("EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'TestColumn1Description', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn1'");
+        }
+
+        [Test]
+        public override void GenerateDescriptionStatementForAlterColumnReturnColumnDescriptionStatement()
+        {
+            var alterColumnExpression = GeneratorTestHelper.GetAlterColumnExpressionWithDescription();
+            var statement = descriptionGenerator.GenerateDescriptionStatement(alterColumnExpression);
+
+            statement.ShouldBe("IF EXISTS (SELECT * FROM fn_listextendedproperty(N'MS_Description', N'SCHEMA', N'dbo', N'TABLE', N'TestTable1', N'Column', N'TestColumn1' )) EXEC sys.sp_dropextendedproperty @name=N'MS_Description', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn1';EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'TestColumn1Description', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn1'");
+        }
+    }
+}

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005GeneratorTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005GeneratorTests.cs
@@ -287,5 +287,54 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
             var result = Generator.Generate(expression);
             result.ShouldBe("ALTER TABLE [dbo].[NewTable] ADD [NewColumn] UNIQUEIDENTIFIER NOT NULL CONSTRAINT [DF__NewColumn] DEFAULT NEWSEQUENTIALID()");
         }
+
+        [Test]
+        public void CanCreateTableWithDescriptionAndColumnDescription()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableWithTableDescriptionAndColumnDescriptions();
+
+            var result = Generator.Generate(expression);
+
+            result.ShouldBe(@"CREATE TABLE [dbo].[TestTable1] ([TestColumn1] NVARCHAR(255), [TestColumn2] INT NOT NULL)
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'TestDescription', @level0type=N'SCHEMA', @level0name='dbo', @level1type=N'TABLE', @level1name='TestTable1';EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'TestColumn1Description', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn1';EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'TestColumn2Description', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn2'
+");
+        }
+
+        [Test]
+        public void CanAlterTableWithDescription()
+        {
+            var expression = GeneratorTestHelper.GetAlterTableWithDescriptionExpression();
+
+            var result = Generator.Generate(expression);
+
+            result.ShouldBe(@"IF EXISTS ( SELECT * FROM fn_listextendedproperty(N'MS_Description', N'SCHEMA', N'dbo', N'TABLE', N'TestTable1', NULL, NULL)) EXEC sys.sp_dropextendedproperty @name=N'MS_Description', @level0type=N'SCHEMA', @level0name='dbo', @level1type=N'TABLE', @level1name='TestTable1';EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'TestDescription', @level0type=N'SCHEMA', @level0name='dbo', @level1type=N'TABLE', @level1name='TestTable1'");
+        }
+
+        [Test]
+        public void CanCreateColumnWithDescription()
+        {
+            var expression = GeneratorTestHelper.GetCreateColumnExpressionWithDescription();
+
+            var result = Generator.Generate(expression);
+
+            result.ShouldBe(@"ALTER TABLE [dbo].[TestTable1] ADD [TestColumn1] NVARCHAR(5) NOT NULL
+GO
+EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'TestColumn1Description', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn1'
+");
+        }
+
+        [Test]
+        public void CanAlterColumnWithDescription()
+        {
+            var expression = GeneratorTestHelper.GetAlterColumnExpressionWithDescription();
+
+            var result = Generator.Generate(expression);
+
+            result.ShouldBe(@"ALTER TABLE [dbo].[TestTable1] ALTER COLUMN [TestColumn1] NVARCHAR(20) NOT NULL
+GO
+IF EXISTS (SELECT * FROM fn_listextendedproperty(N'MS_Description', N'SCHEMA', N'dbo', N'TABLE', N'TestTable1', N'Column', N'TestColumn1' )) EXEC sys.sp_dropextendedproperty @name=N'MS_Description', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn1';EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'TestColumn1Description', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn1'
+");
+        }
     }
 }

--- a/src/FluentMigrator/Builders/Alter/Column/AlterColumnExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Alter/Column/AlterColumnExpressionBuilder.cs
@@ -88,6 +88,12 @@ namespace FluentMigrator.Builders.Alter.Column
             return this;
         }
 
+        public IAlterColumnOptionSyntax WithColumnDescription(string description)
+        {
+            Expression.Column.ColumnDescription = description;
+            return this;
+        }
+
         public IAlterColumnOptionSyntax Identity()
         {
             Expression.Column.IsIdentity = true;

--- a/src/FluentMigrator/Builders/Alter/Table/AlterTableExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Alter/Table/AlterTableExpressionBuilder.cs
@@ -59,9 +59,15 @@ namespace FluentMigrator.Builders.Alter.Table
             _context.Expressions.Add(alterSchema);
         }
 
+        public IAlterTableAddColumnOrAlterColumnSyntax WithDescription(string description)
+        {
+            Expression.TableDescription = description;
+            return this;
+        }
+
         public IAlterTableColumnAsTypeSyntax AddColumn(string name)
         {
-            var column = new ColumnDefinition {Name = name, ModificationType = ColumnModificationType.Create};
+            var column = new ColumnDefinition { Name = name, ModificationType = ColumnModificationType.Create };
             var createColumn = new CreateColumnExpression
                                    {
                                        Column = column,
@@ -77,7 +83,7 @@ namespace FluentMigrator.Builders.Alter.Table
 
         public IAlterTableColumnAsTypeSyntax AlterColumn(string name)
         {
-            var column = new ColumnDefinition {Name = name, ModificationType = ColumnModificationType.Alter};
+            var column = new ColumnDefinition { Name = name, ModificationType = ColumnModificationType.Alter };
             var alterColumn = new AlterColumnExpression
                                   {
                                       Column = column,
@@ -115,6 +121,12 @@ namespace FluentMigrator.Builders.Alter.Table
             }
 
             CurrentColumn.DefaultValue = value;
+            return this;
+        }
+
+        public IAlterTableColumnOptionOrAddColumnOrAlterColumnSyntax WithColumnDescription(string description)
+        {
+            CurrentColumn.ColumnDescription = description;
             return this;
         }
 

--- a/src/FluentMigrator/Builders/Alter/Table/IAlterTableAddColumnOrAlterColumnOrSchemaSyntax.cs
+++ b/src/FluentMigrator/Builders/Alter/Table/IAlterTableAddColumnOrAlterColumnOrSchemaSyntax.cs
@@ -21,5 +21,6 @@ namespace FluentMigrator.Builders.Alter.Table
     public interface IAlterTableAddColumnOrAlterColumnOrSchemaSyntax : IAlterTableAddColumnOrAlterColumnSyntax
     {
         IAlterTableAddColumnOrAlterColumnSyntax InSchema(string schemaName);
+        IAlterTableAddColumnOrAlterColumnSyntax WithDescription(string description);
     }
 }

--- a/src/FluentMigrator/Builders/Create/Column/CreateColumnExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Create/Column/CreateColumnExpressionBuilder.cs
@@ -64,6 +64,12 @@ namespace FluentMigrator.Builders.Create.Column
             return this;
         }
 
+        public ICreateColumnOptionSyntax WithColumnDescription(string description)
+        {
+            Expression.Column.ColumnDescription = description;
+            return this;
+        }
+
         public ICreateColumnOptionSyntax Identity()
         {
             Expression.Column.IsIdentity = true;

--- a/src/FluentMigrator/Builders/Create/Table/CreateTableExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Create/Table/CreateTableExpressionBuilder.cs
@@ -49,9 +49,15 @@ namespace FluentMigrator.Builders.Create.Table
 
         public ICreateTableColumnAsTypeSyntax WithColumn(string name)
         {
-            var column = new ColumnDefinition {Name = name, TableName = Expression.TableName, ModificationType = ColumnModificationType.Create};
+            var column = new ColumnDefinition { Name = name, TableName = Expression.TableName, ModificationType = ColumnModificationType.Create };
             Expression.Columns.Add(column);
             CurrentColumn = column;
+            return this;
+        }
+
+        public ICreateTableWithColumnSyntax WithDescription(string description)
+        {
+            Expression.TableDescription = description;
             return this;
         }
 
@@ -64,6 +70,12 @@ namespace FluentMigrator.Builders.Create.Table
         public ICreateTableColumnOptionOrWithColumnSyntax WithDefaultValue(object value)
         {
             CurrentColumn.DefaultValue = value;
+            return this;
+        }
+
+        public ICreateTableColumnOptionOrWithColumnSyntax WithColumnDescription(string description)
+        {
+            CurrentColumn.ColumnDescription = description;
             return this;
         }
 

--- a/src/FluentMigrator/Builders/Create/Table/ICreateTableWithColumnOrSchemaSyntax.cs
+++ b/src/FluentMigrator/Builders/Create/Table/ICreateTableWithColumnOrSchemaSyntax.cs
@@ -21,5 +21,6 @@ namespace FluentMigrator.Builders.Create.Table
     public interface ICreateTableWithColumnOrSchemaSyntax : ICreateTableWithColumnSyntax
     {
         ICreateTableWithColumnSyntax InSchema(string schemaName);
+        ICreateTableWithColumnSyntax WithDescription(string description);
     }
 }

--- a/src/FluentMigrator/Builders/IColumnOptionSyntax.cs
+++ b/src/FluentMigrator/Builders/IColumnOptionSyntax.cs
@@ -28,6 +28,8 @@ namespace FluentMigrator.Builders
     {
         TNext WithDefault(SystemMethods method);
         TNext WithDefaultValue(object value);
+        TNext WithColumnDescription(string description);
+
         TNext Identity();
         TNext Indexed();
         TNext Indexed(string indexName);

--- a/src/FluentMigrator/Expressions/AlterTableExpression.cs
+++ b/src/FluentMigrator/Expressions/AlterTableExpression.cs
@@ -25,6 +25,7 @@ namespace FluentMigrator.Expressions
     {
         public virtual string SchemaName { get; set; }
         public virtual string TableName { get; set; }
+        public virtual string TableDescription { get; set; }
 
         public AlterTableExpression()
         {

--- a/src/FluentMigrator/Expressions/CreateTableExpression.cs
+++ b/src/FluentMigrator/Expressions/CreateTableExpression.cs
@@ -28,6 +28,7 @@ namespace FluentMigrator.Expressions
         public virtual string SchemaName { get; set; }
         public virtual string TableName { get; set; }
         public virtual IList<ColumnDefinition> Columns { get; set; }
+        public virtual string TableDescription { get; set; }
 
         public CreateTableExpression()
         {

--- a/src/FluentMigrator/Model/ColumnDefinition.cs
+++ b/src/FluentMigrator/Model/ColumnDefinition.cs
@@ -47,6 +47,7 @@ namespace FluentMigrator.Model
         public virtual bool IsUnique { get; set; }
         public virtual string TableName { get; set; }
         public virtual ColumnModificationType ModificationType { get; set; }
+        public virtual string ColumnDescription { get; set; }
 
         public void ApplyConventions(IMigrationConventions conventions)
         {
@@ -72,24 +73,27 @@ namespace FluentMigrator.Model
         {
         }
 
-        public IDictionary<string, object> AdditionalFeatures 
+        public IDictionary<string, object> AdditionalFeatures
         {
             get { return _additionalFeatures; }
         }
 
-        void ISupportAdditionalFeatures.AddAdditionalFeature(string feature, object value) 
+        void ISupportAdditionalFeatures.AddAdditionalFeature(string feature, object value)
         {
-            if (!AdditionalFeatures.ContainsKey(feature)) {
+            if (!AdditionalFeatures.ContainsKey(feature))
+            {
                 AdditionalFeatures.Add(feature, value);
             }
-            else {
+            else
+            {
                 AdditionalFeatures[feature] = value;
             }
         }
 
-        public T GetAdditionalFeature<T>(string key, T defaultValue) 
+        public T GetAdditionalFeature<T>(string key, T defaultValue)
         {
-            if (AdditionalFeatures.ContainsKey(key)) {
+            if (AdditionalFeatures.ContainsKey(key))
+            {
                 object value = AdditionalFeatures[key];
                 if (value is T)
                 {
@@ -101,7 +105,8 @@ namespace FluentMigrator.Model
         }
     }
 
-    public enum ColumnModificationType {
+    public enum ColumnModificationType
+    {
         Create,
         Alter
     }


### PR DESCRIPTION
Description support for tables and columns fixes issues #291 and #368. Implemented this for Oracle and MS SqlServer (version 2005 or higher).

Solution summary:
- The CreateTableExpression and AlterTableExpression contain a new string property TableDescription 
- The ColumnDefinition contains a new string property called ColumnDescription 
- Created IDescriptionGenerator interface and implemented 3 classes for this contract: OracleDescriptionGenerator, SqlServer2005DescriptionGenerator and EmptyDescriptionGenerator 
- The classes that generate the sql (such as OracleGenerator, SqlServer2005Generator) will use the description generator classes mentioned above for generating the appropriate scripts using newly overridden methods:  
  - Generate(CreateTableExpression expression)
  - Generate(AlterTableExpression expression) 
  - Generate(CreateColumnExpression expression), 
  - Generate(AlterColumnExpression expression)
1. On Oracle the syntax for adding / updating description on tables and columns is: 

[For table] COMMENT ON TABLE TestTable IS 'TestDescription'
[For column] COMMENT ON COLUMN TestColumn IS 'TestColumnDescription'

The OracleDescriptionGenerator generates sql statements as above, but I've modified OracleGenerator (see above the precise methods) as well, in order to generate scripts as follows (for example): 

BEGIN EXECUTE IMMEDIATE 'CREATE TABLE TestTable1 (TestColumn1 NVARCHAR2(255) NOT NULL, TestColumn2 NUMBER(10,0) NOT NULL)';
EXECUTE IMMEDIATE 'COMMENT ON TABLE TestTable1 IS ''TestDescription''';
EXECUTE IMMEDIATE 'COMMENT ON COLUMN TestTable1.TestColumn1 IS ''TestColumn1Description'''; END;

Note: The statements needed to wrapped in a BEGIN-END block due to the fact that ExecuteNonQuery was failing when trying to execute multiple statements. Also, the EXECUTE IMMEDIATE are required in order to being able to execute DDL statements in BEGIN-END block. 
1. On MS Sql Server (2005 or higher) descriptions are added on tables and columns using the following stored procedure: 

[For table] EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'TestDescription', @level0type=N'SCHEMA', @level0name='dbo', @level1type=N'TABLE', @level1name='TestTable'
[For column] EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'TestColumnDescription', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable', @level2type = N'Column',  @level2name = 'TestColumn'

As with Oracle implementation, the SqlServerGenerator (the same methods as above) needed to be modified so that the generated sql looks like below: 

CREATE TABLE [...]
GO
EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'TestDescription', @level0type=N'SCHEMA', @level0name='dbo', @level1type=N'TABLE', @level1name='TestTable1';
EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'TestColumn1Description', @level0type = N'SCHEMA', @level0name = 'dbo', @level
1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn1' 

Note: In case of AlterTable or AlterColumn, at the time of the migration the target tables / columns may already contain descriptions which would make the execution of the sp_addextendedproperty to throw an error and the migration to fail. For this, the script would look like this (if the property exists, then it is first deleted and subsequently added with the new value): 

IF EXISTS ( SELECT \* FROM fn_listextendedproperty(N'MS_Description', N'SCHEMA',N'dbo', N'TABLE', N'TestTable1', NULL, NULL)) 
EXEC sys.sp_dropextendedproperty @name=N'MS_Description', @level0type=N'SCHEMA', @level0name='dbo', @level1type=N'TABLE', @level1name='TestTable1';
EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'TestNewDescription', @level0type=N'SCHEMA', @level0name='dbo', level1type=N'TABLE', @level1name='TestTable1' 

The rest of the generator classes haven't been modified, except for injecting the EmptyDescriptionGenerator which doesn't change the existing functionality.

Unit tests have been added for the 2 specialized implementations of IDescriptionGenerator (the ones explained above). Also, added more tests in OracleGeneratorTests and SqlServerGeneratorTests according to the new overridden methods.  

In addition, I've also moved static FormatSqlEscape method (which was duplicated in multiple classes) in newly added static class FormatSqlHelper and refactored accordingly. 

I haven't implemented description support for other database engines (as I only work with Oracle and MS SQL Server), but it could be implemented using this structure. 
