### PR TITLE
Added 'GO' statements to file output when targeting Ms SQL Server (Corrected)

### DIFF
--- a/src/FluentMigrator.Console/MigratorConsole.cs
+++ b/src/FluentMigrator.Console/MigratorConsole.cs
@@ -258,17 +258,26 @@ namespace FluentMigrator.Console
         {
             using (var sw = new StreamWriter(outputTo))
             {
-                var fileAnnouncer = new TextWriterAnnouncer(sw)
-                                        {
-                                            ShowElapsedTime = false,
-                                            ShowSql = true
-                                        };
+                var fileAnnouncer = this.ExecutingAgainstMsSql ?
+                    new TextWriterWithGoAnnouncer(sw) :
+                    new TextWriterAnnouncer(sw);
+
+                fileAnnouncer.ShowElapsedTime = false;
+                fileAnnouncer.ShowSql = true;
+
                 consoleAnnouncer.ShowElapsedTime = Verbose;
                 consoleAnnouncer.ShowSql = Verbose;
 
                 var announcer = new CompositeAnnouncer(consoleAnnouncer, fileAnnouncer);
 
                 ExecuteMigrations(announcer);
+            }
+        }
+        private bool ExecutingAgainstMsSql
+        {
+            get
+            {
+                return ProcessorType.StartsWith("SqlServer", StringComparison.InvariantCultureIgnoreCase);
             }
         }
 

--- a/src/FluentMigrator.Runner/Announcers/TextWriterWithGoAnnouncer.cs
+++ b/src/FluentMigrator.Runner/Announcers/TextWriterWithGoAnnouncer.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace FluentMigrator.Runner.Announcers
+{
+    public class TextWriterWithGoAnnouncer : TextWriterAnnouncer
+    {
+        public TextWriterWithGoAnnouncer(TextWriter writer)
+            : base(writer)
+        { }
+
+        public  TextWriterWithGoAnnouncer(Action<string> write) 
+            : base(write)
+        { }
+
+        public override void Sql(string sql)
+        {
+            if (!ShowSql) return;
+
+            base.Sql(sql);
+
+            if (!string.IsNullOrEmpty(sql))
+                Write("GO", false);
+        } 
+    }
+}

--- a/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
+++ b/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Announcers\NullAnnouncer.cs" />
     <Compile Include="Announcers\ConsoleAnnouncer.cs" />
     <Compile Include="Announcers\TextWriterAnnouncer.cs" />
+    <Compile Include="Announcers\TextWriterWithGoAnnouncer.cs" />
     <Compile Include="CompatabilityMode.cs" />
     <Compile Include="Extensions\SqlServerExtensions.cs" />
     <Compile Include="Extensions\TagsExtensions.cs" />

--- a/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -238,6 +238,7 @@
     <Compile Include="Unit\AnnouncerExtensionsTests.cs" />
     <Compile Include="Unit\Announcers\AnnouncerTests.cs" />
     <Compile Include="Unit\Announcers\TextWriterAnnouncerTests.cs" />
+    <Compile Include="Unit\Announcers\TextWriterWithGoAnnouncerTests.cs" />
     <Compile Include="Unit\AssemblyLoader\AssemblyLoaderTests.cs" />
     <Compile Include="Unit\Builders\Alter\AlterColumnExpressionBuilderTests.cs" />
     <Compile Include="Unit\Builders\Alter\AlterExpressionRootTests.cs" />
@@ -486,6 +487,9 @@
     <Content Include="Unit\Initialization\Fixtures\WithNoConnectionString.exe">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/src/FluentMigrator.Tests/Unit/Announcers/TextWriterWithGoAnnouncerTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Announcers/TextWriterWithGoAnnouncerTests.cs
@@ -1,0 +1,58 @@
+﻿using FluentMigrator.Runner.Announcers;
+using NUnit.Framework;
+using NUnit.Should;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace FluentMigrator.Tests.Unit.Announcers
+{
+    [TestFixture]
+    public class TextWriterWithGoAnnouncerTests
+    {
+        private StringWriter _stringWriter;
+        private TextWriterWithGoAnnouncer announcer;
+
+        [SetUp]
+        public void TestSetup()
+        {
+            _stringWriter = new StringWriter();
+            announcer = new TextWriterWithGoAnnouncer(_stringWriter)
+            {
+                ShowElapsedTime = true,
+                ShowSql = true
+            };
+        }
+
+        [Test]
+        public void Adds_Go_StatementAfterSqlAnouncement()
+        {
+            announcer.Sql("DELETE Blah");
+            Output.ShouldBe("DELETE Blah" + Environment.NewLine + 
+                "GO" + Environment.NewLine);
+        }
+
+        [Test]
+        public void Sql_Should_Not_Write_When_Show_Sql_Is_False()
+        {
+            announcer.ShowSql = false;
+
+            announcer.Sql("SQL");
+            Output.ShouldBe(String.Empty);
+        }
+
+        [Test]
+        public void Sql_Should_Not_Write_Go_When_Sql_Is_Empty()
+        {
+            announcer.Sql("");
+            Assert.IsFalse(Output.Contains("GO"));
+        }
+
+        public string Output
+        {
+            get { return _stringWriter.GetStringBuilder().ToString(); }
+        }
+    }
+}


### PR DESCRIPTION
In order to support scenarios where you have to hand off database change scripts to Dbas/Ops like I do, we need the file output to run without hand editing. I hacked together a way of adding 'GO' statements after each migration to minimize hand editing.

This is a replacement Pull Request for pull request: #492 which included changes not meant for this repo.
