### PR TITLE
Modified IntegrationTestBase so it Assert failure when no database se…

### DIFF
--- a/src/FluentMigrator.Tests/Integration/IntegrationTestBase.cs
+++ b/src/FluentMigrator.Tests/Integration/IntegrationTestBase.cs
@@ -58,7 +58,7 @@ namespace FluentMigrator.Tests.Integration
             if (IntegrationTestOptions.AnyServerTypesEnabled == false)
             {
                 var optionsClassName = nameof(IntegrationTestOptions);
-                Assert.Fail($"No database processors are configured to run your migration tests.  This message is provided to avoid false positives.  To avoid this message enable one or more test runners in the {optionsClassName} class.");
+                Assert.Fail("No database processors are configured to run your migration tests.  This message is provided to avoid false positives.  To avoid this message enable one or more test runners in the {0} class.", optionsClassName);
             }
 
             if (exceptProcessors.Count(t => typeof(SqlServerProcessor).IsAssignableFrom(t)) == 0)

--- a/src/FluentMigrator.Tests/Integration/IntegrationTestBase.cs
+++ b/src/FluentMigrator.Tests/Integration/IntegrationTestBase.cs
@@ -57,7 +57,7 @@ namespace FluentMigrator.Tests.Integration
 
             if (IntegrationTestOptions.AnyServerTypesEnabled == false)
             {
-                var optionsClassName = nameof(IntegrationTestOptions);
+                var optionsClassName = typeof(IntegrationTestOptions).Name;
                 Assert.Fail("No database processors are configured to run your migration tests.  This message is provided to avoid false positives.  To avoid this message enable one or more test runners in the {0} class.", optionsClassName);
             }
 

--- a/src/FluentMigrator.Tests/Integration/IntegrationTestBase.cs
+++ b/src/FluentMigrator.Tests/Integration/IntegrationTestBase.cs
@@ -35,6 +35,8 @@ using FirebirdSql.Data.FirebirdClient;
 using FluentMigrator.Runner.Processors.Firebird;
 using FluentMigrator.Runner.Generators.Firebird;
 
+using NUnit.Framework;
+
 namespace FluentMigrator.Tests.Integration
 {
     public class IntegrationTestBase
@@ -51,6 +53,14 @@ namespace FluentMigrator.Tests.Integration
 
         public void ExecuteWithSupportedProcessors(Action<IMigrationProcessor> test, Boolean tryRollback, params Type[] exceptProcessors)
         {
+
+
+            if (IntegrationTestOptions.AnyServerTypesEnabled == false)
+            {
+                var optionsClassName = nameof(IntegrationTestOptions);
+                Assert.Fail($"No database processors are configured to run your migration tests.  This message is provided to avoid false positives.  To avoid this message enable one or more test runners in the {optionsClassName} class.");
+            }
+
             if (exceptProcessors.Count(t => typeof(SqlServerProcessor).IsAssignableFrom(t)) == 0)
             {
                 ExecuteWithSqlServer2005(test, tryRollback);

--- a/src/FluentMigrator.Tests/IntegrationTestOptions.cs
+++ b/src/FluentMigrator.Tests/IntegrationTestOptions.cs
@@ -86,6 +86,26 @@ namespace FluentMigrator.Tests
             IsEnabled = false
         };
 
+        public static bool AnyServerTypesEnabled
+        {
+            get
+            {
+                return Db2.IsEnabled 
+                    || Firebird.IsEnabled 
+                    || Hana.IsEnabled 
+                    || Jet.IsEnabled 
+                    || MySql.IsEnabled
+                    || Oracle.IsEnabled 
+                    || Postgres.IsEnabled 
+                    || SqlLite.IsEnabled 
+                    || SqlServer2005.IsEnabled
+                    || SqlServer2008.IsEnabled 
+                    || SqlServer2012.IsEnabled 
+                    || SqlServer2014.IsEnabled
+                    || SqlServerCe.IsEnabled;
+            }
+        }
+
         public class DatabaseServerOptions
         {
             public string ConnectionString;


### PR DESCRIPTION
**As discussed with Tom on 11/28/2016**:

Modified IntegrationTestBase so it Assert failure when no database server options are configured.  This prevents false positives when running tests using the ExecuteWithSupportedProcessors method.