### PR TITLE
Fixes the execution of sql scripts using reflection on Devart.Data.Oracle

### DIFF
--- a/src/FluentMigrator.Runner/Processors/DotConnectOracle/DotConnectOracleProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/DotConnectOracle/DotConnectOracleProcessor.cs
@@ -123,15 +123,7 @@ namespace FluentMigrator.Runner.Processors.DotConnectOracle
 
         public override void Execute(string template, params object[] args)
         {
-            if (template == null)
-                throw new ArgumentNullException("template");
-
-            EnsureConnectionIsOpen();
-
-            using (var command = Factory.CreateCommand(String.Format(template, args), Connection))
-            {
-                command.ExecuteNonQuery();
-            }
+            Process(string.Format(template, args));
         }
 
         public override bool Exists(string template, params object[] args)
@@ -192,8 +184,11 @@ namespace FluentMigrator.Runner.Processors.DotConnectOracle
 
             EnsureConnectionIsOpen();
 
-            using (var command = Factory.CreateCommand(sql, Connection))
-                command.ExecuteNonQuery();
+            var oracleScript = AppDomain.CurrentDomain.CreateInstanceAndUnwrap("DevArt.Data.Oracle", "Devart.Data.Oracle.OracleScript");
+            var oracleScriptType = oracleScript.GetType();
+            oracleScriptType.GetProperty("Connection", typeof(IDbConnection)).SetValue(oracleScript, Connection, null);
+            oracleScriptType.GetProperty("ScriptText").SetValue(oracleScript, sql, null);
+            oracleScriptType.GetMethod("Execute").Invoke(oracleScript, new object[] { });
         }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Runners/MigrationProcessorFactoryProviderTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Runners/MigrationProcessorFactoryProviderTests.cs
@@ -17,6 +17,7 @@
 #endregion
 
 using FluentMigrator.Runner.Processors;
+using FluentMigrator.Runner.Processors.DotConnectOracle;
 using FluentMigrator.Runner.Processors.Oracle;
 using FluentMigrator.Runner.Processors.SQLite;
 using FluentMigrator.Runner.Processors.SqlServer;
@@ -89,6 +90,13 @@ namespace FluentMigrator.Tests.Unit.Runners
         {
             IMigrationProcessorFactory factory = migrationProcessorFactoryProvider.GetFactory("Oracle");
             Assert.IsTrue(factory.GetType() == typeof(OracleProcessorFactory));
+        }
+
+        [Test]
+        public void CanRetrieveDotConnectOracleFactoryWithArgumentString()
+        {
+            IMigrationProcessorFactory factory = migrationProcessorFactoryProvider.GetFactory("DotConnectOracle");
+            Assert.IsTrue(factory.GetType() == typeof(DotConnectOracleProcessorFactory));
         }
     }
 }


### PR DESCRIPTION
The execution of sql scripts with the Devart dotConnect data provider for Oracle was wrong. Now using the object OracleScript is possible to run even long scripts.

Aditionally the commit includes a minor improvement at tests for guarantee to get a factory to Devart dotConnect.
