### PR TITLE
Add defaults for NuGet to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,6 @@ db.sqlite
 *.orig
 *.pidb
 *.userprefs
-packages/FluentMigrator/
-packages/FluentMigrator.Tools/
 _UpgradeReport_Files
 UpgradeLog.XML
 *.bak
@@ -33,3 +31,12 @@ src/FluentMigrator.T4.Tests/IntialMigrationCode.cs
 #StyleCop
 *.StyleCop
 /TestResults
+
+# NuGet Packages
+*.nupkg
+# The packages folder can be ignored because of Package Restore
+**/packages/*
+# except build/, which is used as an MSBuild target.
+!**/packages/build/
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/packages/repositories.config


### PR DESCRIPTION
Copied from a default .gitignore file for Visual Studio projects.