### PR TITLE
ForwardOnlyMigration does not throw anymore on down

### DIFF
--- a/src/FluentMigrator/ForwardOnlyMigration.cs
+++ b/src/FluentMigrator/ForwardOnlyMigration.cs
@@ -1,14 +1,27 @@
-﻿
+﻿#region License
+
+// Copyright (c) 2007-2009, Sean Chambers <schambers80@gmail.com>
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
 
 namespace FluentMigrator
 {
-    using System;
-
     public abstract class ForwardOnlyMigration : Migration
     {
-        public sealed override void Down()
+        public override sealed void Down()
         {
-            throw new InvalidOperationException("Only forward migration is supported");
         }
     }
 }


### PR DESCRIPTION
Removed InvalidOperationException and added license region ForwardOnlyMigration closes #436
