### PR TITLE
Insert and Update support DBNull.Value in criteria expression.

### DIFF
--- a/src/FluentMigrator.Runner/Generators/Db2/Db2Generator.cs
+++ b/src/FluentMigrator.Runner/Generators/Db2/Db2Generator.cs
@@ -211,7 +211,7 @@
                     var clauses = row.Aggregate(new StringBuilder(), (acc, rowVal) =>
                     {
                         var accumulator = acc.Length == 0 ? string.Empty : " AND ";
-                        var clauseOperator = rowVal.Value == null ? "IS" : "=";
+                        var clauseOperator = (rowVal.Value == null || rowVal.Value == DBNull.Value) ? "IS" : "=";
 
                         return acc.AppendFormat("{0}{1} {2} {3}", accumulator, Quoter.QuoteColumnName(rowVal.Key), clauseOperator, Quoter.QuoteValue(rowVal.Value));
                     });

--- a/src/FluentMigrator.Runner/Generators/Generic/GenericGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/Generic/GenericGenerator.cs
@@ -310,7 +310,7 @@ namespace FluentMigrator.Runner.Generators.Generic
                 foreach (var item in expression.Where)
                 {
                     whereClauses.Add(string.Format("{0} {1} {2}", Quoter.QuoteColumnName(item.Key),
-                                                   item.Value == null ? "IS" : "=", Quoter.QuoteValue(item.Value)));
+                                                   (item.Value == null || item.Value == DBNull.Value) ? "IS" : "=", Quoter.QuoteValue(item.Value)));
                 }
             }
             return String.Format(UpdateData, Quoter.QuoteTableName(expression.TableName), String.Join(", ", updateItems.ToArray()), String.Join(" AND ", whereClauses.ToArray()));
@@ -332,7 +332,8 @@ namespace FluentMigrator.Runner.Generators.Generic
                     var whereClauses = new List<string>();
                     foreach (KeyValuePair<string, object> item in row)
                     {
-                        whereClauses.Add(string.Format("{0} {1} {2}", Quoter.QuoteColumnName(item.Key), item.Value == null ? "IS" : "=", Quoter.QuoteValue(item.Value)));
+                        whereClauses.Add(string.Format("{0} {1} {2}", Quoter.QuoteColumnName(item.Key), 
+                                                        (item.Value == null || item.Value == DBNull.Value) ? "IS" : "=", Quoter.QuoteValue(item.Value)));
                     }
 
                     deleteItems.Add(string.Format(DeleteData, Quoter.QuoteTableName(expression.TableName), String.Join(" AND ", whereClauses.ToArray())));

--- a/src/FluentMigrator.Runner/Generators/Postgres/PostgresGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/Postgres/PostgresGenerator.cs
@@ -218,7 +218,7 @@ namespace FluentMigrator.Runner.Generators.Postgres
                             where += " AND ";
                         }
 
-                        where += String.Format("{0} {1} {2}", Quoter.QuoteColumnName(item.Key), item.Value == null ? "IS" : "=", Quoter.QuoteValue(item.Value));
+                        where += String.Format("{0} {1} {2}", Quoter.QuoteColumnName(item.Key), (item.Value == null || item.Value == DBNull.Value) ? "IS" : "=", Quoter.QuoteValue(item.Value));
                         i++;
                     }
 

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2005Generator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2005Generator.cs
@@ -145,7 +145,7 @@ namespace FluentMigrator.Runner.Generators.SqlServer
                     var whereClauses = new List<string>();
                     foreach (KeyValuePair<string, object> item in row)
                     {
-                        whereClauses.Add(string.Format("{0} {1} {2}", Quoter.QuoteColumnName(item.Key), item.Value == null ? "IS" : "=", Quoter.QuoteValue(item.Value)));
+                        whereClauses.Add(string.Format("{0} {1} {2}", Quoter.QuoteColumnName(item.Key), (item.Value == null || item.Value == DBNull.Value) ? "IS" : "=", Quoter.QuoteValue(item.Value)));
                     }
 
                     deleteItems.Add(string.Format(DeleteData, Quoter.QuoteSchemaName(expression.SchemaName), Quoter.QuoteTableName(expression.TableName), String.Join(" AND ", whereClauses.ToArray())));

--- a/src/FluentMigrator.Tests/Unit/Generators/BaseDataTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/BaseDataTests.cs
@@ -8,6 +8,7 @@
         public abstract void CanDeleteDataForMultipleRowsWithDefaultSchema();
         public abstract void CanDeleteDataWithCustomSchema();
         public abstract void CanDeleteDataWithDefaultSchema();
+        public abstract void CanDeleteDataWithDbNullCriteria();
         public abstract void CanInsertDataWithCustomSchema();
         public abstract void CanInsertDataWithDefaultSchema();
         public abstract void CanInsertGuidDataWithCustomSchema();
@@ -16,5 +17,6 @@
         public abstract void CanUpdateDataForAllDataWithDefaultSchema();
         public abstract void CanUpdateDataWithCustomSchema();
         public abstract void CanUpdateDataWithDefaultSchema();
+        public abstract void CanUpdateDataWithDbNullCriteria();
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Generators/Db2/Db2DataTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/Db2/Db2DataTests.cs
@@ -77,6 +77,15 @@ namespace FluentMigrator.Tests.Unit.Generators.Db2
         }
 
         [Test]
+        public override void CanDeleteDataWithDbNullCriteria()
+        {
+            var expression = GeneratorTestHelper.GetDeleteDataExpressionWithDbNullValue();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DELETE FROM TestTable1 WHERE Name = 'Just''in' AND Website IS NULL");
+        }
+
+        [Test]
         public override void CanInsertDataWithCustomSchema()
         {
             var expression = GeneratorTestHelper.GetInsertDataExpression();
@@ -151,6 +160,15 @@ namespace FluentMigrator.Tests.Unit.Generators.Db2
 
         [Test]
         public override void CanUpdateDataWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetUpdateDataExpression();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("UPDATE TestTable1 SET Name = 'Just''in', Age = 25 WHERE Id = 9 AND Homepage IS NULL");
+        }
+
+        [Test]
+        public override void CanUpdateDataWithDbNullCriteria()
         {
             var expression = GeneratorTestHelper.GetUpdateDataExpression();
 

--- a/src/FluentMigrator.Tests/Unit/Generators/Firebird/FirebirdDataTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/Firebird/FirebirdDataTests.cs
@@ -75,6 +75,15 @@ namespace FluentMigrator.Tests.Unit.Generators.Firebird
         }
 
         [Test]
+        public override void CanDeleteDataWithDbNullCriteria()
+        {
+            var expression = GeneratorTestHelper.GetDeleteDataExpressionWithDbNullValue();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DELETE FROM TestTable1 WHERE Name = 'Just''in' AND Website IS NULL");
+        }
+
+        [Test]
         public override void CanInsertDataWithCustomSchema()
         {
             var expression = GeneratorTestHelper.GetInsertDataExpression();
@@ -149,6 +158,15 @@ namespace FluentMigrator.Tests.Unit.Generators.Firebird
 
         [Test]
         public override void CanUpdateDataWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetUpdateDataExpression();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("UPDATE TestTable1 SET Name = 'Just''in', Age = 25 WHERE Id = 9 AND Homepage IS NULL");
+        }
+
+        [Test]
+        public override void CanUpdateDataWithDbNullCriteria()
         {
             var expression = GeneratorTestHelper.GetUpdateDataExpression();
 

--- a/src/FluentMigrator.Tests/Unit/Generators/GeneratorTestHelper.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/GeneratorTestHelper.cs
@@ -240,6 +240,25 @@ namespace FluentMigrator.Tests.Unit.Generators
             return expression;
         }
 
+        public static UpdateDataExpression GetUpdateDataExpressionWithDbNullValue()
+        {
+            var expression = new UpdateDataExpression();
+            expression.TableName = TestTableName1;
+
+            expression.Set = new List<KeyValuePair<string, object>>
+                                 {
+                                     new KeyValuePair<string, object>("Name", "Just'in"),
+                                     new KeyValuePair<string, object>("Age", 25)
+                                 };
+
+            expression.Where = new List<KeyValuePair<string, object>>
+                                   {
+                                       new KeyValuePair<string, object>("Id", 9),
+                                       new KeyValuePair<string, object>("Homepage", DBNull.Value)
+                                   };
+            return expression;
+        }
+
         public static UpdateDataExpression GetUpdateDataExpressionWithAllRows()
         {
             var expression = new UpdateDataExpression();
@@ -281,6 +300,19 @@ namespace FluentMigrator.Tests.Unit.Generators
 
             return expression;
         }
+        public static DeleteDataExpression GetDeleteDataExpressionWithDbNullValue()
+        {
+            var expression = new DeleteDataExpression();
+            expression.TableName = TestTableName1;
+            expression.Rows.Add(new DeletionDataDefinition
+                                    {
+                                        new KeyValuePair<string, object>("Name", "Just'in"),
+                                        new KeyValuePair<string, object>("Website", DBNull.Value)
+                                    });
+
+            return expression;
+        }
+
 
         public static DeleteDataExpression GetDeleteDataMultipleRowsExpression()
         {

--- a/src/FluentMigrator.Tests/Unit/Generators/Hana/HanaDataTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/Hana/HanaDataTests.cs
@@ -79,6 +79,15 @@ namespace FluentMigrator.Tests.Unit.Generators.Hana
         }
 
         [Test]
+        public override void CanDeleteDataWithDbNullCriteria()
+        {
+            var expression = GeneratorTestHelper.GetDeleteDataExpressionWithDbNullValue();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DELETE FROM \"TestTable1\" WHERE \"Name\" = 'Just''in' AND \"Website\" IS NULL;");
+        }
+
+        [Test]
         public override void CanInsertDataWithCustomSchema()
         {
             Assert.Ignore("HANA does not support schema like us know schema in hana is a database name");
@@ -162,6 +171,15 @@ namespace FluentMigrator.Tests.Unit.Generators.Hana
 
         [Test]
         public override void CanUpdateDataWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetUpdateDataExpression();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("UPDATE \"TestTable1\" SET \"Name\" = 'Just''in', \"Age\" = 25 WHERE \"Id\" = 9 AND \"Homepage\" IS NULL;");
+        }
+
+        [Test]
+        public override void CanUpdateDataWithDbNullCriteria()
         {
             var expression = GeneratorTestHelper.GetUpdateDataExpression();
 

--- a/src/FluentMigrator.Tests/Unit/Generators/Jet/JetDataTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/Jet/JetDataTests.cs
@@ -73,6 +73,15 @@ namespace FluentMigrator.Tests.Unit.Generators.Jet
         }
 
         [Test]
+        public override void CanDeleteDataWithDbNullCriteria()
+        {
+            var expression = GeneratorTestHelper.GetDeleteDataExpressionWithDbNullValue();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DELETE FROM [TestTable1] WHERE [Name] = 'Just''in' AND [Website] IS NULL");
+        }
+
+        [Test]
         public override void CanInsertDataWithCustomSchema()
         {
             var expression = GeneratorTestHelper.GetInsertDataExpression();
@@ -147,6 +156,15 @@ namespace FluentMigrator.Tests.Unit.Generators.Jet
 
         [Test]
         public override void CanUpdateDataWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetUpdateDataExpression();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("UPDATE [TestTable1] SET [Name] = 'Just''in', [Age] = 25 WHERE [Id] = 9 AND [Homepage] IS NULL");
+        }
+
+        [Test]
+        public override void CanUpdateDataWithDbNullCriteria()
         {
             var expression = GeneratorTestHelper.GetUpdateDataExpression();
 

--- a/src/FluentMigrator.Tests/Unit/Generators/MySql/MySqlDataTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/MySql/MySqlDataTests.cs
@@ -73,6 +73,15 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql
         }
 
         [Test]
+        public override void CanDeleteDataWithDbNullCriteria()
+        {
+            var expression = GeneratorTestHelper.GetDeleteDataExpressionWithDbNullValue();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DELETE FROM `TestTable1` WHERE `Name` = 'Just''in' AND `Website` IS NULL");
+        }
+
+        [Test]
         public override void CanInsertDataWithCustomSchema()
         {
             var expression = GeneratorTestHelper.GetInsertDataExpression();
@@ -147,6 +156,15 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql
 
         [Test]
         public override void CanUpdateDataWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetUpdateDataExpression();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("UPDATE `TestTable1` SET `Name` = 'Just''in', `Age` = 25 WHERE `Id` = 9 AND `Homepage` IS NULL");
+        }
+
+        [Test]
+        public override void CanUpdateDataWithDbNullCriteria()
         {
             var expression = GeneratorTestHelper.GetUpdateDataExpression();
 

--- a/src/FluentMigrator.Tests/Unit/Generators/Oracle/OracleDataTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/Oracle/OracleDataTests.cs
@@ -74,6 +74,15 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
         }
 
         [Test]
+        public override void CanDeleteDataWithDbNullCriteria()
+        {
+            var expression = GeneratorTestHelper.GetDeleteDataExpressionWithDbNullValue();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DELETE FROM TestTable1 WHERE Name = 'Just''in' AND Website IS NULL");
+        }
+
+        [Test]
         public override void CanInsertDataWithCustomSchema()
         {
             var expression = GeneratorTestHelper.GetInsertDataExpression();
@@ -153,6 +162,15 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
 
         [Test]
         public override void CanUpdateDataWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetUpdateDataExpression();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("UPDATE TestTable1 SET Name = 'Just''in', Age = 25 WHERE Id = 9 AND Homepage IS NULL");
+        }
+
+        [Test]
+        public override void CanUpdateDataWithDbNullCriteria()
         {
             var expression = GeneratorTestHelper.GetUpdateDataExpression();
 

--- a/src/FluentMigrator.Tests/Unit/Generators/OracleWithQuotedIdentifier/OracleDataTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/OracleWithQuotedIdentifier/OracleDataTests.cs
@@ -74,6 +74,15 @@ namespace FluentMigrator.Tests.Unit.Generators.OracleWithQuotedIdentifier
         }
 
         [Test]
+        public override void CanDeleteDataWithDbNullCriteria()
+        {
+            var expression = GeneratorTestHelper.GetDeleteDataExpressionWithDbNullValue();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DELETE FROM \"TestTable1\" WHERE \"Name\" = 'Just''in' AND \"Website\" IS NULL");
+        }
+
+        [Test]
         public override void CanInsertDataWithCustomSchema()
         {
             var expression = GeneratorTestHelper.GetInsertDataExpression();
@@ -152,6 +161,15 @@ namespace FluentMigrator.Tests.Unit.Generators.OracleWithQuotedIdentifier
 
         [Test]
         public override void CanUpdateDataWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetUpdateDataExpression();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("UPDATE \"TestTable1\" SET \"Name\" = 'Just''in', \"Age\" = 25 WHERE \"Id\" = 9 AND \"Homepage\" IS NULL");
+        }
+
+        [Test]
+        public override void CanUpdateDataWithDbNullCriteria()
         {
             var expression = GeneratorTestHelper.GetUpdateDataExpression();
 

--- a/src/FluentMigrator.Tests/Unit/Generators/Postgres/PostgresDataTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/Postgres/PostgresDataTests.cs
@@ -73,6 +73,15 @@ namespace FluentMigrator.Tests.Unit.Generators.Postgres
         }
 
         [Test]
+        public override void CanDeleteDataWithDbNullCriteria()
+        {
+            var expression = GeneratorTestHelper.GetDeleteDataExpressionWithDbNullValue();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DELETE FROM \"public\".\"TestTable1\" WHERE \"Name\" = 'Just''in' AND \"Website\" IS NULL;");
+        }
+
+        [Test]
         public override void CanInsertDataWithCustomSchema()
         {
             var expression = GeneratorTestHelper.GetInsertDataExpression();
@@ -147,6 +156,15 @@ namespace FluentMigrator.Tests.Unit.Generators.Postgres
 
         [Test]
         public override void CanUpdateDataWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetUpdateDataExpression();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("UPDATE \"public\".\"TestTable1\" SET \"Name\" = 'Just''in', \"Age\" = 25 WHERE \"Id\" = 9 AND \"Homepage\" IS NULL;");
+        }
+
+        [Test]
+        public override void CanUpdateDataWithDbNullCriteria()
         {
             var expression = GeneratorTestHelper.GetUpdateDataExpression();
 

--- a/src/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteDataTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteDataTests.cs
@@ -75,6 +75,15 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         }
 
         [Test]
+        public override void CanDeleteDataWithDbNullCriteria()
+        {
+            var expression = GeneratorTestHelper.GetDeleteDataExpressionWithDbNullValue();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DELETE FROM \"TestTable1\" WHERE \"Name\" = 'Just''in' AND \"Website\" IS NULL");
+        }
+
+        [Test]
         public override void CanInsertDataWithCustomSchema()
         {
             var expression = GeneratorTestHelper.GetInsertDataExpression();
@@ -149,6 +158,15 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
 
         [Test]
         public override void CanUpdateDataWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetUpdateDataExpression();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("UPDATE \"TestTable1\" SET \"Name\" = 'Just''in', \"Age\" = 25 WHERE \"Id\" = 9 AND \"Homepage\" IS NULL");
+        }
+
+        [Test]
+        public override void CanUpdateDataWithDbNullCriteria()
         {
             var expression = GeneratorTestHelper.GetUpdateDataExpression();
 

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2000/SqlServer2000DataTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2000/SqlServer2000DataTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentMigrator.Runner.Extensions;
+﻿using System;
+using FluentMigrator.Runner.Extensions;
 using FluentMigrator.Runner.Generators.SqlServer;
 using NUnit.Framework;
 using NUnit.Should;
@@ -68,6 +69,15 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2000
         public override void CanDeleteDataWithDefaultSchema()
         {
             var expression = GeneratorTestHelper.GetDeleteDataExpression();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DELETE FROM [TestTable1] WHERE [Name] = 'Just''in' AND [Website] IS NULL");
+        }
+
+        [Test]
+        public override void CanDeleteDataWithDbNullCriteria()
+        {
+            var expression = GeneratorTestHelper.GetDeleteDataExpressionWithDbNullValue();
 
             var result = Generator.Generate(expression);
             result.ShouldBe("DELETE FROM [TestTable1] WHERE [Name] = 'Just''in' AND [Website] IS NULL");
@@ -148,6 +158,15 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2000
 
         [Test]
         public override void CanUpdateDataWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetUpdateDataExpression();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("UPDATE [TestTable1] SET [Name] = 'Just''in', [Age] = 25 WHERE [Id] = 9 AND [Homepage] IS NULL");
+        }
+
+        [Test]
+        public override void CanUpdateDataWithDbNullCriteria()
         {
             var expression = GeneratorTestHelper.GetUpdateDataExpression();
 

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005DataTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005DataTests.cs
@@ -74,6 +74,15 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
         }
 
         [Test]
+        public override void CanDeleteDataWithDbNullCriteria()
+        {
+            var expression = GeneratorTestHelper.GetDeleteDataExpressionWithDbNullValue();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DELETE FROM [dbo].[TestTable1] WHERE [Name] = 'Just''in' AND [Website] IS NULL");
+        }
+
+        [Test]
         public override void CanInsertDataWithCustomSchema()
         {
             var expression = GeneratorTestHelper.GetInsertDataExpression();
@@ -148,6 +157,15 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
 
         [Test]
         public override void CanUpdateDataWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetUpdateDataExpression();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("UPDATE [dbo].[TestTable1] SET [Name] = 'Just''in', [Age] = 25 WHERE [Id] = 9 AND [Homepage] IS NULL");
+        }
+
+        [Test]
+        public override void CanUpdateDataWithDbNullCriteria()
         {
             var expression = GeneratorTestHelper.GetUpdateDataExpression();
 

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServerCe/SqlServerCeDataTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServerCe/SqlServerCeDataTests.cs
@@ -74,6 +74,15 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServerCe
         }
 
         [Test]
+        public override void CanDeleteDataWithDbNullCriteria()
+        {
+            var expression = GeneratorTestHelper.GetDeleteDataExpressionWithDbNullValue();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DELETE FROM [TestTable1] WHERE [Name] = 'Just''in' AND [Website] IS NULL");
+        }
+
+        [Test]
         public override void CanInsertDataWithCustomSchema()
         {
             var expression = GeneratorTestHelper.GetInsertDataExpression();
@@ -148,6 +157,15 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServerCe
 
         [Test]
         public override void CanUpdateDataWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetUpdateDataExpression();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("UPDATE [TestTable1] SET [Name] = 'Just''in', [Age] = 25 WHERE [Id] = 9 AND [Homepage] IS NULL");
+        }
+
+        [Test]
+        public override void CanUpdateDataWithDbNullCriteria()
         {
             var expression = GeneratorTestHelper.GetUpdateDataExpression();
 


### PR DESCRIPTION
Since a where clause cannot use anonymous types with properties set to null, support for DBNull.Value is implemented.

This expression is invalid:
`.Where(new { StatusId = null })`

This expression is valid:
`.Where(new { StatusId = DBNull.Value })`

Support is added for all Generator types in master branch and new unit tests for all Generator types has been created to verify that both delete and update expressions support DBNull.Value.
