### PR TITLE
Ability to specify the Default Schema Name

### DIFF
--- a/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
+++ b/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
@@ -294,25 +294,63 @@
     <Compile Include="VersionOrderInvalidException.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\FluentMigrator\FluentMigrator.csproj">
+      <Project>{FD9410F9-6FEA-47F7-A78E-B4F6FB0539B8}</Project>
+      <Name>FluentMigrator</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <None Include="..\FluentMigrator.snk">
       <Link>FluentMigrator.snk</Link>
     </None>
-    <Content Include="SQLServerCENative\amd64\Microsoft.VC90.CRT\msvcr90.dll" />
-    <Content Include="SQLServerCENative\amd64\Microsoft.VC90.CRT\README_ENU.txt" />
-    <Content Include="SQLServerCENative\amd64\sqlceca40.dll" />
-    <Content Include="SQLServerCENative\amd64\sqlcecompact40.dll" />
-    <Content Include="SQLServerCENative\amd64\sqlceer40EN.dll" />
-    <Content Include="SQLServerCENative\amd64\sqlceme40.dll" />
-    <Content Include="SQLServerCENative\amd64\sqlceqp40.dll" />
-    <Content Include="SQLServerCENative\amd64\sqlcese40.dll" />
-    <Content Include="SQLServerCENative\x86\Microsoft.VC90.CRT\msvcr90.dll" />
-    <Content Include="SQLServerCENative\x86\Microsoft.VC90.CRT\README_ENU.txt" />
-    <Content Include="SQLServerCENative\x86\sqlceca40.dll" />
-    <Content Include="SQLServerCENative\x86\sqlcecompact40.dll" />
-    <Content Include="SQLServerCENative\x86\sqlceer40EN.dll" />
-    <Content Include="SQLServerCENative\x86\sqlceme40.dll" />
-    <Content Include="SQLServerCENative\x86\sqlceqp40.dll" />
-    <Content Include="SQLServerCENative\x86\sqlcese40.dll" />
+    <Content Include="SQLServerCENative\amd64\Microsoft.VC90.CRT\msvcr90.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SQLServerCENative\amd64\Microsoft.VC90.CRT\README_ENU.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SQLServerCENative\amd64\sqlceca40.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SQLServerCENative\amd64\sqlcecompact40.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SQLServerCENative\amd64\sqlceer40EN.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SQLServerCENative\amd64\sqlceme40.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SQLServerCENative\amd64\sqlceqp40.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SQLServerCENative\amd64\sqlcese40.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SQLServerCENative\x86\Microsoft.VC90.CRT\msvcr90.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SQLServerCENative\x86\Microsoft.VC90.CRT\README_ENU.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SQLServerCENative\x86\sqlceca40.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SQLServerCENative\x86\sqlcecompact40.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SQLServerCENative\x86\sqlceer40EN.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SQLServerCENative\x86\sqlceme40.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SQLServerCENative\x86\sqlceqp40.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SQLServerCENative\x86\sqlcese40.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
@@ -332,8 +370,12 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="SQLServerCENative\amd64\Microsoft.VC90.CRT\Microsoft.VC90.CRT.manifest" />
-    <Content Include="SQLServerCENative\x86\Microsoft.VC90.CRT\Microsoft.VC90.CRT.manifest" />
+    <Content Include="SQLServerCENative\amd64\Microsoft.VC90.CRT\Microsoft.VC90.CRT.manifest">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SQLServerCENative\x86\Microsoft.VC90.CRT\Microsoft.VC90.CRT.manifest">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
+++ b/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
@@ -294,63 +294,25 @@
     <Compile Include="VersionOrderInvalidException.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\FluentMigrator\FluentMigrator.csproj">
-      <Project>{FD9410F9-6FEA-47F7-A78E-B4F6FB0539B8}</Project>
-      <Name>FluentMigrator</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <None Include="..\FluentMigrator.snk">
       <Link>FluentMigrator.snk</Link>
     </None>
-    <Content Include="SQLServerCENative\amd64\Microsoft.VC90.CRT\msvcr90.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="SQLServerCENative\amd64\Microsoft.VC90.CRT\README_ENU.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="SQLServerCENative\amd64\sqlceca40.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="SQLServerCENative\amd64\sqlcecompact40.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="SQLServerCENative\amd64\sqlceer40EN.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="SQLServerCENative\amd64\sqlceme40.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="SQLServerCENative\amd64\sqlceqp40.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="SQLServerCENative\amd64\sqlcese40.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="SQLServerCENative\x86\Microsoft.VC90.CRT\msvcr90.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="SQLServerCENative\x86\Microsoft.VC90.CRT\README_ENU.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="SQLServerCENative\x86\sqlceca40.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="SQLServerCENative\x86\sqlcecompact40.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="SQLServerCENative\x86\sqlceer40EN.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="SQLServerCENative\x86\sqlceme40.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="SQLServerCENative\x86\sqlceqp40.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="SQLServerCENative\x86\sqlcese40.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    <Content Include="SQLServerCENative\amd64\Microsoft.VC90.CRT\msvcr90.dll" />
+    <Content Include="SQLServerCENative\amd64\Microsoft.VC90.CRT\README_ENU.txt" />
+    <Content Include="SQLServerCENative\amd64\sqlceca40.dll" />
+    <Content Include="SQLServerCENative\amd64\sqlcecompact40.dll" />
+    <Content Include="SQLServerCENative\amd64\sqlceer40EN.dll" />
+    <Content Include="SQLServerCENative\amd64\sqlceme40.dll" />
+    <Content Include="SQLServerCENative\amd64\sqlceqp40.dll" />
+    <Content Include="SQLServerCENative\amd64\sqlcese40.dll" />
+    <Content Include="SQLServerCENative\x86\Microsoft.VC90.CRT\msvcr90.dll" />
+    <Content Include="SQLServerCENative\x86\Microsoft.VC90.CRT\README_ENU.txt" />
+    <Content Include="SQLServerCENative\x86\sqlceca40.dll" />
+    <Content Include="SQLServerCENative\x86\sqlcecompact40.dll" />
+    <Content Include="SQLServerCENative\x86\sqlceer40EN.dll" />
+    <Content Include="SQLServerCENative\x86\sqlceme40.dll" />
+    <Content Include="SQLServerCENative\x86\sqlceqp40.dll" />
+    <Content Include="SQLServerCENative\x86\sqlcese40.dll" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
@@ -370,12 +332,8 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="SQLServerCENative\amd64\Microsoft.VC90.CRT\Microsoft.VC90.CRT.manifest">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="SQLServerCENative\x86\Microsoft.VC90.CRT\Microsoft.VC90.CRT.manifest">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    <Content Include="SQLServerCENative\amd64\Microsoft.VC90.CRT\Microsoft.VC90.CRT.manifest" />
+    <Content Include="SQLServerCENative\x86\Microsoft.VC90.CRT\Microsoft.VC90.CRT.manifest" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/FluentMigrator.Runner/Initialization/IRunnerContext.cs
+++ b/src/FluentMigrator.Runner/Initialization/IRunnerContext.cs
@@ -46,5 +46,7 @@ namespace FluentMigrator.Runner.Initialization
 
         /// <summary>The arbitrary application context passed to the task runner.</summary>
         object ApplicationContext { get; set; }
+
+        string SchemaName { get; set; }
     }
 }

--- a/src/FluentMigrator.Runner/Initialization/RunnerContext.cs
+++ b/src/FluentMigrator.Runner/Initialization/RunnerContext.cs
@@ -43,5 +43,7 @@ namespace FluentMigrator.Runner.Initialization
 
         /// <summary>The arbitrary application context passed to the task runner.</summary>
         public object ApplicationContext { get; set; }
+
+        public string SchemaName { get; set; }
     }
 }

--- a/src/FluentMigrator.Runner/VersionLoader.cs
+++ b/src/FluentMigrator.Runner/VersionLoader.cs
@@ -73,6 +73,11 @@ namespace FluentMigrator.Runner
 
             if (matchedType == null)
             {
+                if (!string.IsNullOrEmpty(Conventions.GetDefaultSchema()))
+                {
+                    return new DefaultVersionTableMetaDataInSchema(Conventions.GetDefaultSchema());
+                }
+
                 return new DefaultVersionTableMetaData();
             }
 

--- a/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -333,6 +333,7 @@
     <Compile Include="Unit\Definitions\ColumnDefinitionTests.cs" />
     <Compile Include="Unit\Definitions\ForeignKeyDefinitionTests.cs" />
     <Compile Include="Unit\Definitions\IndexColumnDefinitionTests.cs" />
+    <Compile Include="Unit\Definitions\ConstraintDefinitionTests.cs" />
     <Compile Include="Unit\Definitions\IndexDefinitionTests.cs" />
     <Compile Include="Unit\Expressions\AlterColumnExpressionTests.cs" />
     <Compile Include="Unit\Expressions\AlterDefaultConstraintExpressionTests.cs" />
@@ -347,6 +348,8 @@
     <Compile Include="Unit\Expressions\CreateTableExpressionTests.cs" />
     <Compile Include="Unit\Expressions\DeleteColumnExpressionTests.cs" />
     <Compile Include="Unit\Expressions\DeleteConstraintExpressionTests.cs" />
+    <Compile Include="Unit\Definitions\SequenceDefinitionTests.cs" />
+    <Compile Include="Unit\Definitions\TableDefinitionTests.cs" />
     <Compile Include="Unit\Expressions\DeleteDefaultConstraintExpressionTests.cs" />
     <Compile Include="Unit\Expressions\DeleteForeignKeyExpressionTests.cs" />
     <Compile Include="Unit\Expressions\DeleteIndexExpressionTests.cs" />

--- a/src/FluentMigrator.Tests/Integration/MigrationRunnerTests.cs
+++ b/src/FluentMigrator.Tests/Integration/MigrationRunnerTests.cs
@@ -839,11 +839,13 @@ namespace FluentMigrator.Tests.Integration
                                 {
                                     var runner = new MigrationRunner(Assembly.GetExecutingAssembly(), _runnerContext, processor);
 
-                                    runner.Up(new TestCreateSequence());
+                                    runner.Up(new TestCreateSchema());
+                                    runner.Up(new TestCreateSequenceWithSchema());
                                     processor.SequenceExists("TestSchema", "TestSequence");
 
-                                    runner.Down(new TestCreateSequence());
+                                    runner.Down(new TestCreateSequenceWithSchema());
                                     processor.SequenceExists("TestSchema", "TestSequence").ShouldBeFalse();
+                                    runner.Down(new TestCreateSchema());
                                 };
 
             ExecuteWithSqlServer2012(

--- a/src/FluentMigrator.Tests/Unit/DefaultMigrationConventionsTests.cs
+++ b/src/FluentMigrator.Tests/Unit/DefaultMigrationConventionsTests.cs
@@ -16,8 +16,6 @@
 //
 #endregion
 
-using System.IO;
-using System.Reflection;
 using FluentMigrator.Infrastructure;
 using FluentMigrator.Model;
 using NUnit.Framework;
@@ -157,6 +155,14 @@ namespace FluentMigrator.Tests.Unit
 
             defaultWorkingDirectory.ShouldNotBeNull();
             defaultWorkingDirectory.Contains("bin").ShouldBeTrue();
+        }
+
+        [Test]
+        public void DefaultSchemaConventionDefaultsToNull()
+        {
+            var defaultSchema = DefaultMigrationConventions.GetDefaultSchema();
+
+            Assert.That(defaultSchema, Is.Null);
         }
 
         [Test]

--- a/src/FluentMigrator.Tests/Unit/Definitions/ConstraintDefinitionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Definitions/ConstraintDefinitionTests.cs
@@ -1,0 +1,40 @@
+﻿using FluentMigrator.Model;
+using NUnit.Framework;
+
+namespace FluentMigrator.Tests.Unit.Definitions
+{
+    [TestFixture]
+    public class ConstraintDefinitionTests
+    {
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsNotSetThenSchemaShouldBeNull()
+        {
+            var constraintDefinition = new ConstraintDefinition(ConstraintType.PrimaryKey) { ConstraintName = "Test" };
+
+            constraintDefinition.ApplyConventions(new MigrationConventions());
+
+            Assert.That(constraintDefinition.SchemaName, Is.Null);
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsSetThenSchemaShouldNotBeChanged()
+        {
+            var constraintDefinition = new ConstraintDefinition(ConstraintType.PrimaryKey) { ConstraintName = "Test", SchemaName = "testschema" };
+
+            constraintDefinition.ApplyConventions(new MigrationConventions());
+
+            Assert.That(constraintDefinition.SchemaName, Is.EqualTo("testschema"));
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsChangedAndSchemaIsNotSetThenSetSchema()
+        {
+            var constraintDefinition = new ConstraintDefinition(ConstraintType.PrimaryKey) { ConstraintName = "Test" };
+            var migrationConventions = new MigrationConventions { GetDefaultSchema = () => "testdefault" };
+
+            constraintDefinition.ApplyConventions(migrationConventions);
+
+            Assert.That(constraintDefinition.SchemaName, Is.EqualTo("testdefault"));
+        } 
+    }
+}

--- a/src/FluentMigrator.Tests/Unit/Definitions/ForeignKeyDefinitionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Definitions/ForeignKeyDefinitionTests.cs
@@ -123,5 +123,39 @@ namespace FluentMigrator.Tests.Unit.Definitions
             var errors = ValidationHelper.CollectErrors(column);
             errors.ShouldNotContain(ErrorMessages.ForeignKeyMustHaveOneOrMorePrimaryColumns);
         }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsNotSetThenSchemaShouldBeNull()
+        {
+            var foreignKeyDefinition = new ForeignKeyDefinition { Name = "Test" };
+
+            foreignKeyDefinition.ApplyConventions(new MigrationConventions());
+
+            Assert.That(foreignKeyDefinition.ForeignTableSchema, Is.Null);
+            Assert.That(foreignKeyDefinition.PrimaryTableSchema, Is.Null);
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsSetThenSchemaShouldNotBeChanged()
+        {
+            var foreignKeyDefinition = new ForeignKeyDefinition { Name = "Test", ForeignTableSchema = "testschema", PrimaryTableSchema = "testschema" };
+
+            foreignKeyDefinition.ApplyConventions(new MigrationConventions());
+
+            Assert.That(foreignKeyDefinition.ForeignTableSchema, Is.EqualTo("testschema"));
+            Assert.That(foreignKeyDefinition.PrimaryTableSchema, Is.EqualTo("testschema"));
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsChangedAndSchemaIsNotSetThenSetSchema()
+        {
+            var foreignKeyDefinition = new ForeignKeyDefinition { Name = "Test" };
+            var migrationConventions = new MigrationConventions { GetDefaultSchema = () => "testdefault" };
+
+            foreignKeyDefinition.ApplyConventions(migrationConventions);
+
+            Assert.That(foreignKeyDefinition.ForeignTableSchema, Is.EqualTo("testdefault"));
+            Assert.That(foreignKeyDefinition.PrimaryTableSchema, Is.EqualTo("testdefault"));
+        }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Definitions/IndexDefinitionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Definitions/IndexDefinitionTests.cs
@@ -16,5 +16,35 @@ namespace FluentMigrator.Tests.Unit.Definitions
 
             Assert.AreEqual("IX_Table_Name", indexDefinition.Name);
         }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsNotSetThenSchemaShouldBeNull()
+        {
+            var indexDefinition = new IndexDefinition { Name = "Test" };
+
+            indexDefinition.ApplyConventions(new MigrationConventions());
+
+            Assert.That(indexDefinition.SchemaName, Is.Null);
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsSetThenSchemaShouldNotBeChanged()
+        {
+            var indexDefinition = new IndexDefinition{ Name = "Test", SchemaName = "testschema" };
+
+            indexDefinition.ApplyConventions(new MigrationConventions());
+
+            Assert.That(indexDefinition.SchemaName, Is.EqualTo("testschema"));
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsChangedAndSchemaIsNotSetThenSetSchema()
+        {
+            var indexDefinition = new IndexDefinition { Name = "Test" };
+            var migrationConventions = new MigrationConventions {GetDefaultSchema = () => "testdefault"};
+            indexDefinition.ApplyConventions(migrationConventions);
+
+            Assert.That(indexDefinition.SchemaName, Is.EqualTo("testdefault"));
+        }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Definitions/SequenceDefinitionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Definitions/SequenceDefinitionTests.cs
@@ -1,0 +1,40 @@
+﻿using FluentMigrator.Model;
+using NUnit.Framework;
+
+namespace FluentMigrator.Tests.Unit.Definitions
+{
+    [TestFixture]
+    public class SequenceDefinitionTests
+    {
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsNotSetThenSchemaShouldBeNull()
+        {
+            var sequenceDefinition = new SequenceDefinition { Name = "Test" };
+
+            sequenceDefinition.ApplyConventions(new MigrationConventions());
+
+            Assert.That(sequenceDefinition.SchemaName, Is.Null);
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsSetThenSchemaShouldNotBeChanged()
+        {
+            var sequenceDefinition = new SequenceDefinition { Name = "Test", SchemaName = "testschema" };
+
+            sequenceDefinition.ApplyConventions(new MigrationConventions());
+
+            Assert.That(sequenceDefinition.SchemaName, Is.EqualTo("testschema"));
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsChangedAndSchemaIsNotSetThenSetSchema()
+        {
+            var sequenceDefinition = new SequenceDefinition { Name = "Test" };
+            var migrationConventions = new MigrationConventions { GetDefaultSchema = () => "testdefault" };
+
+            sequenceDefinition.ApplyConventions(migrationConventions);
+
+            Assert.That(sequenceDefinition.SchemaName, Is.EqualTo("testdefault"));
+        } 
+    }
+}

--- a/src/FluentMigrator.Tests/Unit/Definitions/TableDefinitionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Definitions/TableDefinitionTests.cs
@@ -1,0 +1,40 @@
+﻿using FluentMigrator.Model;
+using NUnit.Framework;
+
+namespace FluentMigrator.Tests.Unit.Definitions
+{
+    [TestFixture]
+    public class TableDefinitionTests
+    {
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsNotSetThenSchemaShouldBeNull()
+        {
+            var table = new TableDefinition {Name = "Test"};
+
+            table.ApplyConventions(new MigrationConventions());
+
+            Assert.That(table.SchemaName, Is.Null);
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsSetThenSchemaShouldNotBeChanged()
+        {
+            var table = new TableDefinition { Name = "Test", SchemaName = "testschema"};
+
+            table.ApplyConventions(new MigrationConventions());
+
+            Assert.That(table.SchemaName, Is.EqualTo("testschema"));
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsChangedAndSchemaIsNotSetThenSetSchema()
+        {
+            var table = new TableDefinition { Name = "Test" };
+            var migrationConventions = new MigrationConventions {GetDefaultSchema = () => "testdefault"};
+
+            table.ApplyConventions(migrationConventions);
+
+            Assert.That(table.SchemaName, Is.EqualTo("testdefault"));
+        }
+    }
+}

--- a/src/FluentMigrator.Tests/Unit/Expressions/AlterColumnExpressionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Expressions/AlterColumnExpressionTests.cs
@@ -67,5 +67,36 @@ namespace FluentMigrator.Tests.Unit.Expressions
             var expression = new AlterColumnExpression { TableName = "Bacon", Column = { Name = "BaconId", Type = DbType.Int32 } };
             expression.ToString().ShouldBe("AlterColumn Bacon BaconId Int32");
         }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsNotSetThenSchemaShouldBeNull()
+        {
+            var expression = new AlterColumnExpression { TableName = "Bacon", Column = { Name = "BaconId", Type = DbType.Int32 } };
+
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.Null);
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsSetThenSchemaShouldNotBeChanged()
+        {
+            var expression = new AlterColumnExpression { SchemaName = "testschema", TableName = "Bacon", Column = { Name = "BaconId", Type = DbType.Int32 } };
+
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testschema"));
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsChangedAndSchemaIsNotSetThenSetSchema()
+        {
+            var expression = new AlterColumnExpression { TableName = "Bacon", Column = { Name = "BaconId", Type = DbType.Int32 } };
+            var migrationConventions = new MigrationConventions { GetDefaultSchema = () => "testdefault" };
+
+            expression.ApplyConventions(migrationConventions);
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testdefault"));
+        }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Expressions/AlterDefaultConstraintExpressionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Expressions/AlterDefaultConstraintExpressionTests.cs
@@ -44,5 +44,36 @@ namespace FluentMigrator.Tests.Unit.Expressions
             var errors = ValidationHelper.CollectErrors(expression);
             Assert.That(errors.Count, Is.EqualTo(0));
         }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsNotSetThenSchemaShouldBeNull()
+        {
+            var expression = new AlterDefaultConstraintExpression { TableName = "test", ColumnName = "Column1", DefaultValue = SystemMethods.CurrentDateTime };
+
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.Null);
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsSetThenSchemaShouldNotBeChanged()
+        {
+            var expression = new AlterDefaultConstraintExpression { SchemaName = "testschema", TableName = "test", ColumnName = "Column1", DefaultValue = SystemMethods.CurrentDateTime };
+
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testschema"));
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsChangedAndSchemaIsNotSetThenSetSchema()
+        {
+            var expression = new AlterDefaultConstraintExpression { TableName = "test", ColumnName = "Column1", DefaultValue = SystemMethods.CurrentDateTime };
+            var migrationConventions = new MigrationConventions { GetDefaultSchema = () => "testdefault" };
+
+            expression.ApplyConventions(migrationConventions);
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testdefault"));
+        }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Expressions/AlterTableExpressionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Expressions/AlterTableExpressionTests.cs
@@ -27,5 +27,36 @@ namespace FluentMigrator.Tests.Unit.Expressions
             var errors = ValidationHelper.CollectErrors(expression);
             Assert.That(errors.Count, Is.EqualTo(0));
         }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsNotSetThenSchemaShouldBeNull()
+        {
+            var expression = new AlterTableExpression { TableName = "table1" };
+
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.Null);
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsSetThenSchemaShouldNotBeChanged()
+        {
+            var expression = new AlterTableExpression { SchemaName = "testschema", TableName = "table1" };
+
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testschema"));
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsChangedAndSchemaIsNotSetThenSetSchema()
+        {
+            var expression = new AlterTableExpression { TableName = "table1" };
+            var migrationConventions = new MigrationConventions { GetDefaultSchema = () => "testdefault" };
+
+            expression.ApplyConventions(migrationConventions);
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testdefault"));
+        }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Expressions/CreateColumnExpressionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Expressions/CreateColumnExpressionTests.cs
@@ -85,5 +85,36 @@ namespace FluentMigrator.Tests.Unit.Expressions
             var expression = new CreateColumnExpression { TableName = "Bacon", Column = { Name = "BaconId", Type = DbType.Int32 } };
             expression.ToString().ShouldBe("CreateColumn Bacon BaconId Int32");
         }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsNotSetThenSchemaShouldBeNull()
+        {
+            var expression = new CreateColumnExpression { TableName = "Bacon", Column = { Name = "BaconId", Type = DbType.Int32 } };
+
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.Null);
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsSetThenSchemaShouldNotBeChanged()
+        {
+            var expression = new CreateColumnExpression { SchemaName = "testschema", TableName = "Bacon", Column = { Name = "BaconId", Type = DbType.Int32 } };
+
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testschema"));
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsChangedAndSchemaIsNotSetThenSetSchema()
+        {
+            var expression = new CreateColumnExpression { TableName = "Bacon", Column = { Name = "BaconId", Type = DbType.Int32 } };
+            var migrationConventions = new MigrationConventions { GetDefaultSchema = () => "testdefault" };
+
+            expression.ApplyConventions(migrationConventions);
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testdefault"));
+        }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Expressions/CreateTableExpressionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Expressions/CreateTableExpressionTests.cs
@@ -54,5 +54,36 @@ namespace FluentMigrator.Tests.Unit.Expressions
             var errors = ValidationHelper.CollectErrors(expression);
             Assert.That(errors.Count, Is.EqualTo(0));
         }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsNotSetThenSchemaShouldBeNull()
+        {
+            var expression = new CreateTableExpression { TableName = "table1" };
+
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.Null);
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsSetThenSchemaShouldNotBeChanged()
+        {
+            var expression = new CreateTableExpression { SchemaName = "testschema", TableName = "table1" };
+
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testschema"));
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsChangedAndSchemaIsNotSetThenSetSchema()
+        {
+            var expression = new CreateTableExpression { TableName = "table1" };
+            var migrationConventions = new MigrationConventions { GetDefaultSchema = () => "testdefault" };
+
+            expression.ApplyConventions(migrationConventions);
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testdefault"));
+        }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Expressions/DeleteColumnExpressionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Expressions/DeleteColumnExpressionTests.cs
@@ -97,5 +97,36 @@ namespace FluentMigrator.Tests.Unit.Expressions
             var expression = new DeleteColumnExpression { TableName = "Test", ColumnNames = {"Bacon"} };
             expression.ToString().ShouldBe("DeleteColumn Test Bacon");
         }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsNotSetThenSchemaShouldBeNull()
+        {
+            var expression = new DeleteColumnExpression { TableName = "Test", ColumnNames = { "Bacon" } };
+
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.Null);
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsSetThenSchemaShouldNotBeChanged()
+        {
+            var expression = new DeleteColumnExpression { SchemaName = "testschema", TableName = "Test", ColumnNames = { "Bacon" } };
+
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testschema"));
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsChangedAndSchemaIsNotSetThenSetSchema()
+        {
+            var expression = new DeleteColumnExpression { TableName = "Test", ColumnNames = { "Bacon" } };
+            var migrationConventions = new MigrationConventions { GetDefaultSchema = () => "testdefault" };
+
+            expression.ApplyConventions(migrationConventions);
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testdefault"));
+        }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Expressions/DeleteDefaultConstraintExpressionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Expressions/DeleteDefaultConstraintExpressionTests.cs
@@ -61,5 +61,36 @@ namespace FluentMigrator.Tests.Unit.Expressions
 
             expression.ToString().ShouldBe("DeleteDefaultConstraint ThaSchema.ThaTable ThaColumn");
         }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsNotSetThenSchemaShouldBeNull()
+        {
+            var expression = new DeleteDefaultConstraintExpression { TableName = "ThaTable", ColumnName = "ThaColumn" };
+
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.Null);
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsSetThenSchemaShouldNotBeChanged()
+        {
+            var expression = new DeleteDefaultConstraintExpression { SchemaName = "testschema", TableName = "ThaTable", ColumnName = "ThaColumn" };
+
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testschema"));
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsChangedAndSchemaIsNotSetThenSetSchema()
+        {
+            var expression = new DeleteDefaultConstraintExpression { TableName = "ThaTable", ColumnName = "ThaColumn" };
+            var migrationConventions = new MigrationConventions { GetDefaultSchema = () => "testdefault" };
+
+            expression.ApplyConventions(migrationConventions);
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testdefault"));
+        }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Expressions/DeleteSequenceExpressionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Expressions/DeleteSequenceExpressionTests.cs
@@ -28,5 +28,36 @@ namespace FluentMigrator.Tests.Unit.Expressions
             var errors = ValidationHelper.CollectErrors(expression);
             Assert.That(errors.Count, Is.EqualTo(0));
         }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsNotSetThenSchemaShouldBeNull()
+        {
+            var expression = new DeleteSequenceExpression { SequenceName = "sequence1" };
+
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.Null);
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsSetThenSchemaShouldNotBeChanged()
+        {
+            var expression = new DeleteSequenceExpression { SchemaName = "testschema", SequenceName = "sequence1" };
+
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testschema"));
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsChangedAndSchemaIsNotSetThenSetSchema()
+        {
+            var expression = new DeleteSequenceExpression { SequenceName = "sequence1" };
+            var migrationConventions = new MigrationConventions { GetDefaultSchema = () => "testdefault" };
+
+            expression.ApplyConventions(migrationConventions);
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testdefault"));
+        }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Expressions/DeleteTableExpressionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Expressions/DeleteTableExpressionTests.cs
@@ -65,5 +65,36 @@ namespace FluentMigrator.Tests.Unit.Expressions
             var expression = new DeleteTableExpression { TableName = "Bacon" };
             expression.ToString().ShouldBe("DeleteTable Bacon");
         }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsNotSetThenSchemaShouldBeNull()
+        {
+            var expression = new DeleteTableExpression { TableName = "table1" };
+
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.Null);
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsSetThenSchemaShouldNotBeChanged()
+        {
+            var expression = new DeleteTableExpression { SchemaName = "testschema", TableName = "table1" };
+
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testschema"));
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsChangedAndSchemaIsNotSetThenSetSchema()
+        {
+            var expression = new DeleteTableExpression { TableName = "table1" };
+            var migrationConventions = new MigrationConventions { GetDefaultSchema = () => "testdefault" };
+
+            expression.ApplyConventions(migrationConventions);
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testdefault"));
+        }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Expressions/RenameColumnExpressionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Expressions/RenameColumnExpressionTests.cs
@@ -101,5 +101,36 @@ namespace FluentMigrator.Tests.Unit.Expressions
             var expression = new RenameColumnExpression { TableName = "Bacon", OldName = "BaconId", NewName = "ChunkyBaconId" };
             expression.ToString().ShouldBe("RenameColumn Bacon BaconId to ChunkyBaconId");
         }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsNotSetThenSchemaShouldBeNull()
+        {
+            var expression = new RenameColumnExpression { TableName = "Bacon", OldName = "BaconId", NewName = "ChunkyBaconId" };
+
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.Null);
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsSetThenSchemaShouldNotBeChanged()
+        {
+            var expression = new RenameColumnExpression { SchemaName = "testschema", TableName = "Bacon", OldName = "BaconId", NewName = "ChunkyBaconId" };
+
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testschema"));
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsChangedAndSchemaIsNotSetThenSetSchema()
+        {
+            var expression = new RenameColumnExpression { TableName = "Bacon", OldName = "BaconId", NewName = "ChunkyBaconId" };
+            var migrationConventions = new MigrationConventions { GetDefaultSchema = () => "testdefault" };
+
+            expression.ApplyConventions(migrationConventions);
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testdefault"));
+        }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Expressions/RenameTableExpressionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Expressions/RenameTableExpressionTests.cs
@@ -99,5 +99,36 @@ namespace FluentMigrator.Tests.Unit.Expressions
             var expression = new RenameTableExpression { OldName = "Bacon", NewName = "ChunkyBacon" };
             expression.ToString().ShouldBe("RenameTable Bacon ChunkyBacon");
         }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsNotSetThenSchemaShouldBeNull()
+        {
+            var expression = new RenameTableExpression { OldName = "Bacon", NewName = "ChunkyBacon" };
+
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.Null);
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsSetThenSchemaShouldNotBeChanged()
+        {
+            var expression = new RenameTableExpression { SchemaName = "testschema", OldName = "Bacon", NewName = "ChunkyBacon" };
+
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testschema"));
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsChangedAndSchemaIsNotSetThenSetSchema()
+        {
+            var expression = new RenameTableExpression { OldName = "Bacon", NewName = "ChunkyBacon" };
+            var migrationConventions = new MigrationConventions { GetDefaultSchema = () => "testdefault" };
+
+            expression.ApplyConventions(migrationConventions);
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testdefault"));
+        }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Expressions/UpdateDataExpressionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Expressions/UpdateDataExpressionTests.cs
@@ -64,5 +64,33 @@ namespace FluentMigrator.Tests.Unit.Expressions
             var errors = ValidationHelper.CollectErrors(expression);
             errors.ShouldContain(ErrorMessages.UpdateDataExpressionMustNotSpecifyBothWhereClauseAndAllRows);
         }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsNotSetThenSchemaShouldBeNull()
+        {
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.Null);
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsSetThenSchemaShouldNotBeChanged()
+        {
+            expression.SchemaName = "testschema";
+
+            expression.ApplyConventions(new MigrationConventions());
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testschema"));
+        }
+
+        [Test]
+        public void WhenDefaultSchemaConventionIsChangedAndSchemaIsNotSetThenSetSchema()
+        {
+            var migrationConventions = new MigrationConventions { GetDefaultSchema = () => "testdefault" };
+
+            expression.ApplyConventions(migrationConventions);
+
+            Assert.That(expression.SchemaName, Is.EqualTo("testdefault"));
+        }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/MigrationRunnerTests.cs
+++ b/src/FluentMigrator.Tests/Unit/MigrationRunnerTests.cs
@@ -543,8 +543,19 @@ namespace FluentMigrator.Tests.Unit
         [Test]
         public void CanLoadDefaultMigrationConventionsIfNoCustomConventionsAreSpecified()
         {
+            var processorMock = new Mock<IMigrationProcessor>(MockBehavior.Loose);
+
+            var options = new ProcessorOptions
+            {
+                PreviewOnly = false
+            };
+
+            processorMock.SetupGet(x => x.Options).Returns(options);
+
             var asm = "s".GetType().Assembly;
-            var runner = new MigrationRunner(asm, _runnerContextMock.Object, _processorMock.Object);
+
+            var runner = new MigrationRunner(asm, _runnerContextMock.Object, processorMock.Object);
+
             Assert.That(runner.Conventions, Is.TypeOf<MigrationConventions>());
             Assert.That(runner.Conventions.GetDefaultSchema.Invoke(), Is.Null);
         }

--- a/src/FluentMigrator.Tests/Unit/MigrationRunnerTests.cs
+++ b/src/FluentMigrator.Tests/Unit/MigrationRunnerTests.cs
@@ -533,5 +533,29 @@ namespace FluentMigrator.Tests.Unit
             _announcer.Verify(a => a.Error(It.Is<string>(s => s.Contains("CreateColumnExpression: The table's name cannot be null or an empty string. The column's name cannot be null or an empty string. The column does not have a type defined."))));
         }
 
+        [Test]
+        public void CanLoadCustomMigrationConventions()
+        {
+            Assert.That(_runner.Conventions, Is.TypeOf<CustomMigrationConventions>());
+            Assert.That(_runner.Conventions.GetWorkingDirectory.Invoke(), Is.EqualTo("testwd"));
+        }
+
+        [Test]
+        public void CanLoadDefaultMigrationConventionsIfNoCustomConventionsAreSpecified()
+        {
+            var asm = "s".GetType().Assembly;
+            var runner = new MigrationRunner(asm, _runnerContextMock.Object, _processorMock.Object);
+            Assert.That(runner.Conventions, Is.TypeOf<MigrationConventions>());
+            Assert.That(runner.Conventions.GetDefaultSchema.Invoke(), Is.Null);
+        }
+
+    }
+
+    public class CustomMigrationConventions : MigrationConventions
+    {
+        public CustomMigrationConventions()
+        {
+            GetWorkingDirectory = () => "testwd";
+        }
     }
 }

--- a/src/FluentMigrator/Expressions/AlterColumnExpression.cs
+++ b/src/FluentMigrator/Expressions/AlterColumnExpression.cs
@@ -23,7 +23,7 @@ using FluentMigrator.Model;
 
 namespace FluentMigrator.Expressions
 {
-    public class AlterColumnExpression : MigrationExpressionBase
+    public class AlterColumnExpression : MigrationExpressionBase, ICanBeConventional
     {
         public virtual string SchemaName { get; set; }
         public virtual string TableName { get; set; }
@@ -32,6 +32,12 @@ namespace FluentMigrator.Expressions
         public AlterColumnExpression()
         {
             Column = new ColumnDefinition() { ModificationType = ColumnModificationType.Alter };
+        }
+
+        public override void ApplyConventions(IMigrationConventions conventions)
+        {
+            if (String.IsNullOrEmpty(SchemaName))
+                SchemaName = conventions.GetDefaultSchema();
         }
 
         public override void CollectValidationErrors(ICollection<string> errors)

--- a/src/FluentMigrator/Expressions/AlterDefaultConstraintExpression.cs
+++ b/src/FluentMigrator/Expressions/AlterDefaultConstraintExpression.cs
@@ -4,12 +4,18 @@ using FluentMigrator.Infrastructure;
 
 namespace FluentMigrator.Expressions
 {
-    public class AlterDefaultConstraintExpression : MigrationExpressionBase
+    public class AlterDefaultConstraintExpression : MigrationExpressionBase, ICanBeConventional
     {
         public virtual string SchemaName { get; set; }
         public virtual string TableName { get; set; }
         public virtual string ColumnName { get; set; }
         public virtual object DefaultValue { get; set; }
+
+        public override void ApplyConventions(IMigrationConventions conventions)
+        {
+            if (String.IsNullOrEmpty(SchemaName))
+                SchemaName = conventions.GetDefaultSchema();
+        }
 
         public override void CollectValidationErrors(ICollection<string> errors)
         {

--- a/src/FluentMigrator/Expressions/AlterTableExpression.cs
+++ b/src/FluentMigrator/Expressions/AlterTableExpression.cs
@@ -16,12 +16,13 @@
 //
 #endregion
 
+using System;
 using System.Collections.Generic;
 using FluentMigrator.Infrastructure;
 
 namespace FluentMigrator.Expressions
 {
-    public class AlterTableExpression : MigrationExpressionBase
+    public class AlterTableExpression : MigrationExpressionBase, ICanBeConventional
     {
         public virtual string SchemaName { get; set; }
         public virtual string TableName { get; set; }
@@ -29,6 +30,12 @@ namespace FluentMigrator.Expressions
 
         public AlterTableExpression()
         {
+        }
+
+        public override void ApplyConventions(IMigrationConventions conventions)
+        {
+            if (String.IsNullOrEmpty(SchemaName))
+                SchemaName = conventions.GetDefaultSchema();
         }
 
         public override void CollectValidationErrors(ICollection<string> errors)

--- a/src/FluentMigrator/Expressions/CreateColumnExpression.cs
+++ b/src/FluentMigrator/Expressions/CreateColumnExpression.cs
@@ -23,7 +23,7 @@ using FluentMigrator.Model;
 
 namespace FluentMigrator.Expressions
 {
-    public class CreateColumnExpression : MigrationExpressionBase
+    public class CreateColumnExpression : MigrationExpressionBase, ICanBeConventional
     {
         public virtual string SchemaName { get; set; }
         public virtual string TableName { get; set; }
@@ -36,6 +36,9 @@ namespace FluentMigrator.Expressions
 
         public override void ApplyConventions(IMigrationConventions conventions)
         {
+            if (String.IsNullOrEmpty(SchemaName))
+                SchemaName = conventions.GetDefaultSchema();
+
             Column.ApplyConventions(conventions);
         }
 

--- a/src/FluentMigrator/Expressions/CreateTableExpression.cs
+++ b/src/FluentMigrator/Expressions/CreateTableExpression.cs
@@ -23,7 +23,7 @@ using FluentMigrator.Model;
 
 namespace FluentMigrator.Expressions
 {
-    public class CreateTableExpression : MigrationExpressionBase
+    public class CreateTableExpression : MigrationExpressionBase, ICanBeConventional
     {
         public virtual string SchemaName { get; set; }
         public virtual string TableName { get; set; }
@@ -37,6 +37,9 @@ namespace FluentMigrator.Expressions
 
         public override void ApplyConventions(IMigrationConventions conventions)
         {
+            if (String.IsNullOrEmpty(SchemaName))
+                SchemaName = conventions.GetDefaultSchema();
+
             foreach (var column in Columns)
                 column.ApplyConventions(conventions);
         }

--- a/src/FluentMigrator/Expressions/DeleteColumnExpression.cs
+++ b/src/FluentMigrator/Expressions/DeleteColumnExpression.cs
@@ -23,7 +23,7 @@ using FluentMigrator.Infrastructure;
 
 namespace FluentMigrator.Expressions
 {
-    public class DeleteColumnExpression : MigrationExpressionBase
+    public class DeleteColumnExpression : MigrationExpressionBase, ICanBeConventional
     {
         public DeleteColumnExpression()
         {
@@ -33,6 +33,12 @@ namespace FluentMigrator.Expressions
         public virtual string SchemaName { get; set; }
         public virtual string TableName { get; set; }
         public ICollection<string> ColumnNames { get; set; }
+
+        public override void ApplyConventions(IMigrationConventions conventions)
+        {
+            if (String.IsNullOrEmpty(SchemaName))
+                SchemaName = conventions.GetDefaultSchema();
+        }
 
         public override void CollectValidationErrors(ICollection<string> errors)
         {

--- a/src/FluentMigrator/Expressions/DeleteDataExpression.cs
+++ b/src/FluentMigrator/Expressions/DeleteDataExpression.cs
@@ -16,6 +16,7 @@
 //
 #endregion
 
+using System;
 using System.Collections.Generic;
 using FluentMigrator.Model;
 
@@ -63,6 +64,8 @@ namespace FluentMigrator.Expressions
 
         public void ApplyConventions(IMigrationConventions conventions)
         {
+            if (String.IsNullOrEmpty(SchemaName))
+                SchemaName = conventions.GetDefaultSchema();
         }
     }
 }

--- a/src/FluentMigrator/Expressions/DeleteDefaultConstraintExpression.cs
+++ b/src/FluentMigrator/Expressions/DeleteDefaultConstraintExpression.cs
@@ -4,7 +4,7 @@ using FluentMigrator.Infrastructure;
 
 namespace FluentMigrator.Expressions
 {
-    public class DeleteDefaultConstraintExpression : MigrationExpressionBase
+    public class DeleteDefaultConstraintExpression : MigrationExpressionBase, ICanBeConventional
     {
         public virtual string SchemaName { get; set; }
         public virtual string TableName { get; set; }
@@ -13,6 +13,12 @@ namespace FluentMigrator.Expressions
         public override void ExecuteWith(IMigrationProcessor processor)
         {
             processor.Process(this);
+        }
+
+        public override void ApplyConventions(IMigrationConventions conventions)
+        {
+            if (String.IsNullOrEmpty(SchemaName))
+                SchemaName = conventions.GetDefaultSchema();
         }
 
         public override void CollectValidationErrors(ICollection<string> errors)

--- a/src/FluentMigrator/Expressions/DeleteSequenceExpression.cs
+++ b/src/FluentMigrator/Expressions/DeleteSequenceExpression.cs
@@ -4,10 +4,16 @@ using FluentMigrator.Infrastructure;
 
 namespace FluentMigrator.Expressions
 {
-    public class DeleteSequenceExpression : MigrationExpressionBase
+    public class DeleteSequenceExpression : MigrationExpressionBase, ICanBeConventional
     {
         public virtual string SchemaName { get; set; }
         public virtual string SequenceName { get; set; }
+
+        public override void ApplyConventions(IMigrationConventions conventions)
+        {
+            if (String.IsNullOrEmpty(SchemaName))
+                SchemaName = conventions.GetDefaultSchema();
+        }
 
         public override void CollectValidationErrors(ICollection<string> errors)
         {

--- a/src/FluentMigrator/Expressions/DeleteTableExpression.cs
+++ b/src/FluentMigrator/Expressions/DeleteTableExpression.cs
@@ -22,10 +22,16 @@ using FluentMigrator.Infrastructure;
 
 namespace FluentMigrator.Expressions
 {
-    public class DeleteTableExpression : MigrationExpressionBase
+    public class DeleteTableExpression : MigrationExpressionBase, ICanBeConventional
     {
         public virtual string SchemaName { get; set; }
         public virtual string TableName { get; set; }
+
+        public override void ApplyConventions(IMigrationConventions conventions)
+        {
+            if (String.IsNullOrEmpty(SchemaName))
+                SchemaName = conventions.GetDefaultSchema();
+        }
 
         public override void CollectValidationErrors(ICollection<string> errors)
         {

--- a/src/FluentMigrator/Expressions/InsertDataExpression.cs
+++ b/src/FluentMigrator/Expressions/InsertDataExpression.cs
@@ -57,10 +57,10 @@ namespace FluentMigrator.Expressions
         public IMigrationExpression Reverse()
         {
             var expression = new DeleteDataExpression
-                                {
-                                    SchemaName = SchemaName,
-                                    TableName = TableName
-                                };
+            {
+                SchemaName = SchemaName,
+                TableName = TableName
+            };
 
             foreach (var row in Rows)
             {
@@ -75,6 +75,8 @@ namespace FluentMigrator.Expressions
 
         public void ApplyConventions(IMigrationConventions conventions)
         {
+            if (String.IsNullOrEmpty(SchemaName))
+                SchemaName = conventions.GetDefaultSchema();
         }
     }
 }

--- a/src/FluentMigrator/Expressions/RenameColumnExpression.cs
+++ b/src/FluentMigrator/Expressions/RenameColumnExpression.cs
@@ -22,12 +22,18 @@ using FluentMigrator.Infrastructure;
 
 namespace FluentMigrator.Expressions
 {
-    public class RenameColumnExpression : MigrationExpressionBase
+    public class RenameColumnExpression : MigrationExpressionBase, ICanBeConventional
     {
         public virtual string SchemaName { get; set; }
         public virtual string TableName { get; set; }
         public virtual string OldName { get; set; }
         public virtual string NewName { get; set; }
+
+        public override void ApplyConventions(IMigrationConventions conventions)
+        {
+            if (String.IsNullOrEmpty(SchemaName))
+                SchemaName = conventions.GetDefaultSchema();
+        }
 
         public override void CollectValidationErrors(ICollection<string> errors)
         {

--- a/src/FluentMigrator/Expressions/RenameTableExpression.cs
+++ b/src/FluentMigrator/Expressions/RenameTableExpression.cs
@@ -22,11 +22,17 @@ using FluentMigrator.Infrastructure;
 
 namespace FluentMigrator.Expressions
 {
-    public class RenameTableExpression : MigrationExpressionBase
+    public class RenameTableExpression : MigrationExpressionBase, ICanBeConventional
     {
         public virtual string SchemaName { get; set; }
         public virtual string OldName { get; set; }
         public virtual string NewName { get; set; }
+
+        public override void ApplyConventions(IMigrationConventions conventions)
+        {
+            if (String.IsNullOrEmpty(SchemaName))
+                SchemaName = conventions.GetDefaultSchema();
+        }
 
         public override void CollectValidationErrors(ICollection<string> errors)
         {

--- a/src/FluentMigrator/Expressions/UpdateDataExpression.cs
+++ b/src/FluentMigrator/Expressions/UpdateDataExpression.cs
@@ -22,7 +22,7 @@ using FluentMigrator.Infrastructure;
 
 namespace FluentMigrator.Expressions
 {
-    public class UpdateDataExpression : MigrationExpressionBase
+    public class UpdateDataExpression : MigrationExpressionBase, ICanBeConventional
     {
         public string SchemaName { get; set; }
         public string TableName { get; set; }
@@ -30,6 +30,12 @@ namespace FluentMigrator.Expressions
         public List<KeyValuePair<string, object>> Set { get; set; }
         public List<KeyValuePair<string, object>> Where { get; set; }
         public bool IsAllRows { get; set; }
+
+        public override void ApplyConventions(IMigrationConventions conventions)
+        {
+            if (String.IsNullOrEmpty(SchemaName))
+                SchemaName = conventions.GetDefaultSchema();
+        }
 
         public override void CollectValidationErrors(ICollection<string> errors)
         {

--- a/src/FluentMigrator/FluentMigrator.csproj
+++ b/src/FluentMigrator/FluentMigrator.csproj
@@ -123,6 +123,7 @@
     <Compile Include="..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="MigrationConventionsWithDefaultSchema.cs" />
     <Compile Include="MigrationStage.cs" />
     <Compile Include="MaintenanceAttribute.cs" />
     <Compile Include="Builders\Alter\AlterExpressionRoot.cs" />
@@ -266,6 +267,7 @@
     <Compile Include="AutoScriptMigration.cs" />
     <Compile Include="TimestampedMigrationAttribute.cs" />
     <Compile Include="TransactionBehavior.cs" />
+    <Compile Include="VersionTableInfo\DefaultVersionTableMetaDataInSchema.cs" />
     <Compile Include="VersionTableInfo\DefaultVersionTableMetaData.cs" />
     <Compile Include="VersionTableInfo\IVersionTableMetaData.cs" />
     <Compile Include="MigrationTraitAttribute.cs" />

--- a/src/FluentMigrator/IMigrationConventions.cs
+++ b/src/FluentMigrator/IMigrationConventions.cs
@@ -38,5 +38,6 @@ namespace FluentMigrator
         Func<Type, IEnumerable<string>, bool> TypeHasMatchingTags { get; set; }
         Func<Type,string,string> GetAutoScriptUpName {get;set;}
         Func<Type, string, string> GetAutoScriptDownName { get; set; }
+        Func<string> GetDefaultSchema { get; set; }
     }
 }

--- a/src/FluentMigrator/Infrastructure/DefaultMigrationConventions.cs
+++ b/src/FluentMigrator/Infrastructure/DefaultMigrationConventions.cs
@@ -175,5 +175,10 @@ namespace FluentMigrator.Infrastructure
             }
             return string.Empty;
         }
+
+        public static string GetDefaultSchema()
+        {
+            return null;
+        }
     }
 }

--- a/src/FluentMigrator/MigrationConventions.cs
+++ b/src/FluentMigrator/MigrationConventions.cs
@@ -39,6 +39,7 @@ namespace FluentMigrator
         public Func<Type, IEnumerable<string>, bool> TypeHasMatchingTags { get; set; }
         public Func<Type, string, string> GetAutoScriptUpName { get; set; }
         public Func<Type, string, string> GetAutoScriptDownName { get; set; }
+        public Func<string> GetDefaultSchema { get; set; }
 
         public MigrationConventions()
         {
@@ -56,6 +57,7 @@ namespace FluentMigrator
             TypeHasMatchingTags = DefaultMigrationConventions.TypeHasMatchingTags;
             GetAutoScriptUpName = DefaultMigrationConventions.GetAutoScriptUpName;
             GetAutoScriptDownName = DefaultMigrationConventions.GetAutoScriptDownName;
-        }        
+            GetDefaultSchema = DefaultMigrationConventions.GetDefaultSchema;
+        }
     }
 }

--- a/src/FluentMigrator/MigrationConventionsWithDefaultSchema.cs
+++ b/src/FluentMigrator/MigrationConventionsWithDefaultSchema.cs
@@ -1,0 +1,28 @@
+#region License
+// 
+// Copyright (c) 2007-2009, Sean Chambers <schambers80@gmail.com>
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+namespace FluentMigrator
+{
+    public class MigrationConventionsWithDefaultSchema : MigrationConventions
+    {
+        public MigrationConventionsWithDefaultSchema(string schemaName)
+        {
+            this.GetDefaultSchema = () => schemaName;
+        }
+    }
+}

--- a/src/FluentMigrator/Model/ConstraintDefinition.cs
+++ b/src/FluentMigrator/Model/ConstraintDefinition.cs
@@ -57,6 +57,9 @@ namespace FluentMigrator.Model
             if (String.IsNullOrEmpty(ConstraintName)){ 
                 ConstraintName = conventions.GetConstraintName(this);
             }
+
+            if (String.IsNullOrEmpty(SchemaName))
+                SchemaName = conventions.GetDefaultSchema();
         }
 
         #endregion

--- a/src/FluentMigrator/Model/ForeignKeyDefinition.cs
+++ b/src/FluentMigrator/Model/ForeignKeyDefinition.cs
@@ -45,6 +45,12 @@ namespace FluentMigrator.Model
         {
             if (String.IsNullOrEmpty(Name))
                 Name = conventions.GetForeignKeyName(this);
+
+            if (String.IsNullOrEmpty(ForeignTableSchema))
+                ForeignTableSchema = conventions.GetDefaultSchema();
+
+            if (String.IsNullOrEmpty(PrimaryTableSchema))
+                PrimaryTableSchema = conventions.GetDefaultSchema();
         }
 
         public virtual void CollectValidationErrors(ICollection<string> errors)

--- a/src/FluentMigrator/Model/IndexDefinition.cs
+++ b/src/FluentMigrator/Model/IndexDefinition.cs
@@ -44,6 +44,9 @@ namespace FluentMigrator.Model
         {
             if (String.IsNullOrEmpty(Name))
                 Name = conventions.GetIndexName(this);
+
+            if (String.IsNullOrEmpty(SchemaName))
+                SchemaName = conventions.GetDefaultSchema();
         }
 
         public virtual void CollectValidationErrors(ICollection<string> errors)

--- a/src/FluentMigrator/Model/SequenceDefinition.cs
+++ b/src/FluentMigrator/Model/SequenceDefinition.cs
@@ -4,7 +4,7 @@ namespace FluentMigrator.Model
     using System.Collections.Generic;
     using Infrastructure;
 
-    public class SequenceDefinition: ICloneable, ICanBeValidated
+    public class SequenceDefinition : ICloneable, ICanBeValidated, ICanBeConventional
     {
         public virtual string Name { get; set; }
         public virtual string SchemaName { get; set; }
@@ -39,6 +39,12 @@ namespace FluentMigrator.Model
         {
             if (String.IsNullOrEmpty(Name))
                 errors.Add(ErrorMessages.SequenceNameCannotBeNullOrEmpty);
+        }
+
+        public void ApplyConventions(IMigrationConventions conventions)
+        {
+            if (String.IsNullOrEmpty(SchemaName))
+                SchemaName = conventions.GetDefaultSchema();
         }
     }
 }

--- a/src/FluentMigrator/Model/TableDefinition.cs
+++ b/src/FluentMigrator/Model/TableDefinition.cs
@@ -42,7 +42,8 @@ namespace FluentMigrator.Model
 
         public void ApplyConventions(IMigrationConventions conventions)
         {
-            throw new NotImplementedException();
+            if (String.IsNullOrEmpty(SchemaName))
+                SchemaName = conventions.GetDefaultSchema();
         }
 
         public void CollectValidationErrors(ICollection<string> errors)

--- a/src/FluentMigrator/Properties/AssemblyInfo.cs
+++ b/src/FluentMigrator/Properties/AssemblyInfo.cs
@@ -17,7 +17,6 @@
 #endregion
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Security;
 
 [assembly: AssemblyTitle("FluentMigrator")]

--- a/src/FluentMigrator/VersionTableInfo/DefaultVersionTableMetaData.cs
+++ b/src/FluentMigrator/VersionTableInfo/DefaultVersionTableMetaData.cs
@@ -22,6 +22,15 @@ namespace FluentMigrator.VersionTableInfo
 {
     public class DefaultVersionTableMetaData : IVersionTableMetaData
     {
+        public DefaultVersionTableMetaData()
+        {
+        }
+
+        public DefaultVersionTableMetaData(string schemaName)
+        {
+            this.SchemaName = schemaName;
+        }
+
         /// <summary>
         /// Provides access to <code>ApplicationContext</code> object.
         /// </summary>
@@ -32,11 +41,8 @@ namespace FluentMigrator.VersionTableInfo
         /// </remarks>
         public object ApplicationContext { get; set; }
 
-        public virtual string SchemaName
-        {
-            get { return string.Empty; }
-        }
-  
+        public virtual string SchemaName { get; } = string.Empty;
+
         public virtual string TableName
         {
             get { return "VersionInfo"; }

--- a/src/FluentMigrator/VersionTableInfo/DefaultVersionTableMetaData.cs
+++ b/src/FluentMigrator/VersionTableInfo/DefaultVersionTableMetaData.cs
@@ -24,6 +24,7 @@ namespace FluentMigrator.VersionTableInfo
     {
         public DefaultVersionTableMetaData()
         {
+            SchemaName = string.Empty;
         }
 
         public DefaultVersionTableMetaData(string schemaName)
@@ -41,7 +42,7 @@ namespace FluentMigrator.VersionTableInfo
         /// </remarks>
         public object ApplicationContext { get; set; }
 
-        public virtual string SchemaName { get; } = string.Empty;
+        public virtual string SchemaName { get; protected set; }
 
         public virtual string TableName
         {

--- a/src/FluentMigrator/VersionTableInfo/DefaultVersionTableMetaDataInSchema.cs
+++ b/src/FluentMigrator/VersionTableInfo/DefaultVersionTableMetaDataInSchema.cs
@@ -1,0 +1,32 @@
+#region License
+
+// 
+// Copyright (c) 2007-2009, Sean Chambers <schambers80@gmail.com>
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#endregion
+
+namespace FluentMigrator.VersionTableInfo
+{
+    public class DefaultVersionTableMetaDataInSchema : DefaultVersionTableMetaData
+    {
+        public DefaultVersionTableMetaDataInSchema(string schemaName)
+        {
+            this.SchemaName = schemaName;
+        }
+
+        public override string SchemaName { get; }
+    }
+}

--- a/src/FluentMigrator/VersionTableInfo/DefaultVersionTableMetaDataInSchema.cs
+++ b/src/FluentMigrator/VersionTableInfo/DefaultVersionTableMetaDataInSchema.cs
@@ -27,6 +27,6 @@ namespace FluentMigrator.VersionTableInfo
             this.SchemaName = schemaName;
         }
 
-        public override string SchemaName { get; }
+        public override string SchemaName { get; protected set; }
     }
 }


### PR DESCRIPTION
Following the work started by @daniellee in 2013, I completed the work to be able to override the default schema globally.  There are 2 ways to do it:
1- Define a MigrationConventions class in the migration assembly, and it will be used to determine the default schema to use.
2- As a parameter in the RunnerContext.

The 1 takes precedence on 2.