### PR TITLE
Enable delegation to methods for IfDatabase expressions

### DIFF
--- a/src/FluentMigrator/Builders/IfDatabase/IIfDatabaseExpressionRoot.cs
+++ b/src/FluentMigrator/Builders/IfDatabase/IIfDatabaseExpressionRoot.cs
@@ -26,6 +26,7 @@ using FluentMigrator.Builders.Insert;
 using FluentMigrator.Builders.Rename;
 using FluentMigrator.Builders.Schema;
 using FluentMigrator.Builders.Update;
+using System;
 
 namespace FluentMigrator.Builders.IfDatabase
 {
@@ -49,5 +50,7 @@ namespace FluentMigrator.Builders.IfDatabase
         ISchemaExpressionRoot Schema { get; }
 
         IUpdateExpressionRoot Update { get; }
+
+        void Delegate(Action delegation);
     }
 }

--- a/src/FluentMigrator/Builders/IfDatabase/IfDatabaseExpressionRoot.cs
+++ b/src/FluentMigrator/Builders/IfDatabase/IfDatabaseExpressionRoot.cs
@@ -135,5 +135,14 @@ namespace FluentMigrator.Builders.IfDatabase
 
             return false;
         }
+
+        public void Delegate(Action delegation)
+        {
+            if (_context.QuerySchema is NullIfDatabaseProcessor)
+            {
+                return;
+            }
+            delegation.Invoke();
+        }
     }
 }


### PR DESCRIPTION
Enable delegation to methods for IfDatabase expressions within the same migration class.

This enables writing well separated migration rules for different database systems with help of fluentmigrator instead of having to write downright sql scripts for differentiation.

Example:

```
        public override void Up()
        {
            IfDatabase("MySql").Delegate(MigrateMySql);
            IfDatabase("SqlServer").Delegate(MigrateSqlServer);
            IfDatabase("Postgres").Delegate(MigratePostgreSql);
        }

        void MigrateMySql() 
        {
            //Do your MySql stuff here
        }

        void MigrateSqlServer() 
        {
            //Do your Microsoft Sql Server stuff here
        }

        void MigratePostgreSql() 
        {
            //Do your Postgres stuff here
        }
```
