### PR TITLE
Fix for #398

### DIFF
--- a/src/FluentMigrator.Tests/Unit/Builders/Alter/AlterTableExpressionBuilderTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Builders/Alter/AlterTableExpressionBuilderTests.cs
@@ -306,6 +306,44 @@ namespace FluentMigrator.Tests.Unit.Builders.Alter
         }
 
         [Test]
+        public void CallingWithDefaultOnNewColumnDoesNotAddDefaultConstraintExpression()
+        {
+            var expressions = new List<IMigrationExpression>();
+            var contextMock = new Mock<IMigrationContext>();
+            contextMock.Setup(x => x.Expressions).Returns(expressions);
+
+            var columnMock = new Mock<ColumnDefinition>();
+            columnMock.Setup(x => x.ModificationType).Returns(ColumnModificationType.Create);
+
+            var expressionMock = new Mock<AlterTableExpression>();
+
+            var builder = new AlterTableExpressionBuilder(expressionMock.Object, contextMock.Object);
+            builder.CurrentColumn = columnMock.Object;
+            builder.WithDefault(SystemMethods.CurrentDateTime);
+
+            Assert.That(expressions.Count(), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void CallingWithDefaultOnAlterColumnAddsDefaultConstraintExpression()
+        {
+            var expressions = new List<IMigrationExpression>();
+            var contextMock = new Mock<IMigrationContext>();
+            contextMock.Setup(x => x.Expressions).Returns(expressions);
+
+            var columnMock = new Mock<ColumnDefinition>();
+            columnMock.Setup(x => x.ModificationType).Returns(ColumnModificationType.Alter);
+
+            var expressionMock = new Mock<AlterTableExpression>();
+
+            var builder = new AlterTableExpressionBuilder(expressionMock.Object, contextMock.Object);
+            builder.CurrentColumn = columnMock.Object;
+            builder.WithDefault(SystemMethods.CurrentDateTime);
+
+            Assert.That(expressions.Count(), Is.EqualTo(1));
+        }
+
+        [Test]
         public void CallingForeignKeySetsIsForeignKeyToTrue()
         {
             VerifyColumnProperty(c => c.IsForeignKey = true, b => b.ForeignKey());

--- a/src/FluentMigrator/Builders/Alter/Column/AlterColumnExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Alter/Column/AlterColumnExpressionBuilder.cs
@@ -57,25 +57,12 @@ namespace FluentMigrator.Builders.Alter.Column
 
         public IAlterColumnOptionSyntax WithDefault(SystemMethods method)
         {
-            // we need to do a drop constraint and then add constraint to change the defualt value
-            var dc = new AlterDefaultConstraintExpression
-                         {
-                             TableName = Expression.TableName,
-                             SchemaName = Expression.SchemaName,
-                             ColumnName = Expression.Column.Name,
-                             DefaultValue = method
-                         };
-
-            _context.Expressions.Add(dc);
-
-            Expression.Column.DefaultValue = method;
-
-            return this;
+            return WithDefaultValue(method);
         }
 
         public IAlterColumnOptionSyntax WithDefaultValue(object value)
         {
-            // we need to do a drop constraint and then add constraint to change the defualt value
+            // we need to do a drop constraint and then add constraint to change the default value
             var dc = new AlterDefaultConstraintExpression
                          {
                              TableName = Expression.TableName,

--- a/src/FluentMigrator/Builders/Alter/Table/AlterTableExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Alter/Table/AlterTableExpressionBuilder.cs
@@ -102,8 +102,7 @@ namespace FluentMigrator.Builders.Alter.Table
 
         public IAlterTableColumnOptionOrAddColumnOrAlterColumnSyntax WithDefault(SystemMethods method)
         {
-            CurrentColumn.DefaultValue = method;
-            return this;
+            return WithDefaultValue(method);
         }
 
         public IAlterTableColumnOptionOrAddColumnOrAlterColumnSyntax WithDefaultValue(object value)


### PR DESCRIPTION
Change AlterTableExpressionBuilder to alter default values on existing
columns correctly.

The simplest way of doing this was to pass through from WithDefault to WithDefaultValue as that does exactly what I wanted. I also did the same thing in AlterColumnExpressionBuilder for consistency as the two method bodies were identical.

Tested with the two examples given by @derekgreer on #398. Before this change the migration claimed to succeed but no change was made to the database. With this change the migration changes the database as expected.
