### PR TITLE
Added StopOnError flag in order to pause console if some migration fails

### DIFF
--- a/src/FluentMigrator.Console/MigratorConsole.cs
+++ b/src/FluentMigrator.Console/MigratorConsole.cs
@@ -47,6 +47,7 @@ namespace FluentMigrator.Console
         public string Task;
         public int Timeout;
         public bool Verbose;
+        public bool StopOnError;
         public long Version;
         public long StartVersion;
         public bool NoConnection;
@@ -147,6 +148,11 @@ namespace FluentMigrator.Console
                                             "verbose=",
                                             "Show the SQL statements generated and execution time in the console. Default is false.",
                                             v => { Verbose = true; }
+                                            },
+                                        {
+                                            "stopOnError=",
+                                            "Pauses migration execution until the user input if any error occured. Default is false.",
+                                            v => { StopOnError = true; }
                                             },
                                         {
                                             "workingdirectory=|wd=",
@@ -262,6 +268,7 @@ namespace FluentMigrator.Console
         {
             consoleAnnouncer.ShowElapsedTime = Verbose;
             consoleAnnouncer.ShowSql = Verbose;
+            consoleAnnouncer.StopOnError = StopOnError;
 
             ExecuteMigrations(consoleAnnouncer);
         }
@@ -279,6 +286,7 @@ namespace FluentMigrator.Console
 
                 consoleAnnouncer.ShowElapsedTime = Verbose;
                 consoleAnnouncer.ShowSql = Verbose;
+                consoleAnnouncer.StopOnError = StopOnError;
 
                 var announcer = new CompositeAnnouncer(consoleAnnouncer, fileAnnouncer);
 

--- a/src/FluentMigrator.Runner/Announcers/Announcer.cs
+++ b/src/FluentMigrator.Runner/Announcers/Announcer.cs
@@ -24,6 +24,7 @@ namespace FluentMigrator.Runner.Announcers
     {
         public virtual bool ShowSql { get; set; }
         public virtual bool ShowElapsedTime { get; set; }
+        public virtual bool StopOnError { get; set; }
 
         public virtual void Heading(string message)
         {

--- a/src/FluentMigrator.Runner/Announcers/ConsoleAnnouncer.cs
+++ b/src/FluentMigrator.Runner/Announcers/ConsoleAnnouncer.cs
@@ -75,6 +75,12 @@ namespace FluentMigrator.Runner.Announcers
             Console.ForegroundColor = ConsoleColor.Red;
             Console.Error.WriteLine(string.Format("!!! {0}", message));
             Console.ResetColor();
+
+            if (StopOnError)
+            {
+                Console.WriteLine("Press enter to continue...");
+                Console.ReadLine();
+            }
         }
 
         public void Write(string message)


### PR DESCRIPTION
When some migration fails it is good for developer to somehow pause the console and take a look at the error message