### PR TITLE
use unique constraint instead of unique index in ColumnExpressionBuilderHelper.Unique

### DIFF
--- a/src/FluentMigrator.Tests/Unit/Builders/ColumnExpressionBuilderHelperTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Builders/ColumnExpressionBuilderHelperTests.cs
@@ -201,7 +201,7 @@ namespace FluentMigrator.Tests.Unit.Builders
         }
 
         [Test]
-        public void CallingUniqueAddsIndexExpressionToContext()
+        public void CallingUniqueAddsConstraintExpressionToContext()
         {
             var collectionMock = new Mock<ICollection<IMigrationExpression>>();
             var builderMock = new Mock<IColumnExpressionBuilder>();
@@ -213,15 +213,14 @@ namespace FluentMigrator.Tests.Unit.Builders
             contextMock.Setup(x => x.Expressions).Returns(collectionMock.Object);
 
             var helper = new ColumnExpressionBuilderHelper(builderMock.Object, contextMock.Object);
-            helper.Unique("IX_Bacon_BaconId");
+            helper.Unique("UC_Bacon_BaconId");
 
-            collectionMock.Verify(x => x.Add(It.Is<CreateIndexExpression>(
-                ix => ix.Index.Name == "IX_Bacon_BaconId"
-                      && ix.Index.TableName == "Bacon"
-                      && ix.Index.SchemaName == "Eggs"
-                      && ix.Index.IsUnique
-                      && !ix.Index.IsClustered
-                      && ix.Index.Columns.All(c => c.Name == "BaconId")
+            collectionMock.Verify(x => x.Add(It.Is<CreateConstraintExpression>(
+                ix => ix.Constraint.ConstraintName == "UC_Bacon_BaconId"
+                      && ix.Constraint.TableName == "Bacon"
+                      && ix.Constraint.SchemaName == "Eggs"
+                      && ix.Constraint.IsUniqueConstraint
+                      && ix.Constraint.Columns.All(c => c == "BaconId")
                                                  )));
 
             contextMock.VerifyGet(x => x.Expressions);

--- a/src/FluentMigrator/Builders/Alter/Column/AlterColumnExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Alter/Column/AlterColumnExpressionBuilder.cs
@@ -132,9 +132,9 @@ namespace FluentMigrator.Builders.Alter.Column
             return this;
         }
 
-        public IAlterColumnOptionSyntax Unique(string indexName)
+        public IAlterColumnOptionSyntax Unique(string name)
         {
-            ColumnHelper.Unique(indexName);
+            ColumnHelper.Unique(name);
             return this;
         }
 

--- a/src/FluentMigrator/Builders/Alter/Table/AlterTableExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Alter/Table/AlterTableExpressionBuilder.cs
@@ -186,9 +186,9 @@ namespace FluentMigrator.Builders.Alter.Table
             return this;
         }
 
-        public IAlterTableColumnOptionOrAddColumnOrAlterColumnSyntax Unique(string indexName)
+        public IAlterTableColumnOptionOrAddColumnOrAlterColumnSyntax Unique(string name)
         {
-            ColumnHelper.Unique(indexName);
+            ColumnHelper.Unique(name);
             return this;
         }
 

--- a/src/FluentMigrator/Builders/ColumnExpressionBuilderHelper.cs
+++ b/src/FluentMigrator/Builders/ColumnExpressionBuilderHelper.cs
@@ -139,28 +139,24 @@ namespace FluentMigrator.Builders
             }
         }
 
-        public virtual void Unique(string indexName)
+        public virtual void Unique(string name)
         {
             var column = _builder.Column;
             column.IsUnique = true;
 
-            var index = new CreateIndexExpression
+            var expression = new CreateConstraintExpression(ConstraintType.Unique)
             {
-                Index = new IndexDefinition
+                Constraint =
                 {
-                    Name = indexName,
+                    ConstraintName = name,
                     SchemaName = _builder.SchemaName,
-                    TableName = _builder.TableName,
-                    IsUnique = true
+                    TableName = _builder.TableName
                 }
             };
 
-            index.Index.Columns.Add(new IndexColumnDefinition
-            {
-                Name = _builder.Column.Name
-            });
+            expression.Constraint.Columns.Add(_builder.Column.Name);
 
-            _context.Expressions.Add(index);
+            _context.Expressions.Add(expression);
         }
 
         public virtual void Indexed(string indexName)

--- a/src/FluentMigrator/Builders/Create/Column/CreateColumnExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Create/Column/CreateColumnExpressionBuilder.cs
@@ -127,9 +127,9 @@ namespace FluentMigrator.Builders.Create.Column
             return this;
         }
 
-        public ICreateColumnOptionSyntax Unique(string indexName)
+        public ICreateColumnOptionSyntax Unique(string name)
         {
-            ColumnHelper.Unique(indexName);
+            ColumnHelper.Unique(name);
             return this;
         }
 

--- a/src/FluentMigrator/Builders/Create/Table/CreateTableExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Create/Table/CreateTableExpressionBuilder.cs
@@ -130,9 +130,9 @@ namespace FluentMigrator.Builders.Create.Table
             return this;
         }
 
-        public ICreateTableColumnOptionOrWithColumnSyntax Unique(string indexName)
+        public ICreateTableColumnOptionOrWithColumnSyntax Unique(string name)
         {
-            ColumnHelper.Unique(indexName);
+            ColumnHelper.Unique(name);
             return this;
         }
 

--- a/src/FluentMigrator/Builders/IColumnOptionSyntax.cs
+++ b/src/FluentMigrator/Builders/IColumnOptionSyntax.cs
@@ -39,7 +39,7 @@ namespace FluentMigrator.Builders
         TNext Nullable();
         TNext NotNullable();
         TNext Unique();
-        TNext Unique(string indexName);
+        TNext Unique(string name);
 
         TNextFk ForeignKey(string primaryTableName, string primaryColumnName);
         TNextFk ForeignKey(string foreignKeyName, string primaryTableName, string primaryColumnName);


### PR DESCRIPTION
This fixes the convention used `GetConstraintName` instead of `GetIndexName`.

Unfortunately, this might be a breaking change for those that use the Index directly after (for Delete/Rename/etc.)