### PR TITLE
 it is now possible to override the default IVersionLoader implementatio...

### DIFF
--- a/src/FluentMigrator.Runner/MigrationRunner.cs
+++ b/src/FluentMigrator.Runner/MigrationRunner.cs
@@ -109,6 +109,8 @@ namespace FluentMigrator.Runner
 
         public void MigrateUp(bool useAutomaticTransactionManagement)
         {
+            VersionLoader.LoadVersionInfo();
+
             var migrations = MigrationLoader.LoadMigrations();
 
             using (IMigrationScope scope = _migrationScopeHandler.CreateOrWrapMigrationScope(useAutomaticTransactionManagement && TransactionPerSession))
@@ -141,6 +143,8 @@ namespace FluentMigrator.Runner
 
         public void MigrateUp(long targetVersion, bool useAutomaticTransactionManagement)
         {
+            VersionLoader.LoadVersionInfo();
+
             var migrationInfos = GetUpMigrationsToApply(targetVersion);
             using (IMigrationScope scope = _migrationScopeHandler.CreateOrWrapMigrationScope(useAutomaticTransactionManagement && TransactionPerSession))
             {
@@ -183,6 +187,8 @@ namespace FluentMigrator.Runner
 
         public void MigrateDown(long targetVersion, bool useAutomaticTransactionManagement)
         {
+            VersionLoader.LoadVersionInfo();
+
             var migrationInfos = GetDownMigrationsToApply(targetVersion);
 
             using (IMigrationScope scope = _migrationScopeHandler.CreateOrWrapMigrationScope(useAutomaticTransactionManagement && TransactionPerSession))
@@ -289,6 +295,8 @@ namespace FluentMigrator.Runner
 
         public void Rollback(int steps, bool useAutomaticTransactionManagement)
         {
+            VersionLoader.LoadVersionInfo();
+
             var availableMigrations = MigrationLoader.LoadMigrations();
             var migrationsToRollback = new List<IMigrationInfo>();
 
@@ -321,6 +329,8 @@ namespace FluentMigrator.Runner
 
         public void RollbackToVersion(long version, bool useAutomaticTransactionManagement)
         {
+            VersionLoader.LoadVersionInfo();
+
             var availableMigrations = MigrationLoader.LoadMigrations();
             var migrationsToRollback = new List<IMigrationInfo>();
 

--- a/src/FluentMigrator.Runner/VersionLoader.cs
+++ b/src/FluentMigrator.Runner/VersionLoader.cs
@@ -39,8 +39,6 @@ namespace FluentMigrator.Runner
             VersionSchemaMigration = new VersionSchemaMigration(VersionTableMetaData);
             VersionUniqueMigration = new VersionUniqueMigration(VersionTableMetaData);
             VersionDescriptionMigration = new VersionDescriptionMigration(VersionTableMetaData);
-
-            LoadVersionInfo();
         }
 
         public void UpdateVersionInfo(long version)
@@ -60,7 +58,7 @@ namespace FluentMigrator.Runner
 
         public IVersionTableMetaData GetVersionTableMetaData()
         {
-            Type matchedType = Assembly.GetExportedTypes().FirstOrDefault(t => Conventions.TypeIsVersionTableMetaData(t));
+            Type matchedType = Assembly.GetExportedTypes().FirstOrDefault(Conventions.TypeIsVersionTableMetaData);
 
             if (matchedType == null)
             {


### PR DESCRIPTION
...n. #520

implementing IVersionLoader to have a customized table (e.g. with more columns) and setting it in the migration runner used to create the default version table nevertheless. Now its moved to where it is loaded so it is possible to exchange it
