### PR TITLE
Unique index with support for multiple null values

### DIFF
--- a/src/FluentMigrator.Runner/Generators/Firebird/FirebirdGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/Firebird/FirebirdGenerator.cs
@@ -87,7 +87,8 @@ namespace FluentMigrator.Runner.Generators.Firebird
                 , indexDirection == Direction.Ascending ? "ASC " : "DESC "
                 , Quoter.QuoteIndexName(expression.Index.Name)
                 , Quoter.QuoteTableName(expression.Index.TableName)
-                , indexColumns.ToString());
+                , indexColumns.ToString()
+                , GetWithNullsDistinctString(expression.Index));
         }
 
         public override string Generate(AlterColumnExpression expression)

--- a/src/FluentMigrator.Runner/Generators/Generic/GenericGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/Generic/GenericGenerator.cs
@@ -33,7 +33,7 @@ namespace FluentMigrator.Runner.Generators.Generic
         public virtual string AlterSchema { get { return "ALTER SCHEMA {0} TRANSFER {1}.{2}"; } }
         public virtual string DropSchema { get { return "DROP SCHEMA {0}"; } }
 
-        public virtual string CreateIndex { get { return "CREATE {0}{1}INDEX {2} ON {3} ({4})"; } }
+        public virtual string CreateIndex { get { return "CREATE {0}{1}INDEX {2} ON {3} ({4}){5}"; } }
         public virtual string DropIndex { get { return "DROP INDEX {0}"; } }
 
         public virtual string InsertData { get { return "INSERT INTO {0} ({1}) VALUES ({2})"; } }
@@ -51,6 +51,20 @@ namespace FluentMigrator.Runner.Generators.Generic
 
         public virtual string GetClusterTypeString(CreateIndexExpression column)
         {
+            return string.Empty;
+        }
+
+        public virtual string GetWithNullsDistinctString(IndexDefinition index)
+        {
+            if (index.IsNullDistinct.HasValue && !index.IsUnique)
+            {
+                compatabilityMode.HandleCompatabilty("With nulls distinct can only be used for unique indexes");
+            }
+            else if (index.IsNullDistinct.HasValue)
+            {
+                compatabilityMode.HandleCompatabilty("With nulls distinct is not supported");
+            }
+
             return string.Empty;
         }
 
@@ -144,7 +158,8 @@ namespace FluentMigrator.Runner.Generators.Generic
                 , GetClusterTypeString(expression)
                 , Quoter.QuoteIndexName(expression.Index.Name)
                 , Quoter.QuoteTableName(expression.Index.TableName)
-                , String.Join(", ", indexColumns));
+                , String.Join(", ", indexColumns)
+                , GetWithNullsDistinctString(expression.Index));
         }
 
         public override string Generate(DeleteIndexExpression expression)

--- a/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -463,6 +463,7 @@
     <Compile Include="Unit\Generators\SqlServer2005\SqlServer2005SchemaTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2005\SqlServer2005TableTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2008\SqlServer2008GeneratorTests.cs" />
+    <Compile Include="Unit\Generators\SqlServer2008\SqlServer2008IndexTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2012\SqlServer2012SequenceTests.cs" />
     <Compile Include="Unit\Generators\SqlServerCe\SqlServerCeColumnTests.cs" />
     <Compile Include="Unit\Generators\SqlServerCe\SqlServerCeConstraintsTests.cs" />

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2008/SqlServer2008IndexTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2008/SqlServer2008IndexTests.cs
@@ -1,18 +1,22 @@
 ﻿using FluentMigrator.Runner.Generators.SqlServer;
 using NUnit.Framework;
 using NUnit.Should;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
-namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
+namespace FluentMigrator.Tests.Unit.Generators.SqlServer2008
 {
     [TestFixture]
-    public class SqlServer2005IndexTests : BaseIndexTests
+    public class SqlServer2008IndexTests : BaseIndexTests
     {
-        protected SqlServer2005Generator Generator;
+        protected SqlServer2008Generator Generator;
 
         [SetUp]
         public void Setup()
         {
-            Generator = new SqlServer2005Generator();
+            Generator = new SqlServer2008Generator();
         }
 
         [Test]
@@ -121,13 +125,23 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
         }
 
         [Test]
-        public void CanCreateUniqueIndexIgnoringNonDistinctNulls()
+        public void CanCreateUniqueIndexWithNonDistinctNulls()
         {
             var expression = GeneratorTestHelper.GetCreateUniqueIndexExpression();
             expression.Index.IsNullDistinct = false;
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE UNIQUE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC)");
+            result.ShouldBe("CREATE UNIQUE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC) WHERE [TestColumn1] IS NOT NULL");
+        }
+
+        [Test]
+        public void CanCreateMultiColumnUniqueIndexWithNonDistinctNulls()
+        {
+            var expression = GeneratorTestHelper.GetCreateUniqueMultiColumnIndexExpression();
+            expression.Index.IsNullDistinct = false;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE UNIQUE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC, [TestColumn2] DESC) WHERE [TestColumn1] IS NOT NULL AND [TestColumn2] IS NOT NULL");
         }
     }
 }

--- a/src/FluentMigrator/Builders/Create/Index/CreateIndexExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Create/Index/CreateIndexExpressionBuilder.cs
@@ -25,6 +25,7 @@ namespace FluentMigrator.Builders.Create.Index
         ICreateIndexForTableSyntax,
         ICreateIndexOnColumnOrInSchemaSyntax,
         ICreateIndexColumnOptionsSyntax,
+        ICreateIndexUniqueOptionsSyntax,
         ICreateIndexOptionsSyntax
     {
         public IndexColumnDefinition CurrentColumn { get; set; }
@@ -76,9 +77,27 @@ namespace FluentMigrator.Builders.Create.Index
             return this;
         }
 
-        public ICreateIndexOnColumnSyntax Unique()
+        public ICreateIndexUniqueOptionsSyntax Unique()
         {
             Expression.Index.IsUnique = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Multiple rows with null values in index column(s) will be allowed.
+        /// </summary>
+        public ICreateIndexOptionsSyntax WithNullsNotDistinct()
+        {
+            Expression.Index.IsNullDistinct = false;
+            return this;
+        }
+
+        /// <summary>
+        /// Only one row with null values in index column(s) will be allowed.
+        /// </summary>
+        public ICreateIndexOptionsSyntax WithNullsDistinct()
+        {
+            Expression.Index.IsNullDistinct = true;
             return this;
         }
 

--- a/src/FluentMigrator/Builders/Create/Index/ICreateIndexOptionsSyntax.cs
+++ b/src/FluentMigrator/Builders/Create/Index/ICreateIndexOptionsSyntax.cs
@@ -20,7 +20,7 @@ namespace FluentMigrator.Builders.Create.Index
 {
     public interface ICreateIndexOptionsSyntax
     {
-        ICreateIndexOnColumnSyntax Unique();
+        ICreateIndexUniqueOptionsSyntax Unique();
         ICreateIndexOnColumnSyntax NonClustered();
         ICreateIndexOnColumnSyntax Clustered();
     }

--- a/src/FluentMigrator/Builders/Create/Index/ICreateIndexUniqueOptionsSyntax.cs
+++ b/src/FluentMigrator/Builders/Create/Index/ICreateIndexUniqueOptionsSyntax.cs
@@ -1,0 +1,21 @@
+﻿namespace FluentMigrator.Builders.Create.Index
+{
+    /// <summary>
+    /// Special options for unique indexes combined with default create index options.
+    /// </summary>
+    public interface ICreateIndexUniqueOptionsSyntax
+    {
+        /// <summary>
+        /// Multiple rows with null values in index column(s) will be allowed.
+        /// </summary>
+        ICreateIndexOptionsSyntax WithNullsNotDistinct();
+        /// <summary>
+        /// Only one row with null values in index column(s) will be allowed.
+        /// </summary>
+        ICreateIndexOptionsSyntax WithNullsDistinct();
+        /// <summary>
+        /// Specify more options for the index.
+        /// </summary>
+        ICreateIndexOptionsSyntax WithOptions();
+    }
+}

--- a/src/FluentMigrator/FluentMigrator.csproj
+++ b/src/FluentMigrator/FluentMigrator.csproj
@@ -122,6 +122,7 @@
     <Compile Include="..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="Builders\Create\Index\ICreateIndexUniqueOptionsSyntax.cs" />
     <Compile Include="MigrationStage.cs" />
     <Compile Include="MaintenanceAttribute.cs" />
     <Compile Include="Builders\Alter\AlterExpressionRoot.cs" />

--- a/src/FluentMigrator/Model/IndexDefinition.cs
+++ b/src/FluentMigrator/Model/IndexDefinition.cs
@@ -31,6 +31,7 @@ namespace FluentMigrator.Model
         public virtual string TableName { get; set; }
         public virtual bool IsUnique { get; set; }
         public bool IsClustered { get; set; }
+        public bool? IsNullDistinct { get; set; }
         public virtual ICollection<IndexColumnDefinition> Columns { get; set; }
         public virtual ICollection<IndexIncludeDefinition> Includes { get; set; }
 


### PR DESCRIPTION
Related to PR #659 unique indexes that allow multiple rows with null values is a feature to support for SQL Anywhere databases. After further investigation, I found that a similar unique index is supported by SQL Server 2008 and up as well: http://stackoverflow.com/questions/767657/how-do-i-create-a-unique-constraint-that-also-allows-nulls

This PR replaces commit cc97bbb in #659 and additionally adds support for SQL Server 2008 and up.
