### PR TITLE
SQL Server 2016 support WITH (ONLINE = ON|OFF)

### DIFF
--- a/FluentMigrator.sln
+++ b/FluentMigrator.sln
@@ -1,8 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentMigrator.Runner", "src\FluentMigrator.Runner\FluentMigrator.Runner.csproj", "{CB468AD6-60C2-42E9-B3B0-01968EF94C65}"
 EndProject
@@ -79,8 +78,8 @@ Global
 		{664C7334-B44B-4D62-A0F8-063805D630AA}.AutomatedRelease|Any CPU.Build.0 = AutomatedRelease|Any CPU
 		{664C7334-B44B-4D62-A0F8-063805D630AA}.AutomatedRelease|x86.ActiveCfg = Release|x86
 		{664C7334-B44B-4D62-A0F8-063805D630AA}.AutomatedRelease|x86.Build.0 = Release|x86
-		{664C7334-B44B-4D62-A0F8-063805D630AA}.Debug|Any CPU.ActiveCfg = Debug|x86
-		{664C7334-B44B-4D62-A0F8-063805D630AA}.Debug|Any CPU.Build.0 = Debug|x86
+		{664C7334-B44B-4D62-A0F8-063805D630AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{664C7334-B44B-4D62-A0F8-063805D630AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{664C7334-B44B-4D62-A0F8-063805D630AA}.Debug|x86.ActiveCfg = Debug|x86
 		{664C7334-B44B-4D62-A0F8-063805D630AA}.Debug|x86.Build.0 = Debug|x86
 		{664C7334-B44B-4D62-A0F8-063805D630AA}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
+++ b/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Generators\Hana\HanaGenerator.cs" />
     <Compile Include="Generators\Hana\HanaQuoter.cs" />
     <Compile Include="Generators\Hana\HanaTypeMap.cs" />
+    <Compile Include="Generators\SqlServer\SqlServer2016Generator.cs" />
     <Compile Include="Generators\SqlServer\SqlServerCeColumn.cs" />
     <Compile Include="MaintenanceLoader.cs" />
     <Compile Include="IMaintenanceLoader.cs" />
@@ -265,6 +266,7 @@
     <Compile Include="Processors\SqlServer\SqlServer2000Processor.cs" />
     <Compile Include="Processors\SqlServer\SqlServer2012ProcessorFactory.cs" />
     <Compile Include="Processors\SqlServer\SqlServer2014ProcessorFactory.cs" />
+    <Compile Include="Processors\SqlServer\SqlServer2016ProcessorFactory.cs" />
     <Compile Include="Processors\SqlServer\SqlServerCeDbFactory.cs" />
     <Compile Include="Processors\SqlServer\SqlServerDbFactory.cs" />
     <Compile Include="Processors\SqlServer\SqlServerCeProcessor.cs" />

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2016Generator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2016Generator.cs
@@ -47,5 +47,18 @@ namespace FluentMigrator.Runner.Generators.SqlServer
 
             return sql.ToString();
         }
+
+        public override string Generate(DeleteConstraintExpression expression)
+        {
+            StringBuilder sql = new StringBuilder();
+            sql.Append(base.Generate(expression));
+
+            if (expression.Constraint.ApplyOnline.HasValue)
+            {
+                sql.Append(string.Format(" WITH (ONLINE = {0})", (expression.Constraint.ApplyOnline == OnlineMode.On ? "ON" : "OFF")));
+            }
+
+            return sql.ToString();
+        }
     }
 }

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2016Generator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2016Generator.cs
@@ -34,5 +34,18 @@ namespace FluentMigrator.Runner.Generators.SqlServer
 
             return sql.ToString();
         }
+
+        public override string Generate(CreateConstraintExpression expression)
+        {
+            StringBuilder sql = new StringBuilder();
+            sql.Append(base.Generate(expression));
+
+            if (expression.Constraint.ApplyOnline.HasValue)
+            {
+                sql.Append(string.Format(" WITH (ONLINE = {0})", (expression.Constraint.ApplyOnline == OnlineMode.On ? "ON" : "OFF")));
+            }
+
+            return sql.ToString();
+        }
     }
 }

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2016Generator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2016Generator.cs
@@ -21,5 +21,18 @@ namespace FluentMigrator.Runner.Generators.SqlServer
 
             return sql.ToString();
         }
+
+        public override string Generate(DeleteIndexExpression expression)
+        {
+            StringBuilder sql = new StringBuilder();
+            sql.Append(base.Generate(expression));
+
+            if (expression.Index.ApplyOnline.HasValue)
+            {
+                sql.Append(string.Format(" WITH (ONLINE = {0})", (expression.Index.ApplyOnline == OnlineMode.On ? "ON" : "OFF")));
+            }
+
+            return sql.ToString();
+        }
     }
 }

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2016Generator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2016Generator.cs
@@ -2,11 +2,24 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using FluentMigrator.Expressions;
+using FluentMigrator.Model;
 
 namespace FluentMigrator.Runner.Generators.SqlServer
 {
     public class SqlServer2016Generator : SqlServer2014Generator
     {
+        public override string Generate(CreateIndexExpression expression)
+        {
+            StringBuilder sql = new StringBuilder();
+            sql.Append(base.Generate(expression));
 
+            if (expression.Index.ApplyOnline.HasValue)
+            {
+                sql.Append(string.Format(" WITH (ONLINE = {0})", (expression.Index.ApplyOnline == OnlineMode.On ? "ON" : "OFF")));
+            }
+
+            return sql.ToString();
+        }
     }
 }

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2016Generator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2016Generator.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FluentMigrator.Runner.Generators.SqlServer
+{
+    public class SqlServer2016Generator : SqlServer2014Generator
+    {
+
+    }
+}

--- a/src/FluentMigrator.Runner/Processors/SqlServer/SqlServer2016ProcessorFactory.cs
+++ b/src/FluentMigrator.Runner/Processors/SqlServer/SqlServer2016ProcessorFactory.cs
@@ -1,0 +1,14 @@
+﻿using FluentMigrator.Runner.Generators.SqlServer;
+
+namespace FluentMigrator.Runner.Processors.SqlServer
+{
+    public class SqlServer2016ProcessorFactory : MigrationProcessorFactory
+    {
+        public override IMigrationProcessor Create(string connectionString, IAnnouncer announcer, IMigrationProcessorOptions options)
+        {
+            var factory = new SqlServerDbFactory();
+            var connection = factory.CreateConnection(connectionString);
+            return new SqlServerProcessor(connection, new SqlServer2016Generator(), announcer, options, factory);
+        }
+    }
+}

--- a/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -467,6 +467,7 @@
     <Compile Include="Unit\Generators\SqlServer2005\SqlServer2005TableTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2008\SqlServer2008GeneratorTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2012\SqlServer2012SequenceTests.cs" />
+    <Compile Include="Unit\Generators\SqlServer2016\SqlServer2016ConstraintTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2016\SqlServer2016IndexTests.cs" />
     <Compile Include="Unit\Generators\SqlServerCe\SqlServerCeColumnTests.cs" />
     <Compile Include="Unit\Generators\SqlServerCe\SqlServerCeConstraintsTests.cs" />

--- a/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -467,6 +467,7 @@
     <Compile Include="Unit\Generators\SqlServer2005\SqlServer2005TableTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2008\SqlServer2008GeneratorTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2012\SqlServer2012SequenceTests.cs" />
+    <Compile Include="Unit\Generators\SqlServer2016\SqlServer2016IndexTests.cs" />
     <Compile Include="Unit\Generators\SqlServerCe\SqlServerCeColumnTests.cs" />
     <Compile Include="Unit\Generators\SqlServerCe\SqlServerCeConstraintsTests.cs" />
     <Compile Include="Unit\Generators\SqlServerCe\SqlServerCeDataTests.cs" />

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005ConstraintsTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005ConstraintsTests.cs
@@ -488,6 +488,16 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
         }
 
         [Test]
+        public void CanCreatePrimaryKeyAndIgnoreApplyOnlineValue()
+        {
+            var expression = GeneratorTestHelper.GetCreatePrimaryKeyExpression();
+            expression.Constraint.ApplyOnline = Model.OnlineMode.On;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE [dbo].[TestTable1] ADD CONSTRAINT [PK_TestTable1_TestColumn1] PRIMARY KEY ([TestColumn1])");
+        }
+
+        [Test]
         public override void CanDropForeignKeyWithCustomSchema()
         {
             var expression = GeneratorTestHelper.GetDeleteForeignKeyExpression();

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005ConstraintsTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005ConstraintsTests.cs
@@ -536,6 +536,16 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
         }
 
         [Test]
+        public void CanDropPrimaryKeyConstraintAndIgnoreApplyOnlineValue()
+        {
+            var expression = GeneratorTestHelper.GetDeletePrimaryKeyExpression();
+            expression.Constraint.ApplyOnline = Model.OnlineMode.On;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE [dbo].[TestTable1] DROP CONSTRAINT [TESTPRIMARYKEY]");
+        }
+
+        [Test]
         public override void CanDropUniqueConstraintWithCustomSchema()
         {
             var expression = GeneratorTestHelper.GetDeleteUniqueConstraintExpression();

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005IndexTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005IndexTests.cs
@@ -119,5 +119,15 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
             var result = Generator.Generate(expression);
             result.ShouldBe("DROP INDEX [TestIndex] ON [dbo].[TestTable1]");
         }
+
+        [Test]
+        public void CanDropIndexAndIgnoreApplyOnlineValue()
+        {
+            var expression = GeneratorTestHelper.GetDeleteIndexExpression();
+            expression.Index.ApplyOnline = Model.OnlineMode.On;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DROP INDEX [TestIndex] ON [dbo].[TestTable1]");
+        }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005IndexTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005IndexTests.cs
@@ -90,6 +90,16 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
             var result = Generator.Generate(expression);
             result.ShouldBe("CREATE UNIQUE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC)");
         }
+        
+        [Test]
+        public void CanCreateIndexAndIgnoreApplyOnlineValue()
+        {
+            var expression = GeneratorTestHelper.GetCreateIndexExpression();
+            expression.Index.ApplyOnline = Model.OnlineMode.On;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC)");
+        }
 
         [Test]
         public override void CanDropIndexWithCustomSchema()

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2016/SqlServer2016ConstraintTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2016/SqlServer2016ConstraintTests.cs
@@ -47,5 +47,35 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2016
             var result = Generator.Generate(expression);
             result.ShouldBe("ALTER TABLE [dbo].[TestTable1] ADD CONSTRAINT [PK_TestTable1_TestColumn1] PRIMARY KEY ([TestColumn1]) WITH (ONLINE = OFF)");
         }
+
+        [Test]
+        public void CanDropPrimaryKeyWithoutOnlineModeSet()
+        {
+            var expression = GeneratorTestHelper.GetDeletePrimaryKeyExpression();
+            expression.Constraint.ApplyOnline = null;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE [dbo].[TestTable1] DROP CONSTRAINT [TESTPRIMARYKEY]");
+        }
+
+        [Test]
+        public void CanDropPrimaryKeyWithOnlineOn()
+        {
+            var expression = GeneratorTestHelper.GetDeletePrimaryKeyExpression();
+            expression.Constraint.ApplyOnline = Model.OnlineMode.On;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE [dbo].[TestTable1] DROP CONSTRAINT [TESTPRIMARYKEY] WITH (ONLINE = ON)");
+        }
+
+        [Test]
+        public void CanDropPrimaryKeyWithOnlineOff()
+        {
+            var expression = GeneratorTestHelper.GetDeletePrimaryKeyExpression();
+            expression.Constraint.ApplyOnline = Model.OnlineMode.Off;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE [dbo].[TestTable1] DROP CONSTRAINT [TESTPRIMARYKEY] WITH (ONLINE = OFF)");
+        }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2016/SqlServer2016ConstraintTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2016/SqlServer2016ConstraintTests.cs
@@ -1,0 +1,51 @@
+﻿using FluentMigrator.Runner.Generators.SqlServer;
+using NUnit.Framework;
+using NUnit.Should;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FluentMigrator.Tests.Unit.Generators.SqlServer2016
+{
+    public class SqlServer2016ConstraintTests
+    {
+        protected SqlServer2016Generator Generator;
+
+        [SetUp]
+        public void Setup()
+        {
+            Generator = new SqlServer2016Generator();
+        }
+
+        [Test]
+        public void CanCreatePrimaryKeyWithoutOnlineModeSet()
+        {
+            var expression = GeneratorTestHelper.GetCreatePrimaryKeyExpression();
+            expression.Constraint.ApplyOnline = null;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE [dbo].[TestTable1] ADD CONSTRAINT [PK_TestTable1_TestColumn1] PRIMARY KEY ([TestColumn1])");
+        }
+
+        [Test]
+        public void CanCreatePrimaryKeyWithOnlineOn()
+        {
+            var expression = GeneratorTestHelper.GetCreatePrimaryKeyExpression();
+            expression.Constraint.ApplyOnline = Model.OnlineMode.On;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE [dbo].[TestTable1] ADD CONSTRAINT [PK_TestTable1_TestColumn1] PRIMARY KEY ([TestColumn1]) WITH (ONLINE = ON)");
+        }
+
+        [Test]
+        public void CanCreatePrimaryKeyWithOnlineOff()
+        {
+            var expression = GeneratorTestHelper.GetCreatePrimaryKeyExpression();
+            expression.Constraint.ApplyOnline = Model.OnlineMode.Off;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE [dbo].[TestTable1] ADD CONSTRAINT [PK_TestTable1_TestColumn1] PRIMARY KEY ([TestColumn1]) WITH (ONLINE = OFF)");
+        }
+    }
+}

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2016/SqlServer2016IndexTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2016/SqlServer2016IndexTests.cs
@@ -44,5 +44,35 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2016
             var result = Generator.Generate(expression);
             result.ShouldBe("CREATE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC)");
         }
+
+        [Test]
+        public void CanDropIndexWithOnlineOn()
+        {
+            var expression = GeneratorTestHelper.GetDeleteIndexExpression();
+            expression.Index.ApplyOnline = Model.OnlineMode.On;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DROP INDEX [TestIndex] ON [dbo].[TestTable1] WITH (ONLINE = ON)");
+        }
+
+        [Test]
+        public void CanDropIndexWithOnlineOff()
+        {
+            var expression = GeneratorTestHelper.GetDeleteIndexExpression();
+            expression.Index.ApplyOnline = Model.OnlineMode.Off;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DROP INDEX [TestIndex] ON [dbo].[TestTable1] WITH (ONLINE = OFF)");
+        }
+
+        [Test]
+        public void CanDropIndexWithoutOnlineModeSet()
+        {
+            var expression = GeneratorTestHelper.GetDeleteIndexExpression();
+            expression.Index.ApplyOnline = null;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DROP INDEX [TestIndex] ON [dbo].[TestTable1]");
+        }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2016/SqlServer2016IndexTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2016/SqlServer2016IndexTests.cs
@@ -1,0 +1,48 @@
+﻿using FluentMigrator.Runner.Generators.SqlServer;
+using NUnit.Framework;
+using NUnit.Should;
+
+namespace FluentMigrator.Tests.Unit.Generators.SqlServer2016
+{
+    [TestFixture]
+    public class SqlServer2016IndexTests
+    {
+        protected SqlServer2016Generator Generator;
+
+        [SetUp]
+        public void Setup()
+        {
+            Generator = new SqlServer2016Generator();
+        }
+        
+        [Test]
+        public void CanCreateIndexWithOnlineOn()
+        {
+            var expression = GeneratorTestHelper.GetCreateIndexExpression();
+            expression.Index.ApplyOnline = Model.OnlineMode.On;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC) WITH (ONLINE = ON)");
+        }
+
+        [Test]
+        public void CanCreateIndexWithOnlineOff()
+        {
+            var expression = GeneratorTestHelper.GetCreateIndexExpression();
+            expression.Index.ApplyOnline = Model.OnlineMode.Off;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC) WITH (ONLINE = OFF)");
+        }
+
+        [Test]
+        public void CanCreateIndexWithoutOnlineModeSet()
+        {
+            var expression = GeneratorTestHelper.GetCreateIndexExpression();
+            expression.Index.ApplyOnline = null;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC)");
+        }
+    }
+}

--- a/src/FluentMigrator.Tests/Unit/Runners/MigrationProcessorFactoryProviderTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Runners/MigrationProcessorFactoryProviderTests.cs
@@ -79,6 +79,13 @@ namespace FluentMigrator.Tests.Unit.Runners
         }
 
         [Test]
+        public void CanRetrieveSqlServer2016FactoryWithArgumentString()
+        {
+            IMigrationProcessorFactory factory = migrationProcessorFactoryProvider.GetFactory("SqlServer2016");
+            Assert.IsTrue(factory.GetType() == typeof(SqlServer2016ProcessorFactory));
+        }
+
+        [Test]
         public void RetrievesSqlServerProcessorFactoryIfArgumentIsSqlServer()
         {
             IMigrationProcessorFactory factory = migrationProcessorFactoryProvider.GetFactory("SqlServer");

--- a/src/FluentMigrator/Builders/Create/Constraint/CreateConstraintExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Create/Constraint/CreateConstraintExpressionBuilder.cs
@@ -1,4 +1,6 @@
+using System;
 using FluentMigrator.Expressions;
+using FluentMigrator.Model;
 
 namespace FluentMigrator.Builders.Create.Constraint
 {
@@ -39,6 +41,12 @@ namespace FluentMigrator.Builders.Create.Constraint
         public ICreateConstraintColumnsSyntax WithSchema(string schemaName)
         {
             Expression.Constraint.SchemaName = schemaName;
+            return this;
+        }
+
+        public ICreateConstraintOptionsSyntax ApplyOnline(OnlineMode mode)
+        {
+            Expression.Constraint.ApplyOnline = mode;
             return this;
         }
     }

--- a/src/FluentMigrator/Builders/Create/Constraint/ICreateConstraintOptionsSyntax.cs
+++ b/src/FluentMigrator/Builders/Create/Constraint/ICreateConstraintOptionsSyntax.cs
@@ -1,6 +1,27 @@
+#region License
+// 
+// Copyright (c) 2007-2009, Sean Chambers <schambers80@gmail.com>
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+using FluentMigrator.Model;
+
 namespace FluentMigrator.Builders.Create.Constraint
 {
     public interface ICreateConstraintOptionsSyntax
     {
+        ICreateConstraintOptionsSyntax ApplyOnline(OnlineMode mode);
     }
 }

--- a/src/FluentMigrator/Builders/Create/Constraint/ICreateConstraintOptionsSyntax.cs
+++ b/src/FluentMigrator/Builders/Create/Constraint/ICreateConstraintOptionsSyntax.cs
@@ -22,6 +22,16 @@ namespace FluentMigrator.Builders.Create.Constraint
 {
     public interface ICreateConstraintOptionsSyntax
     {
-        ICreateConstraintOptionsSyntax ApplyOnline(OnlineMode mode);
+        /// <summary>
+        /// Specifies whether underlying tables and associated indexes are available for queries and data modification during the index operation.
+        /// The ONLINE option can only be specified in certain situations, please refer to documentation for SQL Server 2016.
+        /// </summary>
+        /// <param name="mode">
+        /// ON
+        /// Long-term table locks are not held. This allows queries or updates to the underlying table to continue.
+        /// OFF
+        /// Table locks are applied and the table is unavailable for the duration of the index operation.
+        /// </param>
+        ICreateConstraintOptionsSyntax ApplyOnline(OnlineMode mode = OnlineMode.On);
     }
 }

--- a/src/FluentMigrator/Builders/Create/Index/CreateIndexExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Create/Index/CreateIndexExpressionBuilder.cs
@@ -16,6 +16,7 @@
 //
 #endregion
 
+using System;
 using FluentMigrator.Expressions;
 using FluentMigrator.Model;
 
@@ -91,6 +92,12 @@ namespace FluentMigrator.Builders.Create.Index
         public ICreateIndexOnColumnSyntax Clustered()
         {
             Expression.Index.IsClustered = true;
+            return this;
+        }
+
+        public ICreateIndexOnColumnSyntax ApplyOnline(OnlineMode mode)
+        {
+            Expression.Index.ApplyOnline = mode;
             return this;
         }
     }

--- a/src/FluentMigrator/Builders/Create/Index/ICreateIndexOptionsSyntax.cs
+++ b/src/FluentMigrator/Builders/Create/Index/ICreateIndexOptionsSyntax.cs
@@ -16,6 +16,8 @@
 //
 #endregion
 
+using FluentMigrator.Model;
+
 namespace FluentMigrator.Builders.Create.Index
 {
     public interface ICreateIndexOptionsSyntax
@@ -23,5 +25,6 @@ namespace FluentMigrator.Builders.Create.Index
         ICreateIndexOnColumnSyntax Unique();
         ICreateIndexOnColumnSyntax NonClustered();
         ICreateIndexOnColumnSyntax Clustered();
+        ICreateIndexOnColumnSyntax ApplyOnline(OnlineMode mode);
     }
 }

--- a/src/FluentMigrator/Builders/Create/Index/ICreateIndexOptionsSyntax.cs
+++ b/src/FluentMigrator/Builders/Create/Index/ICreateIndexOptionsSyntax.cs
@@ -25,6 +25,16 @@ namespace FluentMigrator.Builders.Create.Index
         ICreateIndexOnColumnSyntax Unique();
         ICreateIndexOnColumnSyntax NonClustered();
         ICreateIndexOnColumnSyntax Clustered();
-        ICreateIndexOnColumnSyntax ApplyOnline(OnlineMode mode);
+        /// <summary>
+        /// Specifies whether underlying tables and associated indexes are available for queries and data modification during the index operation.
+        /// The ONLINE option can only be specified in certain situations, please refer to documentation for SQL Server 2016.
+        /// </summary>
+        /// <param name="mode">
+        /// ON
+        /// Long-term table locks are not held. This allows queries or updates to the underlying table to continue.
+        /// OFF
+        /// Table locks are applied and the table is unavailable for the duration of the index operation.
+        /// </param>
+        ICreateIndexOnColumnSyntax ApplyOnline(OnlineMode mode = OnlineMode.On);
     }
 }

--- a/src/FluentMigrator/Builders/Delete/Constraint/DeleteConstraintExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Delete/Constraint/DeleteConstraintExpressionBuilder.cs
@@ -1,8 +1,12 @@
+using System;
 using FluentMigrator.Expressions;
+using FluentMigrator.Model;
 
 namespace FluentMigrator.Builders.Delete.Constraint
 {
-    public class DeleteConstraintExpressionBuilder : ExpressionBuilderBase<DeleteConstraintExpression>, IDeleteConstraintOnTableSyntax, IInSchemaSyntax
+    public class DeleteConstraintExpressionBuilder : ExpressionBuilderBase<DeleteConstraintExpression>, 
+        IDeleteConstraintOnTableSyntax, 
+        IDeleteConstraintInSchemaOptionsSyntax
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="T:CreateConstraintExpressionBuilder"/> class.
@@ -12,15 +16,22 @@ namespace FluentMigrator.Builders.Delete.Constraint
         {
         }
 
-        public IInSchemaSyntax FromTable(string tableName)
+        public IDeleteConstraintInSchemaOptionsSyntax ApplyOnline(OnlineMode mode)
+        {
+            Expression.Constraint.ApplyOnline = mode;
+            return this;
+        }
+
+        public IDeleteConstraintInSchemaOptionsSyntax FromTable(string tableName)
         {
             Expression.Constraint.TableName = tableName;
             return this;
         }
 
-        public void InSchema(string schemaName)
+        public IDeleteConstraintInSchemaOptionsSyntax InSchema(string schemaName)
         {
             Expression.Constraint.SchemaName = schemaName;
+            return this;
         }
     }
 }

--- a/src/FluentMigrator/Builders/Delete/Constraint/IDeleteConstraintInSchemaOptionsSyntax.cs
+++ b/src/FluentMigrator/Builders/Delete/Constraint/IDeleteConstraintInSchemaOptionsSyntax.cs
@@ -22,7 +22,17 @@ namespace FluentMigrator.Builders.Delete.Constraint
 {
     public interface IDeleteConstraintInSchemaOptionsSyntax
     {
-        IDeleteConstraintInSchemaOptionsSyntax ApplyOnline(OnlineMode mode);
+        /// <summary>
+        /// Specifies whether underlying tables and associated indexes are available for queries and data modification during the index operation.
+        /// The ONLINE option can only be specified when you drop clustered indexes (SQL Server 2016).
+        /// </summary>
+        /// <param name="mode">
+        /// ON
+        /// Long-term table locks are not held. This allows queries or updates to the underlying table to continue.
+        /// OFF
+        /// Table locks are applied and the table is unavailable for the duration of the index operation.
+        /// </param>
+        IDeleteConstraintInSchemaOptionsSyntax ApplyOnline(OnlineMode mode = OnlineMode.On);
         IDeleteConstraintInSchemaOptionsSyntax InSchema(string schemaName);
     }
 }

--- a/src/FluentMigrator/Builders/Delete/Constraint/IDeleteConstraintInSchemaOptionsSyntax.cs
+++ b/src/FluentMigrator/Builders/Delete/Constraint/IDeleteConstraintInSchemaOptionsSyntax.cs
@@ -1,0 +1,28 @@
+﻿#region License
+// 
+// Copyright (c) 2007-2009, Sean Chambers <schambers80@gmail.com>
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+using FluentMigrator.Model;
+
+namespace FluentMigrator.Builders.Delete.Constraint
+{
+    public interface IDeleteConstraintInSchemaOptionsSyntax
+    {
+        IDeleteConstraintInSchemaOptionsSyntax ApplyOnline(OnlineMode mode);
+        IDeleteConstraintInSchemaOptionsSyntax InSchema(string schemaName);
+    }
+}

--- a/src/FluentMigrator/Builders/Delete/Constraint/IDeleteConstraintOnTableSyntax.cs
+++ b/src/FluentMigrator/Builders/Delete/Constraint/IDeleteConstraintOnTableSyntax.cs
@@ -2,6 +2,6 @@ namespace FluentMigrator.Builders.Delete.Constraint
 {
     public interface IDeleteConstraintOnTableSyntax
     {
-        IInSchemaSyntax FromTable(string tableName);
+        IDeleteConstraintInSchemaOptionsSyntax FromTable(string tableName);
     }
 }

--- a/src/FluentMigrator/Builders/Delete/Index/DeleteIndexExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Delete/Index/DeleteIndexExpressionBuilder.cs
@@ -16,6 +16,7 @@
 //
 #endregion
 
+using System;
 using FluentMigrator.Expressions;
 using FluentMigrator.Model;
 
@@ -23,7 +24,8 @@ namespace FluentMigrator.Builders.Delete.Index
 {
     public class DeleteIndexExpressionBuilder : ExpressionBuilderBase<DeleteIndexExpression>,
         IDeleteIndexForTableSyntax,
-        IDeleteIndexOnColumnOrInSchemaSyntax
+        IDeleteIndexOnColumnOrInSchemaSyntax,
+        IDeleteIndexOptionsSyntax
     {
         public IndexColumnDefinition CurrentColumn { get; set; }
 
@@ -54,6 +56,28 @@ namespace FluentMigrator.Builders.Delete.Index
         {
             foreach (string columnName in columnNames)
                 Expression.Index.Columns.Add(new IndexColumnDefinition { Name = columnName });
+        }
+
+        public void ApplyOnline(OnlineMode mode)
+        {
+            Expression.Index.ApplyOnline = mode;
+        }
+
+        public IDeleteIndexOptionsSyntax WithOptions()
+        {
+            return this;
+        }
+
+        IDeleteIndexOptionsSyntax IDeleteIndexOnColumnSyntax.OnColumn(string columnName)
+        {
+            OnColumn(columnName);
+            return this;
+        }
+
+        IDeleteIndexOptionsSyntax IDeleteIndexOnColumnSyntax.OnColumns(params string[] columnNames)
+        {
+            OnColumns(columnNames);
+            return this;
         }
     }
 }

--- a/src/FluentMigrator/Builders/Delete/Index/IDeleteIndexOnColumnOrInSchemaSyntax.cs
+++ b/src/FluentMigrator/Builders/Delete/Index/IDeleteIndexOnColumnOrInSchemaSyntax.cs
@@ -23,5 +23,6 @@ namespace FluentMigrator.Builders.Delete.Index
     public interface IDeleteIndexOnColumnOrInSchemaSyntax : IDeleteIndexOnColumnSyntax
     {
         IDeleteIndexOnColumnSyntax InSchema(string schemaName);
+        IDeleteIndexOptionsSyntax WithOptions();
     }
 }

--- a/src/FluentMigrator/Builders/Delete/Index/IDeleteIndexOnColumnSyntax.cs
+++ b/src/FluentMigrator/Builders/Delete/Index/IDeleteIndexOnColumnSyntax.cs
@@ -20,7 +20,7 @@ namespace FluentMigrator.Builders.Delete.Index
 {
     public interface IDeleteIndexOnColumnSyntax
     {
-        void OnColumn(string columnName);
-        void OnColumns(params string[] columnNames);
+        IDeleteIndexOptionsSyntax OnColumn(string columnName);
+        IDeleteIndexOptionsSyntax OnColumns(params string[] columnNames);
     }
 }

--- a/src/FluentMigrator/Builders/Delete/Index/IDeleteIndexOnColumnSyntax.cs
+++ b/src/FluentMigrator/Builders/Delete/Index/IDeleteIndexOnColumnSyntax.cs
@@ -22,5 +22,6 @@ namespace FluentMigrator.Builders.Delete.Index
     {
         IDeleteIndexOptionsSyntax OnColumn(string columnName);
         IDeleteIndexOptionsSyntax OnColumns(params string[] columnNames);
+        IDeleteIndexOptionsSyntax WithOptions();
     }
 }

--- a/src/FluentMigrator/Builders/Delete/Index/IDeleteIndexOptionsSyntax.cs
+++ b/src/FluentMigrator/Builders/Delete/Index/IDeleteIndexOptionsSyntax.cs
@@ -22,6 +22,16 @@ namespace FluentMigrator.Builders.Delete.Index
 {
     public interface IDeleteIndexOptionsSyntax
     {
-        void ApplyOnline(OnlineMode mode);
+        /// <summary>
+        /// Specifies whether underlying tables and associated indexes are available for queries and data modification during the index operation.
+        /// The ONLINE option can only be specified when you drop clustered indexes (SQL Server 2016).
+        /// </summary>
+        /// <param name="mode">
+        /// ON
+        /// Long-term table locks are not held. This allows queries or updates to the underlying table to continue.
+        /// OFF
+        /// Table locks are applied and the table is unavailable for the duration of the index operation.
+        /// </param>
+        void ApplyOnline(OnlineMode mode = OnlineMode.On);
     }
 }

--- a/src/FluentMigrator/Builders/Delete/Index/IDeleteIndexOptionsSyntax.cs
+++ b/src/FluentMigrator/Builders/Delete/Index/IDeleteIndexOptionsSyntax.cs
@@ -1,4 +1,4 @@
-#region License
+﻿#region License
 // 
 // Copyright (c) 2007-2009, Sean Chambers <schambers80@gmail.com>
 // 
@@ -16,11 +16,12 @@
 //
 #endregion
 
+using FluentMigrator.Model;
+
 namespace FluentMigrator.Builders.Delete.Index
 {
-    public interface IDeleteIndexForTableSyntax
+    public interface IDeleteIndexOptionsSyntax
     {
-        IDeleteIndexOnColumnOrInSchemaSyntax OnTable(string tableName);
-        IDeleteIndexOptionsSyntax WithOptions();
+        void ApplyOnline(OnlineMode mode);
     }
 }

--- a/src/FluentMigrator/FluentMigrator.csproj
+++ b/src/FluentMigrator/FluentMigrator.csproj
@@ -123,6 +123,7 @@
     <Compile Include="..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="Builders\Delete\Constraint\IDeleteConstraintInSchemaOptionsSyntax.cs" />
     <Compile Include="Builders\Delete\Index\IDeleteIndexOptionsSyntax.cs" />
     <Compile Include="MigrationStage.cs" />
     <Compile Include="MaintenanceAttribute.cs" />

--- a/src/FluentMigrator/FluentMigrator.csproj
+++ b/src/FluentMigrator/FluentMigrator.csproj
@@ -123,6 +123,7 @@
     <Compile Include="..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="Builders\Delete\Index\IDeleteIndexOptionsSyntax.cs" />
     <Compile Include="MigrationStage.cs" />
     <Compile Include="MaintenanceAttribute.cs" />
     <Compile Include="Builders\Alter\AlterExpressionRoot.cs" />

--- a/src/FluentMigrator/FluentMigrator.csproj
+++ b/src/FluentMigrator/FluentMigrator.csproj
@@ -201,6 +201,7 @@
     <Compile Include="Infrastructure\IMigrationInfo.cs" />
     <Compile Include="Infrastructure\MigrationInfo.cs" />
     <Compile Include="Infrastructure\NonAttributedMigrationToMigrationInfoAdapter.cs" />
+    <Compile Include="Model\OnlineState.cs" />
     <Compile Include="RawSql.cs" />
     <Compile Include="Infrastructure\ISupportAdditionalFeatures.cs" />
     <Compile Include="Builders\Insert\IInsertDataOrInSchemaSyntax.cs" />

--- a/src/FluentMigrator/Model/ConstraintDefinition.cs
+++ b/src/FluentMigrator/Model/ConstraintDefinition.cs
@@ -24,6 +24,7 @@ namespace FluentMigrator.Model
         public virtual string ConstraintName { get; set; }
         public virtual string TableName { get; set; }
         public virtual ICollection<string> Columns { get; set; }
+        public OnlineMode? ApplyOnline { get; set; }
 
 
         /// <summary>

--- a/src/FluentMigrator/Model/IndexDefinition.cs
+++ b/src/FluentMigrator/Model/IndexDefinition.cs
@@ -31,6 +31,7 @@ namespace FluentMigrator.Model
         public virtual string TableName { get; set; }
         public virtual bool IsUnique { get; set; }
         public bool IsClustered { get; set; }
+        public OnlineMode? ApplyOnline { get; set; }
         public virtual ICollection<IndexColumnDefinition> Columns { get; set; }
         public virtual ICollection<IndexIncludeDefinition> Includes { get; set; }
 

--- a/src/FluentMigrator/Model/OnlineState.cs
+++ b/src/FluentMigrator/Model/OnlineState.cs
@@ -1,0 +1,8 @@
+﻿namespace FluentMigrator.Model
+{
+    public enum OnlineMode
+    {
+        Off = 0,
+        On = 1
+    }
+}


### PR DESCRIPTION
Related to issue #756 this PR adds support for WITH (ONLINE = ON|OFF) for SQL Server 2016 and SQL Azure.

Example migration for clustered index and primary key constraint, create and drop:
```
public override void Up()
{
    Create.Table("Notes")
        .WithColumn("NotesId").AsGuid()
        .WithColumn("Body").AsString(4000).NotNullable()
        .WithTimeStamps()
        .WithColumn("User_id").AsInt32();

    Create.Index("IDX_Notes_CreatedAt").OnTable("Notes")
        .WithOptions().ApplyOnline()
        .WithOptions().Clustered()
        .OnColumn("CreatedAt");

    Create.PrimaryKey("PK_Notes").OnTable("Notes")
        .Column("NotesId").ApplyOnline();
}

public override void Down()
{
    Delete.PrimaryKey("PK_Notes").FromTable("Notes");
    Delete.Index("IDX_Notes_CreatedAt").OnTable("Notes")
        .WithOptions().ApplyOnline();
    Delete.Table("Notes");
}
```
<img width="674" alt="2016-12-26_23-53-18" src="https://cloud.githubusercontent.com/assets/791721/21487341/e6c39b30-cbc6-11e6-9fcc-b745d51a4ad1.png">
<img width="674" alt="2016-12-26_23-56-36" src="https://cloud.githubusercontent.com/assets/791721/21487351/0a20b66c-cbc7-11e6-856e-509ef4f8d181.png">
