### PR TITLE
ROWGUIDCOL on SqlServer

### DIFF
--- a/src/FluentMigrator.Runner/Extensions/SqlServerExtensions.cs
+++ b/src/FluentMigrator.Runner/Extensions/SqlServerExtensions.cs
@@ -102,5 +102,12 @@ namespace FluentMigrator.Runner.Extensions
             throw new InvalidOperationException("The seeded identity method can only be called on a valid object.");
         }
 
+        public static ICreateTableColumnOptionOrWithColumnSyntax RowGuid( this ICreateTableColumnOptionOrWithColumnSyntax expression )
+        {
+            CreateTableExpressionBuilder cast = expression as CreateTableExpressionBuilder;
+            if ( cast != null )
+                cast.CurrentColumn.IsRowGuid = true;
+            return expression;
+        }
     }
 }

--- a/src/FluentMigrator.Runner/Generators/Base/ColumnBase.cs
+++ b/src/FluentMigrator.Runner/Generators/Base/ColumnBase.cs
@@ -16,7 +16,7 @@ namespace FluentMigrator.Runner.Generators.Base
         {
             _typeMap = typeMap;
             _quoter = quoter;
-            ClauseOrder = new List<Func<ColumnDefinition, string>> { FormatString, FormatType, FormatNullable, FormatDefaultValue, FormatPrimaryKey, FormatIdentity };
+            ClauseOrder = new List<Func<ColumnDefinition, string>> { FormatString, FormatType, FormatRowGuid, FormatNullable, FormatDefaultValue, FormatPrimaryKey, FormatIdentity };
         }
 
         protected string GetTypeMap(DbType value, int size, int precision)
@@ -77,6 +77,11 @@ namespace FluentMigrator.Runner.Generators.Base
         protected virtual string FormatPrimaryKey(ColumnDefinition column)
         {
             //Most Generators allow for adding primary keys as a constrint
+            return string.Empty;
+        }
+
+        protected virtual string FormatRowGuid(ColumnDefinition column)
+        {
             return string.Empty;
         }
 

--- a/src/FluentMigrator.Runner/Generators/Base/ColumnBase.cs
+++ b/src/FluentMigrator.Runner/Generators/Base/ColumnBase.cs
@@ -16,7 +16,7 @@ namespace FluentMigrator.Runner.Generators.Base
         {
             _typeMap = typeMap;
             _quoter = quoter;
-            ClauseOrder = new List<Func<ColumnDefinition, string>> { FormatString, FormatType, FormatRowGuid, FormatNullable, FormatDefaultValue, FormatPrimaryKey, FormatIdentity };
+            ClauseOrder = new List<Func<ColumnDefinition, string>> { FormatString, FormatType, FormatNullable, FormatDefaultValue, FormatPrimaryKey, FormatIdentity };
         }
 
         protected string GetTypeMap(DbType value, int size, int precision)
@@ -77,11 +77,6 @@ namespace FluentMigrator.Runner.Generators.Base
         protected virtual string FormatPrimaryKey(ColumnDefinition column)
         {
             //Most Generators allow for adding primary keys as a constrint
-            return string.Empty;
-        }
-
-        protected virtual string FormatRowGuid(ColumnDefinition column)
-        {
             return string.Empty;
         }
 

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServerColumn.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServerColumn.cs
@@ -41,6 +41,11 @@ namespace FluentMigrator.Runner.Generators.SqlServer
                 column.GetAdditionalFeature(SqlServerExtensions.IdentityIncrement, 1));
         }
 
+        protected override string FormatRowGuid( ColumnDefinition column )
+        {
+            return column.IsRowGuid ? "ROWGUIDCOL" : string.Empty;
+        }
+
         protected override string FormatSystemMethods(SystemMethods systemMethod)
         {
             switch (systemMethod)

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServerColumn.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServerColumn.cs
@@ -1,6 +1,7 @@
 ﻿using FluentMigrator.Model;
 using FluentMigrator.Runner.Extensions;
 using FluentMigrator.Runner.Generators.Base;
+using System.Linq;
 
 namespace FluentMigrator.Runner.Generators.SqlServer
 {
@@ -9,6 +10,8 @@ namespace FluentMigrator.Runner.Generators.SqlServer
         public SqlServerColumn(ITypeMap typeMap)
             : base(typeMap, new SqlServerQuoter())
         {
+            // place the ROWGUIDCOL keyword after data type.
+            ClauseOrder.Insert( ClauseOrder.IndexOf( FormatType ) + 1, FormatRowGuid );
         }
 
         protected override string FormatDefaultValue(ColumnDefinition column)
@@ -41,7 +44,7 @@ namespace FluentMigrator.Runner.Generators.SqlServer
                 column.GetAdditionalFeature(SqlServerExtensions.IdentityIncrement, 1));
         }
 
-        protected override string FormatRowGuid( ColumnDefinition column )
+        protected string FormatRowGuid( ColumnDefinition column )
         {
             return column.IsRowGuid ? "ROWGUIDCOL" : string.Empty;
         }

--- a/src/FluentMigrator/Model/ColumnDefinition.cs
+++ b/src/FluentMigrator/Model/ColumnDefinition.cs
@@ -45,6 +45,7 @@ namespace FluentMigrator.Model
         public virtual string PrimaryKeyName { get; set; }
         public virtual bool? IsNullable { get; set; }
         public virtual bool IsUnique { get; set; }
+        public virtual bool IsRowGuid { get; set; }
         public virtual string TableName { get; set; }
         public virtual ColumnModificationType ModificationType { get; set; }
         public virtual string ColumnDescription { get; set; }


### PR DESCRIPTION
Added option to set ROWGUIDCOL attribute when creating table (SqlServer
only)

```
Create.Table( "TestTable" ).InSchema( "TestSchema" )
        .WithColumn( "TestTableID" ).AsGuid().RowGuid().PrimaryKey().WithDefault( SystemMethods.NewSequentialId ).NotNullable();
```

ps. I had to remove previous pull request because I messed something while trying to add another pull request.
