### PR TITLE
Corrected parameter name from "primaryTableName" to "foreignTableName"

### DIFF
--- a/src/FluentMigrator/Builders/Delete/ForeignKey/IDeleteForeignKeyOnTableSyntax.cs
+++ b/src/FluentMigrator/Builders/Delete/ForeignKey/IDeleteForeignKeyOnTableSyntax.cs
@@ -22,6 +22,6 @@ namespace FluentMigrator.Builders.Delete.ForeignKey
 {
     public interface IDeleteForeignKeyOnTableSyntax : IFluentSyntax
     {
-        IInSchemaSyntax OnTable(string primaryTableName);
+        IInSchemaSyntax OnTable(string foreignTableName);
     }
 }


### PR DESCRIPTION
Corrected to match parameter name in `DeleteForeignKeyExpressionBuilder`.
