### PR TITLE
ListMigrations says "(not applied)" for migrations not applied.

### DIFF
--- a/src/FluentMigrator.Runner/MigrationRunner.cs
+++ b/src/FluentMigrator.Runner/MigrationRunner.cs
@@ -537,9 +537,10 @@ namespace FluentMigrator.Runner
             {
                 string migrationName = migration.Value.GetName();
                 bool isCurrent = migration.Key == currentVersion;
+                bool isApplied = VersionLoader.VersionInfo.HasAppliedMigration(migration.Value.Version);
                 string message = string.Format("{0}{1}",
                                                 migrationName,
-                                                isCurrent ? " (current)" : string.Empty);
+                                                (isCurrent ? " (current)" : (isApplied ? string.Empty : " (not applied)")));
 
                 if(isCurrent)
                     _announcer.Emphasize(message);

--- a/src/FluentMigrator.Tests/Unit/MigrationRunnerTests.cs
+++ b/src/FluentMigrator.Tests/Unit/MigrationRunnerTests.cs
@@ -478,20 +478,24 @@ namespace FluentMigrator.Tests.Unit
         {
             const long version1 = 2011010101;
             const long version2 = 2011010102;
+            const long version3 = 2011010103;
 
             var mockMigration1 = new Mock<IMigration>();
             var mockMigration2 = new Mock<IMigration>();
-            
-            LoadVersionData(version1, version2);
+            var mockMigration3 = new Mock<IMigration>();
+
+            LoadVersionData(version1, version3);
 
             _migrationList.Clear();
             _migrationList.Add(version1, new MigrationInfo(version1, TransactionBehavior.Default, mockMigration1.Object));
             _migrationList.Add(version2, new MigrationInfo(version2, TransactionBehavior.Default, mockMigration2.Object));
+            _migrationList.Add(version3, new MigrationInfo(version3, TransactionBehavior.Default, mockMigration3.Object));
 
             _runner.ListMigrations();
 
             _announcer.Verify(a => a.Say("2011010101: IMigrationProxy"));
-            _announcer.Verify(a => a.Emphasize("2011010102: IMigrationProxy (current)"));
+            _announcer.Verify(a => a.Say("2011010102: IMigrationProxy (not applied)"));
+            _announcer.Verify(a => a.Emphasize("2011010103: IMigrationProxy (current)"));
         }
 
         [Test]


### PR DESCRIPTION
Fixes #749 
![2016-11-29_20-16-02](https://cloud.githubusercontent.com/assets/791721/20725253/80504732-b671-11e6-901d-9a7d743222e2.png)
Announcers don't have a way to say the [-] sign requested, so I suggest saying "(not applied)" instead.