### PR TITLE
Find Profiles alphabetically

### DIFF
--- a/src/FluentMigrator.Runner/ProfileLoader.cs
+++ b/src/FluentMigrator.Runner/ProfileLoader.cs
@@ -37,7 +37,8 @@ namespace FluentMigrator.Runner
         public IEnumerable<IMigration> FindProfilesIn(Assembly assembly, string profile)
         {
             IEnumerable<Type> matchedTypes = assembly.GetExportedTypes()
-                .Where(t => Conventions.TypeIsProfile(t) && t.GetOneAttribute<ProfileAttribute>().ProfileName.ToLower() == profile.ToLower());
+                .Where(t => Conventions.TypeIsProfile(t) && t.GetOneAttribute<ProfileAttribute>().ProfileName.ToLower() == profile.ToLower())
+                .OrderBy(x => x.Name);
 
             foreach (Type type in matchedTypes)
             {


### PR DESCRIPTION
Added an alphabeticall sorting to the FindProfilesIn method, so when you have mulitple migrations that have the Profile Attribute, you get handled in alphabetical order.

Allows for an arbitrary ordering when creating migrations for profiles
