### PR TITLE
Add MySQL alter and drop of defaults

### DIFF
--- a/src/FluentMigrator.Runner/Generators/MySql/MySqlGenerator.cs
+++ b/src/FluentMigrator.Runner/Generators/MySql/MySqlGenerator.cs
@@ -75,7 +75,7 @@ namespace FluentMigrator.Runner.Generators.MySql
 
         public override string Generate(AlterDefaultConstraintExpression expression)
         {
-            return compatabilityMode.HandleCompatabilty("Altering of default constraints is not supporteed for MySql");
+            return string.Format("ALTER TABLE {0} ALTER {1} SET DEFAULT ({2})", Quoter.QuoteTableName(expression.TableName), Quoter.QuoteColumnName(expression.ColumnName), Quoter.QuoteValue(expression.DefaultValue));
         }
 
         public override string Generate(CreateSequenceExpression expression)
@@ -104,7 +104,8 @@ namespace FluentMigrator.Runner.Generators.MySql
 
         public override string Generate(DeleteDefaultConstraintExpression expression)
         {
-            return compatabilityMode.HandleCompatabilty("Default constraints are not supported");
+            return string.Format("ALTER TABLE {0} ALTER {1} DROP DEFAULT", Quoter.QuoteTableName(expression.TableName), Quoter.QuoteColumnName(expression.ColumnName));
         }
     }
 }
+


### PR DESCRIPTION
While MySQL doesn't treat default values as named constraints, there is
a syntacitical facility under ALTER TABLE for manipulating them; see
https://dev.mysql.com/doc/refman/5.7/en/alter-table.html