### PR TITLE
Added Constraint("name").Exists() to SchemaTable syntax

### DIFF
--- a/src/FluentMigrator.Tests/Unit/Builders/Schema/SchemaExpressionRootTest.cs
+++ b/src/FluentMigrator.Tests/Unit/Builders/Schema/SchemaExpressionRootTest.cs
@@ -31,6 +31,7 @@ namespace FluentMigrator.Tests.Unit.Builders.Schema
         private Mock<IMigrationContext> _migrationContextMock;
         private string _testColumn;
         private string _testConstraint;
+        private string _testIndex;
         private string _testTable;
         private string _testSchema;
         private SchemaExpressionRoot _builder;
@@ -42,6 +43,7 @@ namespace FluentMigrator.Tests.Unit.Builders.Schema
             _querySchemaMock = new Mock<IQuerySchema>();
             _testSchema = "testSchema";
             _testTable = "testTable";
+            _testIndex = "testIndex";
             _testColumn = "testColumn";
             _testConstraint = "testConstraint";
 
@@ -77,6 +79,16 @@ namespace FluentMigrator.Tests.Unit.Builders.Schema
         }
 
         [Test]
+        public void TestIndexExists()
+        {
+            _querySchemaMock.Setup(x => x.IndexExists(null, _testTable, _testIndex)).Returns(true);
+
+
+            _builder.Table(_testTable).Index(_testIndex).Exists().ShouldBeTrue();
+            _querySchemaMock.Verify(x => x.IndexExists(null, _testTable, _testIndex));
+        }
+
+        [Test]
         public void TestTableExistsWithSchema()
         {
             _querySchemaMock.Setup(x => x.TableExists(_testSchema, _testTable)).Returns(true);
@@ -101,6 +113,15 @@ namespace FluentMigrator.Tests.Unit.Builders.Schema
 
             _builder.Schema(_testSchema).Table(_testTable).Constraint(_testConstraint).Exists().ShouldBeTrue();
             _querySchemaMock.Verify(x => x.ConstraintExists(_testSchema, _testTable, _testConstraint));
+        }
+
+        [Test]
+        public void TestIndexExistsWithSchema()
+        {
+            _querySchemaMock.Setup(x => x.IndexExists(_testSchema, _testTable, _testIndex)).Returns(true);
+
+            _builder.Schema(_testSchema).Table(_testTable).Index(_testIndex).Exists().ShouldBeTrue();
+            _querySchemaMock.Verify(x => x.IndexExists(_testSchema, _testTable, _testIndex));
         }
     }
 }


### PR DESCRIPTION
I've added the Constaint Exist functionality to the schematable syntax. The underlaying code in the processors was already present, just not implemented yet on the syntax interface.

The solution file is changed as well due to usage of VS2013; I seem to be unable to exclude this file from the pull request. So you might want to skip that one, or how can I skip this file in the pull request? :)
