### PR TITLE
Removed methods from AutoReversingMigration that can create non-autor…

### DIFF
--- a/src/FluentMigrator/AutoReversingMigration.cs
+++ b/src/FluentMigrator/AutoReversingMigration.cs
@@ -36,23 +36,5 @@ namespace FluentMigrator
             GetUpExpressions(context);
             context.Expressions = context.Expressions.Select(e => e.Reverse()).Reverse().ToList();
         }
-
-        [Obsolete("Delete cannot auto-reversed and will no longer be available for auto-reversing migrations.", false)]
-        public IDeleteExpressionRoot Delete
-        {
-            get { return new DeleteExpressionRoot(_context); }
-        }
-
-        [Obsolete("Execute cannot auto-reversed and will no longer be available for auto-reversing migrations.", false)]
-        public IExecuteExpressionRoot Execute
-        {
-            get { return new ExecuteExpressionRoot(_context); }
-        }
-
-        [Obsolete("Update cannot auto-reversed and will no longer be available for auto-reversing migrations.", false)]
-        public IUpdateExpressionRoot Update
-        {
-            get { return new UpdateExpressionRoot(_context); }
-        }
     }
 }


### PR DESCRIPTION
…eversible migrations.

Fixes #439 .

In response to the ticket: I think it is worth actually defining which migrations are possible and which aren't. Why not remove the ability to even make the mistake by disallowing the use of the 'Create' etc. functions?
