### PR TITLE
Calling MigrateUp or MigrateDown now always applies profiles after migra...

### DIFF
--- a/src/FluentMigrator.Runner/MigrationRunner.cs
+++ b/src/FluentMigrator.Runner/MigrationRunner.cs
@@ -134,6 +134,8 @@ namespace FluentMigrator.Runner
                     ApplyMigrationUp(migrationInfo, useAutomaticTransactionManagement && migrationInfo.TransactionBehavior == TransactionBehavior.Default);
                 }
 
+                ApplyProfiles();
+
                 scope.Complete();
             }
 
@@ -174,6 +176,8 @@ namespace FluentMigrator.Runner
                 {
                     ApplyMigrationDown(migrationInfo, useAutomaticTransactionManagement && migrationInfo.TransactionBehavior == TransactionBehavior.Default);
                 }
+
+                ApplyProfiles();
 
                 scope.Complete();
             }

--- a/src/FluentMigrator.Tests/Unit/MigrationRunnerTests.cs
+++ b/src/FluentMigrator.Tests/Unit/MigrationRunnerTests.cs
@@ -111,6 +111,27 @@ namespace FluentMigrator.Tests.Unit
             _fakeVersionLoader.LoadVersionInfo();
         }
 
+        [Test]
+        public void ProfilesAreAppliedWhenMigrateUpIsCalledWithNoVersion()
+        {
+            _runner.MigrateUp();
+            _profileLoaderMock.Verify(x => x.ApplyProfiles(), Times.Once());
+        }
+
+        [Test]
+        public void ProfilesAreAppliedWhenMigrateUpIsCalledWithVersionParameter()
+        {
+            _runner.MigrateUp(2009010101);
+            _profileLoaderMock.Verify(x => x.ApplyProfiles(), Times.Once());
+        }
+
+        [Test]
+        public void ProfilesAreAppliedWhenMigrateDownIsCalled()
+        {
+            _runner.MigrateDown(2009010101);
+            _profileLoaderMock.Verify(x => x.ApplyProfiles(), Times.Once());
+        }
+
         /// <summary>Unit test which ensures that the application context is correctly propagated down to each migration class.</summary>
         [Test(Description = "Ensure that the application context is correctly propagated down to each migration class.")]
         public void CanPassApplicationContext()


### PR DESCRIPTION
This brings the code in line with the docs at https://github.com/schambers/fluentmigrator/wiki/Profiles.  It adds the missing calls to profileLoader.ApplyProfiles() to ensure that profiles always get run when running either migrating up or down - regardless of whether a version is specified or not.
