### PR TITLE
Update MySqlTypeMap.cs

### DIFF
--- a/src/FluentMigrator.Runner/Generators/MySql/MySqlTypeMap.cs
+++ b/src/FluentMigrator.Runner/Generators/MySql/MySqlTypeMap.cs
@@ -9,6 +9,7 @@ namespace FluentMigrator.Runner.Generators.MySql
         public const int StringCapacity = 255;
         public const int TextCapacity = 65535;
         public const int MediumTextCapacity = 16777215;
+        public const int LongTextCapacity = int.MaxValue;
         public const int DecimalCapacity = 19;
 
         protected override void SetupTypeMaps()
@@ -17,10 +18,12 @@ namespace FluentMigrator.Runner.Generators.MySql
             SetTypeMap(DbType.AnsiStringFixedLength, "CHAR($size)", StringCapacity);
             SetTypeMap(DbType.AnsiStringFixedLength, "TEXT", TextCapacity);
             SetTypeMap(DbType.AnsiStringFixedLength, "MEDIUMTEXT", MediumTextCapacity);
+            SetTypeMap(DbType.AnsiStringFixedLength, "LONGTEXT", LongTextCapacity);
             SetTypeMap(DbType.AnsiString, "VARCHAR(255)");
             SetTypeMap(DbType.AnsiString, "VARCHAR($size)", StringCapacity);
             SetTypeMap(DbType.AnsiString, "TEXT", TextCapacity);
             SetTypeMap(DbType.AnsiString, "MEDIUMTEXT", MediumTextCapacity);
+            SetTypeMap(DbType.AnsiString, "LONGTEXT", LongTextCapacity);
             SetTypeMap(DbType.Binary, "LONGBLOB");
             SetTypeMap(DbType.Binary, "TINYBLOB", AnsiTinyStringCapacity);
             SetTypeMap(DbType.Binary, "BLOB", TextCapacity);
@@ -42,10 +45,12 @@ namespace FluentMigrator.Runner.Generators.MySql
             SetTypeMap(DbType.StringFixedLength, "CHAR($size)", StringCapacity);
             SetTypeMap(DbType.StringFixedLength, "TEXT", TextCapacity);
             SetTypeMap(DbType.StringFixedLength, "MEDIUMTEXT", MediumTextCapacity);
+            SetTypeMap(DbType.StringFixedLength, "LONGTEXT", LongTextCapacity);
             SetTypeMap(DbType.String, "VARCHAR(255)");
             SetTypeMap(DbType.String, "VARCHAR($size)", StringCapacity);
             SetTypeMap(DbType.String, "TEXT", TextCapacity);
             SetTypeMap(DbType.String, "MEDIUMTEXT", MediumTextCapacity);
+            SetTypeMap(DbType.String, "LONGTEXT", LongTextCapacity);
             SetTypeMap(DbType.Time, "DATETIME");
         }
     }


### PR DESCRIPTION
version 1.1.2 causes error when migrating 'versioninfo' table by adding a 'description' column on MySQL database.
This error caused by method 'Up' in 'VersionDescriptionMigration' class. The method calls .AsString(int.MaxValue) which is beyond 
definition in MySqlTypeMap class
