### PR TITLE
Add optional constructor VersionTableMetaData parameter to MigrationRunner and VersionLoader

### DIFF
--- a/src/FluentMigrator.Runner/ConnectionlessVersionLoader.cs
+++ b/src/FluentMigrator.Runner/ConnectionlessVersionLoader.cs
@@ -13,7 +13,7 @@ namespace FluentMigrator.Runner
     {
         private bool _versionsLoaded;
 
-        public ConnectionlessVersionLoader(IMigrationRunner runner, IAssemblyCollection assemblies, IMigrationConventions conventions, long startVersion, long targetVersion)
+        public ConnectionlessVersionLoader(IMigrationRunner runner, IAssemblyCollection assemblies, IMigrationConventions conventions, long startVersion, long targetVersion, IVersionTableMetaData versionTableMetaData = null)
         {
             Runner = runner;
             Assemblies = assemblies;
@@ -24,7 +24,7 @@ namespace FluentMigrator.Runner
             Processor = Runner.Processor;
 
             VersionInfo = new VersionInfo();
-            VersionTableMetaData = GetVersionTableMetaData();
+            VersionTableMetaData = versionTableMetaData ?? GetVersionTableMetaData();
             VersionMigration = new VersionMigration(VersionTableMetaData);
             VersionSchemaMigration = new VersionSchemaMigration(VersionTableMetaData);
             VersionUniqueMigration = new VersionUniqueMigration(VersionTableMetaData);

--- a/src/FluentMigrator.Runner/MigrationRunner.cs
+++ b/src/FluentMigrator.Runner/MigrationRunner.cs
@@ -28,6 +28,7 @@ using FluentMigrator.Runner.Initialization;
 using FluentMigrator.Runner.Processors;
 using FluentMigrator.Runner.Versioning;
 using FluentMigrator.Infrastructure.Extensions;
+using FluentMigrator.VersionTableInfo;
 
 namespace FluentMigrator.Runner
 {
@@ -68,13 +69,19 @@ namespace FluentMigrator.Runner
 
         public IRunnerContext RunnerContext { get; private set; }
 
+        public MigrationRunner(Assembly assembly, IRunnerContext runnerContext, IMigrationProcessor processor, IVersionTableMetaData versionTableMetaData)
+          : this(new SingleAssembly(assembly), runnerContext, processor, versionTableMetaData)
+        {
+
+        }
+
         public MigrationRunner(Assembly assembly, IRunnerContext runnerContext, IMigrationProcessor processor)
           : this(new SingleAssembly(assembly), runnerContext, processor)
         {
 
         }
 
-        public MigrationRunner(IAssemblyCollection assemblies, IRunnerContext runnerContext, IMigrationProcessor processor)
+        public MigrationRunner(IAssemblyCollection assemblies, IRunnerContext runnerContext, IMigrationProcessor processor, IVersionTableMetaData versionTableMetaData = null)
         {
             _migrationAssemblies = assemblies;
             _announcer = runnerContext.Announcer;
@@ -96,10 +103,10 @@ namespace FluentMigrator.Runner
             MaintenanceLoader = new MaintenanceLoader(_migrationAssemblies, runnerContext.Tags, Conventions);
 
             if (runnerContext.NoConnection){
-                VersionLoader = new ConnectionlessVersionLoader(this, _migrationAssemblies, Conventions, runnerContext.StartVersion, runnerContext.Version);
+                VersionLoader = new ConnectionlessVersionLoader(this, _migrationAssemblies, Conventions, runnerContext.StartVersion, runnerContext.Version, versionTableMetaData);
             }
             else{
-                VersionLoader = new VersionLoader(this, _migrationAssemblies, Conventions);
+                VersionLoader = new VersionLoader(this, _migrationAssemblies, Conventions, versionTableMetaData);
             }
         }
 

--- a/src/FluentMigrator.Runner/VersionLoader.cs
+++ b/src/FluentMigrator.Runner/VersionLoader.cs
@@ -29,19 +29,19 @@ namespace FluentMigrator.Runner
         public IMigration VersionUniqueMigration { get; private set; }
         public IMigration VersionDescriptionMigration { get; private set; }
 
-        public VersionLoader(IMigrationRunner runner, Assembly assembly, IMigrationConventions conventions)
-          : this(runner, new SingleAssembly(assembly), conventions)
+        public VersionLoader(IMigrationRunner runner, Assembly assembly, IMigrationConventions conventions, IVersionTableMetaData versionTableMetaData = null)
+          : this(runner, new SingleAssembly(assembly), conventions, versionTableMetaData)
         {
         }
 
-        public VersionLoader(IMigrationRunner runner, IAssemblyCollection assemblies, IMigrationConventions conventions)
+        public VersionLoader(IMigrationRunner runner, IAssemblyCollection assemblies, IMigrationConventions conventions, IVersionTableMetaData versionTableMetaData = null)
         {
             Runner = runner;
             Processor = runner.Processor;
             Assemblies = assemblies;
 
             Conventions = conventions;
-            VersionTableMetaData = GetVersionTableMetaData();
+            VersionTableMetaData = versionTableMetaData ?? GetVersionTableMetaData();
             VersionMigration = new VersionMigration(VersionTableMetaData);
             VersionSchemaMigration = new VersionSchemaMigration(VersionTableMetaData);
             VersionUniqueMigration = new VersionUniqueMigration(VersionTableMetaData);


### PR DESCRIPTION
Add optional constructor VersionTableMetaData parameter to MigrationRunner and VersionLoader.
This enables runtime configuration of VersionTableMetaData.

This change is based on @ioleksiy change #488.
#### Use case

We are developing a multitenant application with one schema per tenant and one common schema that is shared between all tenants. We therefore need one VersionInfo table per schema, the existing solution does not support this. 
Currently fluentmigrator only supports one VersionTable (https://github.com/schambers/fluentmigrator/wiki/Create-custom-metadata-for-the-VersionInfo-table).

This change enables us to dynamically alter the VersionTableMetaData in runtime.

Example usage:

``` csharp
private static string _schema;

[VersionTableMetaData]
public class VersionTable : DefaultVersionTableMetaData
{
    public override string SchemaName => _schema;
}

public void MigrateToLatest(string connectionString, string schema) {
    _schema = schema;

    using (var processor = _factory.Create(connectionString, _announcer, _options))
    {
        IVersionTableMetaData versionMetadata = new VersionTable { };
        var runner = new MigrationRunner(_assembly, migrationContext, processor, versionMetadata);
        runner.MigrateUp(true);
    }
}
```
#### Related issues

Added ability to pass VersionMetaData directly to MigrationRunner #488
Enable FluentMigrator extensibility with new IRunnerFactory #287
