### PR TITLE
Unique index with support for multiple null values per column

### DIFF
--- a/src/FluentMigrator.Runner/Generators/Generic/GenericGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/Generic/GenericGenerator.cs
@@ -54,6 +54,20 @@ namespace FluentMigrator.Runner.Generators.Generic
             return string.Empty;
         }
 
+        public virtual string GetWithNullsDistinctString(IndexDefinition index)
+        {
+            if (index.Columns.Where(c => c.IsNullDistinct.HasValue).Any() && !index.IsUnique)
+            {
+                compatabilityMode.HandleCompatabilty("With nulls distinct can only be used for unique indexes");
+            }
+            else if (index.Columns.Where(c => c.IsNullDistinct.HasValue).Any())
+            {
+                compatabilityMode.HandleCompatabilty("With nulls distinct is not supported");
+            }
+
+            return string.Empty;
+        }
+
         /// <summary>
         /// Outputs a create table string
         /// </summary>

--- a/src/FluentMigrator.Runner/Generators/Generic/GenericGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/Generic/GenericGenerator.cs
@@ -153,6 +153,8 @@ namespace FluentMigrator.Runner.Generators.Generic
                 }
             }
 
+            GetWithNullsDistinctString(expression.Index);  // Runs validation and throws in strict mode
+
             return String.Format(CreateIndex
                 , GetUniqueString(expression)
                 , GetClusterTypeString(expression)

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2005Generator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2005Generator.cs
@@ -265,6 +265,8 @@ namespace FluentMigrator.Runner.Generators.SqlServer
                 indexIncludes[i] = Quoter.QuoteColumnName(includeDef.Name);
             }
 
+            GetWithNullsDistinctString(expression.Index);  // Runs validation and throws in strict mode
+
             return String.Format(CreateIndex
                 , GetUniqueString(expression)
                 , GetClusterTypeString(expression)

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2008Generator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2008Generator.cs
@@ -42,21 +42,14 @@ namespace FluentMigrator.Runner.Generators.SqlServer
                 compatabilityMode.HandleCompatabilty("With nulls distinct can only be used for unique indexes");
             }
 
-            return string.Empty;
-        }
-
-        public override string Generate(CreateIndexExpression expression)
-        {
-            string sql = base.Generate(expression);
-
-            if (expression.Index.IsUnique)
+            if (index.IsUnique)
             {
                 bool isFirstColumn = true;
                 bool appendFilterToSql = false;
                 StringBuilder filterSql = new StringBuilder();
                 filterSql.AppendFormat(" WHERE");
 
-                foreach (var column in expression.Index.Columns)
+                foreach (var column in index.Columns)
                 {
                     if (column.IsNullDistinct.HasValue && column.IsNullDistinct.Value == false)
                     {
@@ -70,9 +63,17 @@ namespace FluentMigrator.Runner.Generators.SqlServer
                 }
 
                 if (appendFilterToSql)
-                    sql += filterSql.ToString();
+                    return filterSql.ToString();
             }
 
+            return string.Empty;
+        }
+
+        public override string Generate(CreateIndexExpression expression)
+        {
+            string sql = base.Generate(expression);
+            sql += GetWithNullsDistinctString(expression.Index);
+            
             return sql;
         }
 

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2008Generator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2008Generator.cs
@@ -16,6 +16,11 @@
 //
 #endregion
 
+using FluentMigrator.Expressions;
+using FluentMigrator.Model;
+using System.Linq;
+using System.Text;
+
 namespace FluentMigrator.Runner.Generators.SqlServer
 {
     public class SqlServer2008Generator : SqlServer2005Generator
@@ -29,5 +34,47 @@ namespace FluentMigrator.Runner.Generators.SqlServer
             :base(column, descriptionGenerator)
         {
         }
+
+        public override string GetWithNullsDistinctString(IndexDefinition index)
+        {
+            if (index.Columns.Where(c => c.IsNullDistinct.HasValue).Any() && !index.IsUnique)
+            {
+                compatabilityMode.HandleCompatabilty("With nulls distinct can only be used for unique indexes");
+            }
+
+            return string.Empty;
+        }
+
+        public override string Generate(CreateIndexExpression expression)
+        {
+            string sql = base.Generate(expression);
+
+            if (expression.Index.IsUnique)
+            {
+                bool isFirstColumn = true;
+                bool appendFilterToSql = false;
+                StringBuilder filterSql = new StringBuilder();
+                filterSql.AppendFormat(" WHERE");
+
+                foreach (var column in expression.Index.Columns)
+                {
+                    if (column.IsNullDistinct.HasValue && column.IsNullDistinct.Value == false)
+                    {
+                        if (!isFirstColumn)
+                            filterSql.AppendFormat(" AND");
+
+                        filterSql.AppendFormat(" {0} IS NOT NULL", Quoter.QuoteColumnName(column.Name));
+                        isFirstColumn = false;
+                        appendFilterToSql = true;
+                    }
+                }
+
+                if (appendFilterToSql)
+                    sql += filterSql.ToString();
+            }
+
+            return sql;
+        }
+
     }
 }

--- a/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -463,6 +463,7 @@
     <Compile Include="Unit\Generators\SqlServer2005\SqlServer2005SchemaTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2005\SqlServer2005TableTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2008\SqlServer2008GeneratorTests.cs" />
+    <Compile Include="Unit\Generators\SqlServer2008\SqlServer2008IndexTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2012\SqlServer2012SequenceTests.cs" />
     <Compile Include="Unit\Generators\SqlServerCe\SqlServerCeColumnTests.cs" />
     <Compile Include="Unit\Generators\SqlServerCe\SqlServerCeConstraintsTests.cs" />

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2008/SqlServer2008IndexTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2008/SqlServer2008IndexTests.cs
@@ -3,17 +3,17 @@ using NUnit.Framework;
 using NUnit.Should;
 using System.Linq;
 
-namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
+namespace FluentMigrator.Tests.Unit.Generators.SqlServer2008
 {
     [TestFixture]
-    public class SqlServer2005IndexTests : BaseIndexTests
+    public class SqlServer2008IndexTests : BaseIndexTests
     {
-        protected SqlServer2005Generator Generator;
+        protected SqlServer2008Generator Generator;
 
         [SetUp]
         public void Setup()
         {
-            Generator = new SqlServer2005Generator();
+            Generator = new SqlServer2008Generator();
         }
 
         [Test]
@@ -122,13 +122,35 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
         }
 
         [Test]
-        public void CanCreateUniqueIndexIgnoringNonDistinctNulls()
+        public void CanCreateUniqueIndexWithNonDistinctNulls()
         {
             var expression = GeneratorTestHelper.GetCreateUniqueIndexExpression();
             expression.Index.Columns.First().IsNullDistinct = false;
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE UNIQUE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC)");
+            result.ShouldBe("CREATE UNIQUE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC) WHERE [TestColumn1] IS NOT NULL");
+        }
+
+        [Test]
+        public void CanCreateMultiColumnUniqueIndexWithOneNonDistinctNulls()
+        {
+            var expression = GeneratorTestHelper.GetCreateUniqueMultiColumnIndexExpression();
+            expression.Index.Columns.First().IsNullDistinct = false;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE UNIQUE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC, [TestColumn2] DESC) WHERE [TestColumn1] IS NOT NULL");
+        }
+
+        [Test]
+        public void CanCreateMultiColumnUniqueIndexWithTwoNonDistinctNulls()
+        {
+            var expression = GeneratorTestHelper.GetCreateUniqueMultiColumnIndexExpression();
+
+            foreach(var c in expression.Index.Columns)
+                c.IsNullDistinct = false;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE UNIQUE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC, [TestColumn2] DESC) WHERE [TestColumn1] IS NOT NULL AND [TestColumn2] IS NOT NULL");
         }
     }
 }

--- a/src/FluentMigrator/Builders/Create/Index/CreateIndexExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Create/Index/CreateIndexExpressionBuilder.cs
@@ -25,6 +25,7 @@ namespace FluentMigrator.Builders.Create.Index
         ICreateIndexForTableSyntax,
         ICreateIndexOnColumnOrInSchemaSyntax,
         ICreateIndexColumnOptionsSyntax,
+        ICreateIndexMoreColumnOptionsSyntax,
         ICreateIndexOptionsSyntax
     {
         public IndexColumnDefinition CurrentColumn { get; set; }
@@ -58,13 +59,13 @@ namespace FluentMigrator.Builders.Create.Index
             return this;
         }
 
-        public ICreateIndexOnColumnSyntax Ascending()
+        public ICreateIndexMoreColumnOptionsSyntax Ascending()
         {
             CurrentColumn.Direction = Direction.Ascending;
             return this;
         }
 
-        public ICreateIndexOnColumnSyntax Descending()
+        public ICreateIndexMoreColumnOptionsSyntax Descending()
         {
             CurrentColumn.Direction = Direction.Descending;
             return this;
@@ -73,6 +74,24 @@ namespace FluentMigrator.Builders.Create.Index
         ICreateIndexOnColumnSyntax ICreateIndexColumnOptionsSyntax.Unique()
         {
             Expression.Index.IsUnique = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Column should have unique values, but multiple rows with null values should be accepted.
+        /// </summary>
+        public ICreateIndexOnColumnSyntax UniqueWithNullsNotDistinct()
+        {
+            CurrentColumn.IsNullDistinct = false;
+            return this;
+        }
+
+        /// <summary>
+        /// Column should have unique values. Only one row with null value should be accepted (default for most known database engines).
+        /// </summary>
+        public ICreateIndexOnColumnSyntax UniqueWithNullsDistinct()
+        {
+            CurrentColumn.IsNullDistinct = true;
             return this;
         }
 

--- a/src/FluentMigrator/Builders/Create/Index/ICreateIndexColumnOptionsSyntax.cs
+++ b/src/FluentMigrator/Builders/Create/Index/ICreateIndexColumnOptionsSyntax.cs
@@ -20,8 +20,16 @@ namespace FluentMigrator.Builders.Create.Index
 {
     public interface ICreateIndexColumnOptionsSyntax
     {
-        ICreateIndexOnColumnSyntax Ascending();
-        ICreateIndexOnColumnSyntax Descending();
+        ICreateIndexMoreColumnOptionsSyntax Ascending();
+        ICreateIndexMoreColumnOptionsSyntax Descending();
         ICreateIndexOnColumnSyntax Unique();
+        /// <summary>
+        /// Column should have unique values, but multiple rows with null values should be accepted.
+        /// </summary>
+        ICreateIndexOnColumnSyntax UniqueWithNullsNotDistinct();
+        /// <summary>
+        /// Column should have unique values. Only one row with null value should be accepted (default for most known database engines).
+        /// </summary>
+        ICreateIndexOnColumnSyntax UniqueWithNullsDistinct();
     }
 }

--- a/src/FluentMigrator/Builders/Create/Index/ICreateIndexMoreColumnOptionsSyntax.cs
+++ b/src/FluentMigrator/Builders/Create/Index/ICreateIndexMoreColumnOptionsSyntax.cs
@@ -1,0 +1,17 @@
+﻿namespace FluentMigrator.Builders.Create.Index
+{
+    /// <summary>
+    /// Syntax for continue setting more column options or add another column to the index.
+    /// </summary>
+    public interface ICreateIndexMoreColumnOptionsSyntax : ICreateIndexOnColumnSyntax
+    {
+        /// <summary>
+        /// Column should have unique values, but multiple rows with null values should be accepted.
+        /// </summary>
+        ICreateIndexOnColumnSyntax UniqueWithNullsNotDistinct();
+        /// <summary>
+        /// Column should have unique values. Only one row with null value should be accepted (default for most known database engines).
+        /// </summary>
+        ICreateIndexOnColumnSyntax UniqueWithNullsDistinct();
+    }
+}

--- a/src/FluentMigrator/FluentMigrator.csproj
+++ b/src/FluentMigrator/FluentMigrator.csproj
@@ -122,6 +122,7 @@
     <Compile Include="..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="Builders\Create\Index\ICreateIndexMoreColumnOptionsSyntax.cs" />
     <Compile Include="MigrationStage.cs" />
     <Compile Include="MaintenanceAttribute.cs" />
     <Compile Include="Builders\Alter\AlterExpressionRoot.cs" />

--- a/src/FluentMigrator/Model/IndexColumnDefinition.cs
+++ b/src/FluentMigrator/Model/IndexColumnDefinition.cs
@@ -26,6 +26,10 @@ namespace FluentMigrator.Model
     {
         public virtual string Name { get; set; }
         public virtual Direction Direction { get; set; }
+        /// <summary>
+        /// Gets or sets whether or not a unique index should treat null values as distinct for this column.
+        /// </summary>
+        public bool? IsNullDistinct { get; set; }
 
         public virtual void CollectValidationErrors(ICollection<string> errors)
         {


### PR DESCRIPTION
Related to PR #659 unique indexes that allow multiple rows with null values is a feature to support for SQL Anywhere databases. After further investigation, I found that a similar unique index is supported by SQL Server 2008 and up as well: http://stackoverflow.com/questions/767657/how-do-i-create-a-unique-constraint-that-also-allows-nulls

This PR replaces commit  cc97bbb  in #659 and additionally adds support for SQL Server 2008 and up.

The difference between this and PR #716 is that this PR supports setting the `WithNullsNotDistinct` option on a per-column basis, which is possible in SQL Server 2008 and up.
