### PR TITLE
SQL Server 2005 support WITH (ONLINE = ON|OFF)

### DIFF
--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2005Generator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2005Generator.cs
@@ -343,7 +343,14 @@ namespace FluentMigrator.Runner.Generators.SqlServer
 
         public override string Generate(CreateConstraintExpression expression)
         {
-            return string.Format("ALTER TABLE {0}.{1}", Quoter.QuoteSchemaName(expression.Constraint.SchemaName), base.Generate(expression));
+            string withOnline = string.Empty;
+
+            if (expression.Constraint.ApplyOnline.HasValue)
+            {
+                withOnline = string.Format(" WITH (ONLINE = {0})", (expression.Constraint.ApplyOnline == OnlineMode.On ? "ON" : "OFF"));
+            }
+
+            return string.Format("ALTER TABLE {0}.{1}{2}", Quoter.QuoteSchemaName(expression.Constraint.SchemaName), base.Generate(expression), withOnline);
         }
 
         public override string Generate(DeleteDefaultConstraintExpression expression)

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2005Generator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2005Generator.cs
@@ -49,7 +49,7 @@ namespace FluentMigrator.Runner.Generators.SqlServer
         public override string RenameTable { get { return "{0}', '{1}'"; } }
 
         public override string CreateIndex { get { return "CREATE {0}{1}INDEX {2} ON {3}.{4} ({5}{6}{7}){8}"; } }
-        public override string DropIndex { get { return "DROP INDEX {0} ON {1}.{2}"; } }
+        public override string DropIndex { get { return "DROP INDEX {0} ON {1}.{2}{3}"; } }
 
         public override string InsertData { get { return "INSERT INTO {0}.{1} ({2}) VALUES ({3})"; } }
         public override string UpdateData { get { return "{0} SET {1} WHERE {2}"; } }
@@ -286,7 +286,18 @@ namespace FluentMigrator.Runner.Generators.SqlServer
 
         public override string Generate(DeleteIndexExpression expression)
         {
-            return String.Format(DropIndex, Quoter.QuoteIndexName(expression.Index.Name), Quoter.QuoteSchemaName(expression.Index.SchemaName), Quoter.QuoteTableName(expression.Index.TableName));
+            string withOnline = string.Empty;
+
+            if (expression.Index.ApplyOnline.HasValue)
+            {
+                withOnline = string.Format(" WITH (ONLINE = {0})", (expression.Index.ApplyOnline == OnlineMode.On ? "ON" : "OFF"));
+            }
+
+            return String.Format(DropIndex
+                , Quoter.QuoteIndexName(expression.Index.Name)
+                , Quoter.QuoteSchemaName(expression.Index.SchemaName)
+                , Quoter.QuoteTableName(expression.Index.TableName)
+                , withOnline);
         }
 
         protected override void BuildDelete(DeleteColumnExpression expression, string columnName, StringBuilder builder)

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2005Generator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2005Generator.cs
@@ -48,7 +48,7 @@ namespace FluentMigrator.Runner.Generators.SqlServer
         public override string RenameColumn { get { return "{0}.{1}', '{2}'"; } }
         public override string RenameTable { get { return "{0}', '{1}'"; } }
 
-        public override string CreateIndex { get { return "CREATE {0}{1}INDEX {2} ON {3}.{4} ({5}{6}{7})"; } }
+        public override string CreateIndex { get { return "CREATE {0}{1}INDEX {2} ON {3}.{4} ({5}{6}{7}){8}"; } }
         public override string DropIndex { get { return "DROP INDEX {0} ON {1}.{2}"; } }
 
         public override string InsertData { get { return "INSERT INTO {0}.{1} ({2}) VALUES ({3})"; } }
@@ -265,6 +265,13 @@ namespace FluentMigrator.Runner.Generators.SqlServer
                 indexIncludes[i] = Quoter.QuoteColumnName(includeDef.Name);
             }
 
+            string withOnline = string.Empty;
+
+            if (expression.Index.ApplyOnline.HasValue)
+            {
+                withOnline = string.Format(" WITH (ONLINE = {0})", (expression.Index.ApplyOnline == OnlineMode.On ? "ON" : "OFF"));
+            }
+
             return String.Format(CreateIndex
                 , GetUniqueString(expression)
                 , GetClusterTypeString(expression)
@@ -273,7 +280,8 @@ namespace FluentMigrator.Runner.Generators.SqlServer
                 , Quoter.QuoteTableName(expression.Index.TableName)
                 , String.Join(", ", indexColumns)
                 , GetIncludeString(expression)
-                , String.Join(", ", indexIncludes));
+                , String.Join(", ", indexIncludes)
+                , withOnline);
         }
 
         public override string Generate(DeleteIndexExpression expression)

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2005Generator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2005Generator.cs
@@ -376,7 +376,14 @@ namespace FluentMigrator.Runner.Generators.SqlServer
 
         public override string Generate(DeleteConstraintExpression expression)
         {
-            return string.Format("ALTER TABLE {0}.{1}", Quoter.QuoteSchemaName(expression.Constraint.SchemaName), base.Generate(expression));
+            string withOnline = string.Empty;
+
+            if (expression.Constraint.ApplyOnline.HasValue)
+            {
+                withOnline = string.Format(" WITH (ONLINE = {0})", (expression.Constraint.ApplyOnline == OnlineMode.On ? "ON" : "OFF"));
+            }
+
+            return string.Format("ALTER TABLE {0}.{1}{2}", Quoter.QuoteSchemaName(expression.Constraint.SchemaName), base.Generate(expression), withOnline);
         }
 
         public override string Generate(CreateSchemaExpression expression)

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005ConstraintsTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005ConstraintsTests.cs
@@ -488,6 +488,36 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
         }
 
         [Test]
+        public void CanCreatePrimaryKeyWithoutOnlineModeSet()
+        {
+            var expression = GeneratorTestHelper.GetCreatePrimaryKeyExpression();
+            expression.Constraint.ApplyOnline = null;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE [dbo].[TestTable1] ADD CONSTRAINT [PK_TestTable1_TestColumn1] PRIMARY KEY ([TestColumn1])");
+        }
+
+        [Test]
+        public void CanCreatePrimaryKeyWithOnlineOn()
+        {
+            var expression = GeneratorTestHelper.GetCreatePrimaryKeyExpression();
+            expression.Constraint.ApplyOnline = Model.OnlineMode.On;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE [dbo].[TestTable1] ADD CONSTRAINT [PK_TestTable1_TestColumn1] PRIMARY KEY ([TestColumn1]) WITH (ONLINE = ON)");
+        }
+
+        [Test]
+        public void CanCreatePrimaryKeyWithOnlineOff()
+        {
+            var expression = GeneratorTestHelper.GetCreatePrimaryKeyExpression();
+            expression.Constraint.ApplyOnline = Model.OnlineMode.Off;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE [dbo].[TestTable1] ADD CONSTRAINT [PK_TestTable1_TestColumn1] PRIMARY KEY ([TestColumn1]) WITH (ONLINE = OFF)");
+        }
+
+        [Test]
         public override void CanDropForeignKeyWithCustomSchema()
         {
             var expression = GeneratorTestHelper.GetDeleteForeignKeyExpression();

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005ConstraintsTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005ConstraintsTests.cs
@@ -556,6 +556,36 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
         }
 
         [Test]
+        public void CanDropPrimaryKeyWithoutOnlineModeSet()
+        {
+            var expression = GeneratorTestHelper.GetDeletePrimaryKeyExpression();
+            expression.Constraint.ApplyOnline = null;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE [dbo].[TestTable1] DROP CONSTRAINT [TESTPRIMARYKEY]");
+        }
+
+        [Test]
+        public void CanDropPrimaryKeyWithOnlineOn()
+        {
+            var expression = GeneratorTestHelper.GetDeletePrimaryKeyExpression();
+            expression.Constraint.ApplyOnline = Model.OnlineMode.On;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE [dbo].[TestTable1] DROP CONSTRAINT [TESTPRIMARYKEY] WITH (ONLINE = ON)");
+        }
+
+        [Test]
+        public void CanDropPrimaryKeyWithOnlineOff()
+        {
+            var expression = GeneratorTestHelper.GetDeletePrimaryKeyExpression();
+            expression.Constraint.ApplyOnline = Model.OnlineMode.Off;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE [dbo].[TestTable1] DROP CONSTRAINT [TESTPRIMARYKEY] WITH (ONLINE = OFF)");
+        }
+
+        [Test]
         public override void CanDropUniqueConstraintWithCustomSchema()
         {
             var expression = GeneratorTestHelper.GetDeleteUniqueConstraintExpression();

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005IndexTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005IndexTests.cs
@@ -139,5 +139,35 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
             var result = Generator.Generate(expression);
             result.ShouldBe("DROP INDEX [TestIndex] ON [dbo].[TestTable1]");
         }
+
+        [Test]
+        public void CanDropIndexWithOnlineOn()
+        {
+            var expression = GeneratorTestHelper.GetDeleteIndexExpression();
+            expression.Index.ApplyOnline = Model.OnlineMode.On;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DROP INDEX [TestIndex] ON [dbo].[TestTable1] WITH (ONLINE = ON)");
+        }
+
+        [Test]
+        public void CanDropIndexWithOnlineOff()
+        {
+            var expression = GeneratorTestHelper.GetDeleteIndexExpression();
+            expression.Index.ApplyOnline = Model.OnlineMode.Off;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DROP INDEX [TestIndex] ON [dbo].[TestTable1] WITH (ONLINE = OFF)");
+        }
+
+        [Test]
+        public void CanDropIndexWithoutOnlineModeSet()
+        {
+            var expression = GeneratorTestHelper.GetDeleteIndexExpression();
+            expression.Index.ApplyOnline = null;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DROP INDEX [TestIndex] ON [dbo].[TestTable1]");
+        }
     }
 }

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005IndexTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005IndexTests.cs
@@ -92,6 +92,36 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
         }
 
         [Test]
+        public void CanCreateIndexWithOnlineOn()
+        {
+            var expression = GeneratorTestHelper.GetCreateIndexExpression();
+            expression.Index.ApplyOnline = Model.OnlineMode.On;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC) WITH (ONLINE = ON)");
+        }
+
+        [Test]
+        public void CanCreateIndexWithOnlineOff()
+        {
+            var expression = GeneratorTestHelper.GetCreateIndexExpression();
+            expression.Index.ApplyOnline = Model.OnlineMode.Off;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC) WITH (ONLINE = OFF)");
+        }
+
+        [Test]
+        public void CanCreateIndexWithoutOnlineModeSet()
+        {
+            var expression = GeneratorTestHelper.GetCreateIndexExpression();
+            expression.Index.ApplyOnline = null;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC)");
+        }
+
+        [Test]
         public override void CanDropIndexWithCustomSchema()
         {
             var expression = GeneratorTestHelper.GetDeleteIndexExpression();

--- a/src/FluentMigrator/Builders/Create/Constraint/CreateConstraintExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Create/Constraint/CreateConstraintExpressionBuilder.cs
@@ -44,7 +44,7 @@ namespace FluentMigrator.Builders.Create.Constraint
             return this;
         }
 
-        public ICreateConstraintOptionsSyntax ApplyOnline(OnlineMode mode)
+        public ICreateConstraintOptionsSyntax ApplyOnline(OnlineMode mode = OnlineMode.On)
         {
             Expression.Constraint.ApplyOnline = mode;
             return this;

--- a/src/FluentMigrator/Builders/Create/Constraint/CreateConstraintExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Create/Constraint/CreateConstraintExpressionBuilder.cs
@@ -1,4 +1,6 @@
+using System;
 using FluentMigrator.Expressions;
+using FluentMigrator.Model;
 
 namespace FluentMigrator.Builders.Create.Constraint
 {
@@ -39,6 +41,12 @@ namespace FluentMigrator.Builders.Create.Constraint
         public ICreateConstraintColumnsSyntax WithSchema(string schemaName)
         {
             Expression.Constraint.SchemaName = schemaName;
+            return this;
+        }
+
+        public ICreateConstraintOptionsSyntax ApplyOnline(OnlineMode mode)
+        {
+            Expression.Constraint.ApplyOnline = mode;
             return this;
         }
     }

--- a/src/FluentMigrator/Builders/Create/Constraint/ICreateConstraintOptionsSyntax.cs
+++ b/src/FluentMigrator/Builders/Create/Constraint/ICreateConstraintOptionsSyntax.cs
@@ -1,6 +1,27 @@
+#region License
+// 
+// Copyright (c) 2007-2009, Sean Chambers <schambers80@gmail.com>
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+using FluentMigrator.Model;
+
 namespace FluentMigrator.Builders.Create.Constraint
 {
     public interface ICreateConstraintOptionsSyntax
     {
+        ICreateConstraintOptionsSyntax ApplyOnline(OnlineMode mode);
     }
 }

--- a/src/FluentMigrator/Builders/Create/Constraint/ICreateConstraintOptionsSyntax.cs
+++ b/src/FluentMigrator/Builders/Create/Constraint/ICreateConstraintOptionsSyntax.cs
@@ -22,6 +22,16 @@ namespace FluentMigrator.Builders.Create.Constraint
 {
     public interface ICreateConstraintOptionsSyntax
     {
-        ICreateConstraintOptionsSyntax ApplyOnline(OnlineMode mode);
+        /// <summary>
+        /// Specifies whether underlying tables and associated indexes are available for queries and data modification during the index operation.
+        /// The ONLINE option can only be specified in certain situations, please refer to documentation for SQL Server 2005 and newer.
+        /// </summary>
+        /// <param name="mode">
+        /// ON
+        /// Long-term table locks are not held. This allows queries or updates to the underlying table to continue.
+        /// OFF
+        /// Table locks are applied and the table is unavailable for the duration of the index operation.
+        /// </param>
+        ICreateConstraintOptionsSyntax ApplyOnline(OnlineMode mode = OnlineMode.On);
     }
 }

--- a/src/FluentMigrator/Builders/Create/Index/CreateIndexExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Create/Index/CreateIndexExpressionBuilder.cs
@@ -95,7 +95,7 @@ namespace FluentMigrator.Builders.Create.Index
             return this;
         }
 
-        public ICreateIndexOnColumnSyntax ApplyOnline(OnlineMode mode)
+        public ICreateIndexOnColumnSyntax ApplyOnline(OnlineMode mode = OnlineMode.On)
         {
             Expression.Index.ApplyOnline = mode;
             return this;

--- a/src/FluentMigrator/Builders/Create/Index/CreateIndexExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Create/Index/CreateIndexExpressionBuilder.cs
@@ -16,6 +16,7 @@
 //
 #endregion
 
+using System;
 using FluentMigrator.Expressions;
 using FluentMigrator.Model;
 
@@ -91,6 +92,12 @@ namespace FluentMigrator.Builders.Create.Index
         public ICreateIndexOnColumnSyntax Clustered()
         {
             Expression.Index.IsClustered = true;
+            return this;
+        }
+
+        public ICreateIndexOnColumnSyntax ApplyOnline(OnlineMode mode)
+        {
+            Expression.Index.ApplyOnline = mode;
             return this;
         }
     }

--- a/src/FluentMigrator/Builders/Create/Index/ICreateIndexOptionsSyntax.cs
+++ b/src/FluentMigrator/Builders/Create/Index/ICreateIndexOptionsSyntax.cs
@@ -16,6 +16,8 @@
 //
 #endregion
 
+using FluentMigrator.Model;
+
 namespace FluentMigrator.Builders.Create.Index
 {
     public interface ICreateIndexOptionsSyntax
@@ -23,5 +25,6 @@ namespace FluentMigrator.Builders.Create.Index
         ICreateIndexOnColumnSyntax Unique();
         ICreateIndexOnColumnSyntax NonClustered();
         ICreateIndexOnColumnSyntax Clustered();
+        ICreateIndexOnColumnSyntax ApplyOnline(OnlineMode mode);
     }
 }

--- a/src/FluentMigrator/Builders/Create/Index/ICreateIndexOptionsSyntax.cs
+++ b/src/FluentMigrator/Builders/Create/Index/ICreateIndexOptionsSyntax.cs
@@ -25,6 +25,16 @@ namespace FluentMigrator.Builders.Create.Index
         ICreateIndexOnColumnSyntax Unique();
         ICreateIndexOnColumnSyntax NonClustered();
         ICreateIndexOnColumnSyntax Clustered();
-        ICreateIndexOnColumnSyntax ApplyOnline(OnlineMode mode);
+        /// <summary>
+        /// Specifies whether underlying tables and associated indexes are available for queries and data modification during the index operation.
+        /// The ONLINE option can only be specified in certain situations, please refer to documentation for SQL Server 2005 and newer.
+        /// </summary>
+        /// <param name="mode">
+        /// ON
+        /// Long-term table locks are not held. This allows queries or updates to the underlying table to continue.
+        /// OFF
+        /// Table locks are applied and the table is unavailable for the duration of the index operation.
+        /// </param>
+        ICreateIndexOnColumnSyntax ApplyOnline(OnlineMode mode = OnlineMode.On);
     }
 }

--- a/src/FluentMigrator/Builders/Delete/Constraint/DeleteConstraintExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Delete/Constraint/DeleteConstraintExpressionBuilder.cs
@@ -16,7 +16,7 @@ namespace FluentMigrator.Builders.Delete.Constraint
         {
         }
 
-        public IDeleteConstraintInSchemaOptionsSyntax ApplyOnline(OnlineMode mode)
+        public IDeleteConstraintInSchemaOptionsSyntax ApplyOnline(OnlineMode mode = OnlineMode.On)
         {
             Expression.Constraint.ApplyOnline = mode;
             return this;

--- a/src/FluentMigrator/Builders/Delete/Constraint/DeleteConstraintExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Delete/Constraint/DeleteConstraintExpressionBuilder.cs
@@ -1,8 +1,12 @@
+using System;
 using FluentMigrator.Expressions;
+using FluentMigrator.Model;
 
 namespace FluentMigrator.Builders.Delete.Constraint
 {
-    public class DeleteConstraintExpressionBuilder : ExpressionBuilderBase<DeleteConstraintExpression>, IDeleteConstraintOnTableSyntax, IInSchemaSyntax
+    public class DeleteConstraintExpressionBuilder : ExpressionBuilderBase<DeleteConstraintExpression>, 
+        IDeleteConstraintOnTableSyntax, 
+        IDeleteConstraintInSchemaOptionsSyntax
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="T:CreateConstraintExpressionBuilder"/> class.
@@ -12,15 +16,22 @@ namespace FluentMigrator.Builders.Delete.Constraint
         {
         }
 
-        public IInSchemaSyntax FromTable(string tableName)
+        public IDeleteConstraintInSchemaOptionsSyntax ApplyOnline(OnlineMode mode)
+        {
+            Expression.Constraint.ApplyOnline = mode;
+            return this;
+        }
+
+        public IDeleteConstraintInSchemaOptionsSyntax FromTable(string tableName)
         {
             Expression.Constraint.TableName = tableName;
             return this;
         }
 
-        public void InSchema(string schemaName)
+        public IDeleteConstraintInSchemaOptionsSyntax InSchema(string schemaName)
         {
             Expression.Constraint.SchemaName = schemaName;
+            return this;
         }
     }
 }

--- a/src/FluentMigrator/Builders/Delete/Constraint/IDeleteConstraintInSchemaOptionsSyntax.cs
+++ b/src/FluentMigrator/Builders/Delete/Constraint/IDeleteConstraintInSchemaOptionsSyntax.cs
@@ -22,7 +22,17 @@ namespace FluentMigrator.Builders.Delete.Constraint
 {
     public interface IDeleteConstraintInSchemaOptionsSyntax
     {
-        IDeleteConstraintInSchemaOptionsSyntax ApplyOnline(OnlineMode mode);
+        /// <summary>
+        /// Specifies whether underlying tables and associated indexes are available for queries and data modification during the index operation.
+        /// The ONLINE option can only be specified when you drop clustered indexes (SQL Server 2005 Enterprise Edition).
+        /// </summary>
+        /// <param name="mode">
+        /// ON
+        /// Long-term table locks are not held. This allows queries or updates to the underlying table to continue.
+        /// OFF
+        /// Table locks are applied and the table is unavailable for the duration of the index operation.
+        /// </param>
+        IDeleteConstraintInSchemaOptionsSyntax ApplyOnline(OnlineMode mode = OnlineMode.On);
         IDeleteConstraintInSchemaOptionsSyntax InSchema(string schemaName);
     }
 }

--- a/src/FluentMigrator/Builders/Delete/Constraint/IDeleteConstraintInSchemaOptionsSyntax.cs
+++ b/src/FluentMigrator/Builders/Delete/Constraint/IDeleteConstraintInSchemaOptionsSyntax.cs
@@ -1,0 +1,28 @@
+﻿#region License
+// 
+// Copyright (c) 2007-2009, Sean Chambers <schambers80@gmail.com>
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+using FluentMigrator.Model;
+
+namespace FluentMigrator.Builders.Delete.Constraint
+{
+    public interface IDeleteConstraintInSchemaOptionsSyntax
+    {
+        IDeleteConstraintInSchemaOptionsSyntax ApplyOnline(OnlineMode mode);
+        IDeleteConstraintInSchemaOptionsSyntax InSchema(string schemaName);
+    }
+}

--- a/src/FluentMigrator/Builders/Delete/Constraint/IDeleteConstraintOnTableSyntax.cs
+++ b/src/FluentMigrator/Builders/Delete/Constraint/IDeleteConstraintOnTableSyntax.cs
@@ -2,6 +2,6 @@ namespace FluentMigrator.Builders.Delete.Constraint
 {
     public interface IDeleteConstraintOnTableSyntax
     {
-        IInSchemaSyntax FromTable(string tableName);
+        IDeleteConstraintInSchemaOptionsSyntax FromTable(string tableName);
     }
 }

--- a/src/FluentMigrator/Builders/Delete/Index/DeleteIndexExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Delete/Index/DeleteIndexExpressionBuilder.cs
@@ -58,7 +58,7 @@ namespace FluentMigrator.Builders.Delete.Index
                 Expression.Index.Columns.Add(new IndexColumnDefinition { Name = columnName });
         }
 
-        public void ApplyOnline(OnlineMode mode)
+        public void ApplyOnline(OnlineMode mode = OnlineMode.On)
         {
             Expression.Index.ApplyOnline = mode;
         }

--- a/src/FluentMigrator/Builders/Delete/Index/DeleteIndexExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Delete/Index/DeleteIndexExpressionBuilder.cs
@@ -16,6 +16,7 @@
 //
 #endregion
 
+using System;
 using FluentMigrator.Expressions;
 using FluentMigrator.Model;
 
@@ -23,7 +24,8 @@ namespace FluentMigrator.Builders.Delete.Index
 {
     public class DeleteIndexExpressionBuilder : ExpressionBuilderBase<DeleteIndexExpression>,
         IDeleteIndexForTableSyntax,
-        IDeleteIndexOnColumnOrInSchemaSyntax
+        IDeleteIndexOnColumnOrInSchemaSyntax,
+        IDeleteIndexOptionsSyntax
     {
         public IndexColumnDefinition CurrentColumn { get; set; }
 
@@ -54,6 +56,28 @@ namespace FluentMigrator.Builders.Delete.Index
         {
             foreach (string columnName in columnNames)
                 Expression.Index.Columns.Add(new IndexColumnDefinition { Name = columnName });
+        }
+
+        public void ApplyOnline(OnlineMode mode)
+        {
+            Expression.Index.ApplyOnline = mode;
+        }
+
+        public IDeleteIndexOptionsSyntax WithOptions()
+        {
+            return this;
+        }
+
+        IDeleteIndexOptionsSyntax IDeleteIndexOnColumnSyntax.OnColumn(string columnName)
+        {
+            OnColumn(columnName);
+            return this;
+        }
+
+        IDeleteIndexOptionsSyntax IDeleteIndexOnColumnSyntax.OnColumns(params string[] columnNames)
+        {
+            OnColumns(columnNames);
+            return this;
         }
     }
 }

--- a/src/FluentMigrator/Builders/Delete/Index/IDeleteIndexOnColumnOrInSchemaSyntax.cs
+++ b/src/FluentMigrator/Builders/Delete/Index/IDeleteIndexOnColumnOrInSchemaSyntax.cs
@@ -23,5 +23,6 @@ namespace FluentMigrator.Builders.Delete.Index
     public interface IDeleteIndexOnColumnOrInSchemaSyntax : IDeleteIndexOnColumnSyntax
     {
         IDeleteIndexOnColumnSyntax InSchema(string schemaName);
+        IDeleteIndexOptionsSyntax WithOptions();
     }
 }

--- a/src/FluentMigrator/Builders/Delete/Index/IDeleteIndexOnColumnSyntax.cs
+++ b/src/FluentMigrator/Builders/Delete/Index/IDeleteIndexOnColumnSyntax.cs
@@ -20,7 +20,7 @@ namespace FluentMigrator.Builders.Delete.Index
 {
     public interface IDeleteIndexOnColumnSyntax
     {
-        void OnColumn(string columnName);
-        void OnColumns(params string[] columnNames);
+        IDeleteIndexOptionsSyntax OnColumn(string columnName);
+        IDeleteIndexOptionsSyntax OnColumns(params string[] columnNames);
     }
 }

--- a/src/FluentMigrator/Builders/Delete/Index/IDeleteIndexOnColumnSyntax.cs
+++ b/src/FluentMigrator/Builders/Delete/Index/IDeleteIndexOnColumnSyntax.cs
@@ -22,5 +22,6 @@ namespace FluentMigrator.Builders.Delete.Index
     {
         IDeleteIndexOptionsSyntax OnColumn(string columnName);
         IDeleteIndexOptionsSyntax OnColumns(params string[] columnNames);
+        IDeleteIndexOptionsSyntax WithOptions();
     }
 }

--- a/src/FluentMigrator/Builders/Delete/Index/IDeleteIndexOptionsSyntax.cs
+++ b/src/FluentMigrator/Builders/Delete/Index/IDeleteIndexOptionsSyntax.cs
@@ -22,6 +22,16 @@ namespace FluentMigrator.Builders.Delete.Index
 {
     public interface IDeleteIndexOptionsSyntax
     {
-        void ApplyOnline(OnlineMode mode);
+        /// <summary>
+        /// Specifies whether underlying tables and associated indexes are available for queries and data modification during the index operation.
+        /// The ONLINE option can only be specified when you drop clustered indexes (SQL Server 2005 Enterprise Edition).
+        /// </summary>
+        /// <param name="mode">
+        /// ON
+        /// Long-term table locks are not held. This allows queries or updates to the underlying table to continue.
+        /// OFF
+        /// Table locks are applied and the table is unavailable for the duration of the index operation.
+        /// </param>
+        void ApplyOnline(OnlineMode mode = OnlineMode.On);
     }
 }

--- a/src/FluentMigrator/Builders/Delete/Index/IDeleteIndexOptionsSyntax.cs
+++ b/src/FluentMigrator/Builders/Delete/Index/IDeleteIndexOptionsSyntax.cs
@@ -1,4 +1,4 @@
-#region License
+﻿#region License
 // 
 // Copyright (c) 2007-2009, Sean Chambers <schambers80@gmail.com>
 // 
@@ -16,11 +16,12 @@
 //
 #endregion
 
+using FluentMigrator.Model;
+
 namespace FluentMigrator.Builders.Delete.Index
 {
-    public interface IDeleteIndexForTableSyntax
+    public interface IDeleteIndexOptionsSyntax
     {
-        IDeleteIndexOnColumnOrInSchemaSyntax OnTable(string tableName);
-        IDeleteIndexOptionsSyntax WithOptions();
+        void ApplyOnline(OnlineMode mode);
     }
 }

--- a/src/FluentMigrator/FluentMigrator.csproj
+++ b/src/FluentMigrator/FluentMigrator.csproj
@@ -123,6 +123,7 @@
     <Compile Include="..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="Builders\Delete\Constraint\IDeleteConstraintInSchemaOptionsSyntax.cs" />
     <Compile Include="Builders\Delete\Index\IDeleteIndexOptionsSyntax.cs" />
     <Compile Include="MigrationStage.cs" />
     <Compile Include="MaintenanceAttribute.cs" />

--- a/src/FluentMigrator/FluentMigrator.csproj
+++ b/src/FluentMigrator/FluentMigrator.csproj
@@ -123,6 +123,7 @@
     <Compile Include="..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="Builders\Delete\Index\IDeleteIndexOptionsSyntax.cs" />
     <Compile Include="MigrationStage.cs" />
     <Compile Include="MaintenanceAttribute.cs" />
     <Compile Include="Builders\Alter\AlterExpressionRoot.cs" />

--- a/src/FluentMigrator/FluentMigrator.csproj
+++ b/src/FluentMigrator/FluentMigrator.csproj
@@ -201,6 +201,7 @@
     <Compile Include="Infrastructure\IMigrationInfo.cs" />
     <Compile Include="Infrastructure\MigrationInfo.cs" />
     <Compile Include="Infrastructure\NonAttributedMigrationToMigrationInfoAdapter.cs" />
+    <Compile Include="Model\OnlineState.cs" />
     <Compile Include="RawSql.cs" />
     <Compile Include="Infrastructure\ISupportAdditionalFeatures.cs" />
     <Compile Include="Builders\Insert\IInsertDataOrInSchemaSyntax.cs" />

--- a/src/FluentMigrator/Model/ConstraintDefinition.cs
+++ b/src/FluentMigrator/Model/ConstraintDefinition.cs
@@ -24,6 +24,7 @@ namespace FluentMigrator.Model
         public virtual string ConstraintName { get; set; }
         public virtual string TableName { get; set; }
         public virtual ICollection<string> Columns { get; set; }
+        public OnlineMode? ApplyOnline { get; set; }
 
 
         /// <summary>

--- a/src/FluentMigrator/Model/IndexDefinition.cs
+++ b/src/FluentMigrator/Model/IndexDefinition.cs
@@ -31,6 +31,7 @@ namespace FluentMigrator.Model
         public virtual string TableName { get; set; }
         public virtual bool IsUnique { get; set; }
         public bool IsClustered { get; set; }
+        public OnlineMode? ApplyOnline { get; set; }
         public virtual ICollection<IndexColumnDefinition> Columns { get; set; }
         public virtual ICollection<IndexIncludeDefinition> Includes { get; set; }
 

--- a/src/FluentMigrator/Model/OnlineState.cs
+++ b/src/FluentMigrator/Model/OnlineState.cs
@@ -1,0 +1,8 @@
+﻿namespace FluentMigrator.Model
+{
+    public enum OnlineMode
+    {
+        Off = 0,
+        On = 1
+    }
+}


### PR DESCRIPTION
Related to issue #756 this PR adds support for WITH (ONLINE = ON|OFF) for SQL Server 2005 (Enterprise Edition) and newer. Since there's no way to check edition, users will have to write migrations using this option only if they know Enterprise Edition is the target engine.

Example migration for clustered index and primary key constraint, create and drop:
```
public override void Up()
{
    Create.Table("Notes")
        .WithColumn("NotesId").AsGuid()
        .WithColumn("Body").AsString(4000).NotNullable()
        .WithTimeStamps()
        .WithColumn("User_id").AsInt32();

    Create.Index("IDX_Notes_CreatedAt").OnTable("Notes")
        .WithOptions().ApplyOnline()
        .WithOptions().Clustered()
        .OnColumn("CreatedAt");

    Create.PrimaryKey("PK_Notes").OnTable("Notes")
        .Column("NotesId").ApplyOnline();
}

public override void Down()
{
    Delete.PrimaryKey("PK_Notes").FromTable("Notes");
    Delete.Index("IDX_Notes_CreatedAt").OnTable("Notes")
        .WithOptions().ApplyOnline();
    Delete.Table("Notes");
}
```

![2017-03-14_23-22-16](https://cloud.githubusercontent.com/assets/791721/23925062/cc56984a-090d-11e7-8d83-ac1e2c3a44d4.png)
![2017-03-14_23-25-17](https://cloud.githubusercontent.com/assets/791721/23925063/d268796a-090d-11e7-8e11-875f0bd909d0.png)

This is the same as PR #763 only this one is for SQL Server 2005 and up. If this one gets merged, #763 should be closed. The reason is explained in this comment: https://github.com/fluentmigrator/fluentmigrator/issues/756#issuecomment-269860211

I've only got SQL Server 2016 Developer Edition installed, so I've verified the sample migrations run against this engine using the SqlServer2005Generator.
