### PR TITLE
set CLS compliance to true

### DIFF
--- a/default.build
+++ b/default.build
@@ -25,6 +25,7 @@
 				<attribute type="System.Reflection.AssemblyVersionAttribute" value="${complete.version}"/>
 				<attribute type="System.Reflection.AssemblyCopyrightAttribute" value="Copyright - Sean Chambers 2008-2010" />
 				<attribute type="System.Reflection.AssemblyConfigurationAttribute" value="${build.config}" />
+				<attribute type="System.CLSCompliantAttribute" value="true" />
 			</attributes>
 		</asminfo>
 	</target>


### PR DESCRIPTION
This is just a small change but removes a nuisance for us that are referring FluentMigrator's dlls from CLS compliant assemblies.

Marking assemblies asl CLS Compliant is considered a best practice http://msdn.microsoft.com/en-us/library/ms182156.aspx
