### PR TITLE
Syntax for creating indexes with nonkey columns

### DIFF
--- a/src/FluentMigrator/Builders/Create/Index/CreateIndexExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Create/Index/CreateIndexExpressionBuilder.cs
@@ -16,6 +16,7 @@
 //
 #endregion
 
+using System;
 using FluentMigrator.Expressions;
 using FluentMigrator.Model;
 
@@ -24,10 +25,12 @@ namespace FluentMigrator.Builders.Create.Index
     public class CreateIndexExpressionBuilder : ExpressionBuilderBase<CreateIndexExpression>,
         ICreateIndexForTableSyntax,
         ICreateIndexOnColumnOrInSchemaSyntax,
+        ICreateIndexNonKeyColumnSyntax,
         ICreateIndexColumnOptionsSyntax,
         ICreateIndexOptionsSyntax
     {
         public IndexColumnDefinition CurrentColumn { get; set; }
+        public IndexIncludeDefinition CurrentNonkeyColumn { get; set; }
 
         public CreateIndexExpressionBuilder(CreateIndexExpression expression)
             : base(expression)
@@ -91,6 +94,13 @@ namespace FluentMigrator.Builders.Create.Index
         public ICreateIndexOnColumnSyntax Clustered()
         {
             Expression.Index.IsClustered = true;
+            return this;
+        }
+
+        public ICreateIndexNonKeyColumnSyntax Include(string columnName)
+        {
+            CurrentNonkeyColumn = new IndexIncludeDefinition() { Name = columnName };
+            Expression.Index.Includes.Add(CurrentNonkeyColumn);
             return this;
         }
     }

--- a/src/FluentMigrator/Builders/Create/Index/ICreateIndexNonKeyColumnSyntax.cs
+++ b/src/FluentMigrator/Builders/Create/Index/ICreateIndexNonKeyColumnSyntax.cs
@@ -1,4 +1,4 @@
-#region License
+﻿#region License
 // 
 // Copyright (c) 2007-2009, Sean Chambers <schambers80@gmail.com>
 // 
@@ -18,10 +18,8 @@
 
 namespace FluentMigrator.Builders.Create.Index
 {
-    public interface ICreateIndexOnColumnSyntax
+    public interface ICreateIndexNonKeyColumnSyntax
     {
-        ICreateIndexColumnOptionsSyntax OnColumn(string columnName);
         ICreateIndexNonKeyColumnSyntax Include(string columnName);
-        ICreateIndexOptionsSyntax WithOptions();
     }
 }

--- a/src/FluentMigrator/FluentMigrator.csproj
+++ b/src/FluentMigrator/FluentMigrator.csproj
@@ -123,6 +123,7 @@
     <Compile Include="..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="Builders\Create\Index\ICreateIndexNonKeyColumnSyntax.cs" />
     <Compile Include="MigrationStage.cs" />
     <Compile Include="MaintenanceAttribute.cs" />
     <Compile Include="Builders\Alter\AlterExpressionRoot.cs" />


### PR DESCRIPTION
Related to issue #756 

If someone who knows the history can say why the Include syntax was left out, we probably have a reason to not merge this PR as is. But as far as I can see, there's no reason why the IndexIncludeDefinition created in commit ceca4ea shouldn't be supported.
![2016-12-18_15-52-35](https://cloud.githubusercontent.com/assets/791721/21294304/16a6af7e-c53a-11e6-8f54-e4809ec00cf0.png)
