### PR TITLE
remove System.Runtime.Serialization usage

### DIFF
--- a/src/FluentMigrator.Console/Options.cs
+++ b/src/FluentMigrator.Console/Options.cs
@@ -130,8 +130,6 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Globalization;
 using System.IO;
-using System.Runtime.Serialization;
-using System.Security.Permissions;
 using System.Text;
 using System.Text.RegularExpressions;
 

--- a/src/FluentMigrator.Console/Options.cs
+++ b/src/FluentMigrator.Console/Options.cs
@@ -478,7 +478,6 @@ namespace Mono.Options
         }
     }
 
-    [Serializable]
     public class OptionException : Exception
     {
         private string option;
@@ -499,22 +498,9 @@ namespace Mono.Options
             this.option = optionName;
         }
 
-        protected OptionException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-            this.option = info.GetString("OptionName");
-        }
-
         public string OptionName
         {
             get { return this.option; }
-        }
-
-        [SecurityPermission(SecurityAction.LinkDemand, SerializationFormatter = true)]
-        public override void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            base.GetObjectData(info, context);
-            info.AddValue("OptionName", option);
         }
     }
 

--- a/src/FluentMigrator/Exceptions/DatabaseOperationNotSupportedException.cs
+++ b/src/FluentMigrator/Exceptions/DatabaseOperationNotSupportedException.cs
@@ -17,11 +17,9 @@
 #endregion
 
 using System;
-using System.Runtime.Serialization;
 
 namespace FluentMigrator.Exceptions
 {
-    [Serializable]
     public class DatabaseOperationNotSupportedException : FluentMigratorException
     {
         public DatabaseOperationNotSupportedException()
@@ -34,11 +32,6 @@ namespace FluentMigrator.Exceptions
 
         public DatabaseOperationNotSupportedException(string message, Exception innerException)
             : base(message, innerException)
-        {
-        }
-
-        public DatabaseOperationNotSupportedException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
         {
         }
     }

--- a/src/FluentMigrator/Exceptions/DuplicateMigrationException.cs
+++ b/src/FluentMigrator/Exceptions/DuplicateMigrationException.cs
@@ -17,11 +17,9 @@
 #endregion
 
 using System;
-using System.Runtime.Serialization;
 
 namespace FluentMigrator.Exceptions
 {
-    [Serializable]
     public class DuplicateMigrationException : FluentMigratorException
     {
         public DuplicateMigrationException()
@@ -33,10 +31,6 @@ namespace FluentMigrator.Exceptions
         }
 
         public DuplicateMigrationException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        public DuplicateMigrationException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/src/FluentMigrator/Exceptions/FluentMigratorException.cs
+++ b/src/FluentMigrator/Exceptions/FluentMigratorException.cs
@@ -17,11 +17,9 @@
 #endregion
 
 using System;
-using System.Runtime.Serialization;
 
 namespace FluentMigrator.Exceptions
 {
-    [Serializable]
     public abstract class FluentMigratorException : Exception
     {
         protected FluentMigratorException()
@@ -33,10 +31,6 @@ namespace FluentMigrator.Exceptions
         }
 
         protected FluentMigratorException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        protected FluentMigratorException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/src/FluentMigrator/Exceptions/ProcessorFactoryNotFoundException.cs
+++ b/src/FluentMigrator/Exceptions/ProcessorFactoryNotFoundException.cs
@@ -17,11 +17,9 @@
 #endregion
 
 using System;
-using System.Runtime.Serialization;
 
 namespace FluentMigrator.Exceptions
 {
-    [Serializable]
     public class ProcessorFactoryNotFoundException : FluentMigratorException
     {
         public ProcessorFactoryNotFoundException()
@@ -34,10 +32,6 @@ namespace FluentMigrator.Exceptions
 
         public ProcessorFactoryNotFoundException(string message, Exception innerException)
             : base(message, innerException)
-        {
-        }
-
-        public ProcessorFactoryNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/src/FluentMigrator/Exceptions/UndeterminableConnectionException.cs
+++ b/src/FluentMigrator/Exceptions/UndeterminableConnectionException.cs
@@ -17,11 +17,9 @@
 #endregion
 
 using System;
-using System.Runtime.Serialization;
 
 namespace FluentMigrator.Exceptions
 {
-    [Serializable]
     public class UndeterminableConnectionException : FluentMigratorException
     {
         public UndeterminableConnectionException()
@@ -34,10 +32,6 @@ namespace FluentMigrator.Exceptions
 
         public UndeterminableConnectionException(string message, Exception innerException)
             : base(message, innerException)
-        {
-        }
-
-        public UndeterminableConnectionException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }


### PR DESCRIPTION
Part of #712 . I've removed System.Runtime.Serialization usages as they aren't longer supported in netstandard