### PR TITLE
Allow before-each & after-each Maintenance only if migrations are run; DRY on MigrateUp.

### DIFF
--- a/src/FluentMigrator.Runner/MigrationRunner.cs
+++ b/src/FluentMigrator.Runner/MigrationRunner.cs
@@ -136,9 +136,7 @@ namespace FluentMigrator.Runner
 
         public void MigrateUp(long targetVersion, bool useAutomaticTransactionManagement)
         {
-            var migrationInfos = GetUpMigrationsToApply(targetVersion);
-
-            if (!migrationInfos.Any()) return;
+            var migrationInfos = GetUpMigrationsToApply(targetVersion).ToList();
 
             using (IMigrationScope scope = _migrationScopeHandler.CreateOrWrapMigrationScope(useAutomaticTransactionManagement && TransactionPerSession))
             {


### PR DESCRIPTION
Would really like a few sets of eyes on this one, especially original authors.  

This PR consolidates the logic for MigrateUp by (1) pre-filtering the migration set in the "full install" polymorph and (2) adding ApplyMaintence to the version-specific polymorph.

Further, it limits the execution to only run in the case where there are migrations to apply.  *This materially changes the Maintenance Migration logic,* though in a way that seems closer to the original intent--previously, because filtering for "full install" MigrateUp occurred in ApplyMigrationup, all maintenance *for every migration* would run, even if no migrations were actually run.

I also need some guidance on testing this, since the Maintenance feature does not seem very test-friendly.

This is hypothetically breaking, if there are Maintenance Migrations out there that are depending on the "always-run" "feature."  But it is certainly at least a minor-version change.