### PR TITLE
Add db type datetime2

### DIFF
--- a/src/FluentMigrator.Runner/TypeFinder.cs
+++ b/src/FluentMigrator.Runner/TypeFinder.cs
@@ -27,7 +27,7 @@ namespace FluentMigrator.Runner
                 if (loadNestedNamespaces)
                 {
                     string matchNested = @namespace + ".";
-                    shouldInclude = t => t.Namespace == @namespace || t.Namespace.StartsWith(matchNested);
+                    shouldInclude = t => t.Namespace != null && (t.Namespace == @namespace || t.Namespace.StartsWith(matchNested));
                 }
 
                 return types.Where(shouldInclude);

--- a/src/FluentMigrator.Tests/Unit/Builders/Alter/AlterColumnExpressionBuilderTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Builders/Alter/AlterColumnExpressionBuilderTests.cs
@@ -196,6 +196,11 @@ namespace FluentMigrator.Tests.Unit.Builders.Alter
         }
 
         [Test]
+        public void CallingAsDateTime2SetsColumnDbTypeToDateTime2() {
+          VerifyColumnDbType(DbType.DateTime2, b => b.AsDateTime2());
+        }
+
+        [Test]
         public void CallingAsDateTimeOffsetSetsColumnDbTypeToDateTimeOffset() 
         {
             VerifyColumnDbType(DbType.DateTimeOffset, b => b.AsDateTimeOffset());

--- a/src/FluentMigrator.Tests/Unit/Builders/Alter/AlterTableExpressionBuilderTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Builders/Alter/AlterTableExpressionBuilderTests.cs
@@ -97,6 +97,12 @@ namespace FluentMigrator.Tests.Unit.Builders.Alter
         }
 
         [Test]
+        public void CallingAsDateTime2SetsColumnDbTypeToDateTime2()
+        {
+          VerifyColumnDbType(DbType.DateTime2, b=>b.AsDateTime2());
+        }
+
+        [Test]
         public void CallingAsDateTimeOffsetSetsColumnDbTypeToDateTimeOffset() 
         {
             VerifyColumnDbType(DbType.DateTimeOffset, b => b.AsDateTimeOffset());

--- a/src/FluentMigrator.Tests/Unit/Builders/Create/CreateColumnExpressionBuilderTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Builders/Create/CreateColumnExpressionBuilderTests.cs
@@ -116,6 +116,11 @@ namespace FluentMigrator.Tests.Unit.Builders.Create
         }
 
         [Test]
+        public void CallingAsDateTime2SetsColumnDbTypeToDateTime2() {
+          VerifyColumnDbType(DbType.DateTime2, b => b.AsDateTime2());
+        }
+
+        [Test]
         public void CallingAsDateTimeOffsetSetsColumnDbTypeToDateTimeOffset()
         {
             VerifyColumnDbType(DbType.DateTimeOffset, b => b.AsDateTimeOffset());

--- a/src/FluentMigrator.Tests/Unit/Builders/Create/CreateTableExpressionBuilderTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Builders/Create/CreateTableExpressionBuilderTests.cs
@@ -97,6 +97,11 @@ namespace FluentMigrator.Tests.Unit.Builders.Create
         }
 
         [Test]
+        public void CallingAsDateTime2SetsColumnDbTypeToDateTime2() {
+          VerifyColumnDbType(DbType.DateTime2, b => b.AsDateTime2());
+        }
+
+        [Test]
         public void CallingAsDateTimeOffsetSetsColumnDbTypeToDateTimeOffset() 
         {
             VerifyColumnDbType(DbType.DateTimeOffset, b => b.AsDateTimeOffset());

--- a/src/FluentMigrator/Builders/ExpressionBuilderWithColumnTypesBase.cs
+++ b/src/FluentMigrator/Builders/ExpressionBuilderWithColumnTypesBase.cs
@@ -88,6 +88,12 @@ namespace FluentMigrator.Builders
             return (NextT)(object)this;
         }
 
+        public NextT AsDateTime2()
+        {
+          Column.Type = DbType.DateTime2;
+          return (NextT) (object) this;
+        }
+
         public NextT AsDateTimeOffset()
         {
             Column.Type = DbType.DateTimeOffset;

--- a/src/FluentMigrator/Builders/IColumnTypeSyntax.cs
+++ b/src/FluentMigrator/Builders/IColumnTypeSyntax.cs
@@ -34,6 +34,7 @@ namespace FluentMigrator.Builders
         TNext AsCurrency();
         TNext AsDate();
         TNext AsDateTime();
+        TNext AsDateTime2();
         TNext AsDateTimeOffset();
         TNext AsDecimal();
         TNext AsDecimal(int size, int precision);


### PR DESCRIPTION
DateTime2 was in the SqlServer2008 Map but not available as an option when altering or creating columns for a table.  
