### PR TITLE
Add SystemMethods.CurrentDateTimeOffset

### DIFF
--- a/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
+++ b/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Announcers\TextWriterWithGoAnnouncer.cs" />
     <Compile Include="CompatabilityMode.cs" />
     <Compile Include="Generators\Postgres\PostgresDescriptionGenerator.cs" />
+    <Compile Include="Generators\SqlServer\SqlServer2008Column.cs" />
     <Compile Include="Generators\SqlServer\SqlServer2014Generator.cs" />
     <Compile Include="Generators\Hana\HanaColumn.cs" />
     <Compile Include="Generators\Hana\HanaDescriptionGenerator.cs" />
@@ -209,7 +210,7 @@
     <Compile Include="Generators\SqlServer\SqlServer2008TypeMap.cs" />
     <Compile Include="Generators\SqlServer\SqlServerCeGenerator.cs" />
     <Compile Include="Generators\SqlServer\SqlServerCeTypeMap.cs" />
-    <Compile Include="Generators\SqlServer\SqlServerColumn.cs" />
+    <Compile Include="Generators\SqlServer\SqlServer2000Column.cs" />
     <Compile Include="Generators\Base\TypeMapBase.cs" />
     <Compile Include="Generators\SqlServer\SqlServerQuoter.cs" />
     <Compile Include="IAnnouncer.cs" />

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2000Column.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2000Column.cs
@@ -4,9 +4,9 @@ using FluentMigrator.Runner.Generators.Base;
 
 namespace FluentMigrator.Runner.Generators.SqlServer
 {
-    internal class SqlServerColumn : ColumnBase
+    internal class SqlServer2000Column : ColumnBase
     {
-        public SqlServerColumn(ITypeMap typeMap)
+        public SqlServer2000Column(ITypeMap typeMap)
             : base(typeMap, new SqlServerQuoter())
         {
         }
@@ -51,6 +51,7 @@ namespace FluentMigrator.Runner.Generators.SqlServer
                     return "NEWSEQUENTIALID()";
                 case SystemMethods.CurrentDateTime:
                     return "GETDATE()";
+                case SystemMethods.CurrentDateTimeOffset:  // Fallback to GETUTCDATE() for SQL Server 2000 and 2005
                 case SystemMethods.CurrentUTCDateTime:
                     return "GETUTCDATE()";
                 case SystemMethods.CurrentUser:

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2000Generator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2000Generator.cs
@@ -29,7 +29,7 @@ namespace FluentMigrator.Runner.Generators.SqlServer
     public class SqlServer2000Generator : GenericGenerator
     {
         public SqlServer2000Generator()
-            : base(new SqlServerColumn(new SqlServer2000TypeMap()), new SqlServerQuoter(), new EmptyDescriptionGenerator())
+            : base(new SqlServer2000Column(new SqlServer2000TypeMap()), new SqlServerQuoter(), new EmptyDescriptionGenerator())
         {
         }
 
@@ -138,7 +138,7 @@ namespace FluentMigrator.Runner.Generators.SqlServer
                 Quoter.QuoteTableName(expression.TableName),
                 Quoter.QuoteColumnName(expression.ColumnName),
                 Quoter.QuoteValue(expression.DefaultValue),
-                Quoter.QuoteConstraintName(SqlServerColumn.GetDefaultConstraintName(expression.TableName, expression.ColumnName))));
+                Quoter.QuoteConstraintName(SqlServer2000Column.GetDefaultConstraintName(expression.TableName, expression.ColumnName))));
 
             return builder.ToString();
         }

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2005Generator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2005Generator.cs
@@ -29,7 +29,7 @@ namespace FluentMigrator.Runner.Generators.SqlServer
     public class SqlServer2005Generator : SqlServer2000Generator
     {
         public SqlServer2005Generator()
-            : base(new SqlServerColumn(new SqlServer2005TypeMap()), new SqlServer2005DescriptionGenerator())
+            : base(new SqlServer2000Column(new SqlServer2005TypeMap()), new SqlServer2005DescriptionGenerator())
         {
         }
 
@@ -315,9 +315,9 @@ namespace FluentMigrator.Runner.Generators.SqlServer
             builder.Append(String.Format("-- create alter table command to create new default constraint as string and run it" + Environment.NewLine + "ALTER TABLE {3}.{0} WITH NOCHECK ADD CONSTRAINT {4} DEFAULT({2}) FOR {1};",
                 Quoter.QuoteTableName(expression.TableName),
                 Quoter.QuoteColumnName(expression.ColumnName),
-                ((SqlServerColumn)Column).FormatDefaultValue(expression.DefaultValue),
+                ((SqlServer2000Column)Column).FormatDefaultValue(expression.DefaultValue),
                 Quoter.QuoteSchemaName(expression.SchemaName),
-                Quoter.QuoteConstraintName(SqlServerColumn.GetDefaultConstraintName(expression.TableName, expression.ColumnName))));
+                Quoter.QuoteConstraintName(SqlServer2000Column.GetDefaultConstraintName(expression.TableName, expression.ColumnName))));
 
             return builder.ToString();
         }

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2008Column.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2008Column.cs
@@ -1,6 +1,6 @@
 ﻿#region License
 // 
-// Copyright (c) 2010, Nathan Brown
+// Copyright (c) 2007-2017, Sean Chambers <schambers80@gmail.com>
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,16 +18,21 @@
 
 namespace FluentMigrator.Runner.Generators.SqlServer
 {
-    public class SqlServer2008Generator : SqlServer2005Generator
+    internal class SqlServer2008Column : SqlServer2000Column
     {
-        public SqlServer2008Generator()
-            : base(new SqlServer2008Column(new SqlServer2008TypeMap()), new SqlServer2005DescriptionGenerator())
-        {
-        }
+        public SqlServer2008Column(ITypeMap typeMap)
+            : base(typeMap)
+        { }
 
-        public SqlServer2008Generator(IColumn column, IDescriptionGenerator descriptionGenerator)
-            :base(column, descriptionGenerator)
+        protected override string FormatSystemMethods(SystemMethods systemMethod)
         {
+            switch (systemMethod)
+            {
+                case SystemMethods.CurrentDateTimeOffset:
+                    return "SYSDATETIMEOFFSET()";
+            }
+
+            return base.FormatSystemMethods(systemMethod);
         }
     }
 }

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2012Generator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2012Generator.cs
@@ -24,7 +24,7 @@ namespace FluentMigrator.Runner.Generators.SqlServer
     public class SqlServer2012Generator : SqlServer2008Generator
     {
         public SqlServer2012Generator()
-            :base(new SqlServer2000Column(new SqlServer2008TypeMap()), new SqlServer2005DescriptionGenerator())
+            :base(new SqlServer2008Column(new SqlServer2008TypeMap()), new SqlServer2005DescriptionGenerator())
         {
         }
 

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2012Generator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2012Generator.cs
@@ -24,7 +24,7 @@ namespace FluentMigrator.Runner.Generators.SqlServer
     public class SqlServer2012Generator : SqlServer2008Generator
     {
         public SqlServer2012Generator()
-            :base(new SqlServerColumn(new SqlServer2008TypeMap()), new SqlServer2005DescriptionGenerator())
+            :base(new SqlServer2000Column(new SqlServer2008TypeMap()), new SqlServer2005DescriptionGenerator())
         {
         }
 

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServerCeColumn.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServerCeColumn.cs
@@ -2,7 +2,7 @@
 
 namespace FluentMigrator.Runner.Generators.SqlServer
 {
-    internal class SqlServerCeColumn : SqlServerColumn
+    internal class SqlServerCeColumn : SqlServer2000Column
     {
         public SqlServerCeColumn(ITypeMap typeMap) : base(typeMap)
         {

--- a/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -467,6 +467,8 @@
     <Compile Include="Unit\Generators\SqlServer2005\SqlServer2005TableTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2008\SqlServer2008ConstraintsTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2008\SqlServer2008GeneratorTests.cs" />
+    <Compile Include="Unit\Generators\SqlServer2012\SqlServer2012ContraintsTests.cs" />
+    <Compile Include="Unit\Generators\SqlServer2012\SqlServer2012GeneratorTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2012\SqlServer2012SequenceTests.cs" />
     <Compile Include="Unit\Generators\SqlServerCe\SqlServerCeColumnTests.cs" />
     <Compile Include="Unit\Generators\SqlServerCe\SqlServerCeConstraintsTests.cs" />

--- a/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -465,6 +465,7 @@
     <Compile Include="Unit\Generators\SqlServer2005\SqlServer2005IndexTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2005\SqlServer2005SchemaTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2005\SqlServer2005TableTests.cs" />
+    <Compile Include="Unit\Generators\SqlServer2008\SqlServer2008ConstraintsTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2008\SqlServer2008GeneratorTests.cs" />
     <Compile Include="Unit\Generators\SqlServer2012\SqlServer2012SequenceTests.cs" />
     <Compile Include="Unit\Generators\SqlServerCe\SqlServerCeColumnTests.cs" />

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005ConstraintsTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005ConstraintsTests.cs
@@ -102,6 +102,34 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
         }
 
         [Test]
+        public void CanAlterDefaultConstraintWithCurrentDateTimeOffsetUsingGetUtcDateAsDefault()
+        {
+            var expression = GeneratorTestHelper.GetAlterDefaultConstraintExpression();
+            expression.DefaultValue = SystemMethods.CurrentDateTimeOffset;
+
+            string expected = "DECLARE @default sysname, @sql nvarchar(max);" + Environment.NewLine + Environment.NewLine +
+            "-- get name of default constraint" + Environment.NewLine +
+            "SELECT @default = name" + Environment.NewLine +
+            "FROM sys.default_constraints" + Environment.NewLine +
+            "WHERE parent_object_id = object_id('[dbo].[TestTable1]')" + Environment.NewLine +
+            "AND type = 'D'" + Environment.NewLine +
+            "AND parent_column_id = (" + Environment.NewLine +
+            "SELECT column_id" + Environment.NewLine +
+            "FROM sys.columns" + Environment.NewLine +
+            "WHERE object_id = object_id('[dbo].[TestTable1]')" + Environment.NewLine +
+            "AND name = 'TestColumn1'" + Environment.NewLine +
+            ");" + Environment.NewLine + Environment.NewLine +
+            "-- create alter table command to drop constraint as string and run it" + Environment.NewLine +
+            "SET @sql = N'ALTER TABLE [dbo].[TestTable1] DROP CONSTRAINT ' + @default;" + Environment.NewLine +
+            "EXEC sp_executesql @sql;" + Environment.NewLine + Environment.NewLine +
+            "-- create alter table command to create new default constraint as string and run it" + Environment.NewLine +
+            "ALTER TABLE [dbo].[TestTable1] WITH NOCHECK ADD CONSTRAINT [DF_TestTable1_TestColumn1] DEFAULT(GETUTCDATE()) FOR [TestColumn1];";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe(expected);
+        }
+
+        [Test]
         public void CanAlterDefaultConstraintWithNewGuidAsDefault()
         {
             var expression = GeneratorTestHelper.GetAlterDefaultConstraintExpression();

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005GeneratorTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005GeneratorTests.cs
@@ -17,7 +17,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
         [SetUp]
         public void Setup()
         {
-            Generator = new SqlServer2008Generator();
+            Generator = new SqlServer2005Generator();
         }
 
         [Test]

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005GeneratorTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005GeneratorTests.cs
@@ -255,6 +255,24 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
         }
 
         [Test]
+        public void CanUseSystemMethodCurrentDateTimeOffsetUsingGetUtcDateAsADefaultValueForAColumn()
+        {
+            var expression = new CreateColumnExpression
+            {
+                Column = new ColumnDefinition
+                {
+                    Name = "NewColumn",
+                    Type = DbType.DateTime,
+                    DefaultValue = SystemMethods.CurrentDateTimeOffset
+                },
+                TableName = "NewTable"
+            };
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE [dbo].[NewTable] ADD [NewColumn] DATETIME NOT NULL CONSTRAINT [DF__NewColumn] DEFAULT GETUTCDATE()");
+        }
+
+        [Test]
         public void CanUseSystemMethodNewGuidAsADefaultValueForAColumn()
         {
             var expression = new CreateColumnExpression

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2008/SqlServer2008ConstraintsTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2008/SqlServer2008ConstraintsTests.cs
@@ -1,0 +1,47 @@
+﻿using FluentMigrator.Runner.Generators.SqlServer;
+using NUnit.Framework;
+using NUnit.Should;
+using System;
+
+namespace FluentMigrator.Tests.Unit.Generators.SqlServer2008
+{
+    [TestFixture]
+    public class SqlServer2008ConstraintsTests
+    {
+        protected SqlServer2008Generator Generator;
+
+        [SetUp]
+        public void Setup()
+        {
+            Generator = new SqlServer2008Generator();
+        }
+
+        [Test]
+        public void CanAlterDefaultConstraintWithCurrentDateTimeOffsetAsDefault()
+        {
+            var expression = GeneratorTestHelper.GetAlterDefaultConstraintExpression();
+            expression.DefaultValue = SystemMethods.CurrentDateTimeOffset;
+
+            string expected = "DECLARE @default sysname, @sql nvarchar(max);" + Environment.NewLine + Environment.NewLine +
+            "-- get name of default constraint" + Environment.NewLine +
+            "SELECT @default = name" + Environment.NewLine +
+            "FROM sys.default_constraints" + Environment.NewLine +
+            "WHERE parent_object_id = object_id('[dbo].[TestTable1]')" + Environment.NewLine +
+            "AND type = 'D'" + Environment.NewLine +
+            "AND parent_column_id = (" + Environment.NewLine +
+            "SELECT column_id" + Environment.NewLine +
+            "FROM sys.columns" + Environment.NewLine +
+            "WHERE object_id = object_id('[dbo].[TestTable1]')" + Environment.NewLine +
+            "AND name = 'TestColumn1'" + Environment.NewLine +
+            ");" + Environment.NewLine + Environment.NewLine +
+            "-- create alter table command to drop constraint as string and run it" + Environment.NewLine +
+            "SET @sql = N'ALTER TABLE [dbo].[TestTable1] DROP CONSTRAINT ' + @default;" + Environment.NewLine +
+            "EXEC sp_executesql @sql;" + Environment.NewLine + Environment.NewLine +
+            "-- create alter table command to create new default constraint as string and run it" + Environment.NewLine +
+            "ALTER TABLE [dbo].[TestTable1] WITH NOCHECK ADD CONSTRAINT [DF_TestTable1_TestColumn1] DEFAULT(SYSDATETIMEOFFSET()) FOR [TestColumn1];";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe(expected);
+        }
+    }
+}

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2008/SqlServer2008GeneratorTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2008/SqlServer2008GeneratorTests.cs
@@ -33,6 +33,24 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2008
         }
 
         [Test]
+        public void CanUseSystemMethodCurrentDateTimeOffsetAsADefaultValueForAColumn()
+        {
+            var expression = new CreateColumnExpression
+            {
+                Column = new ColumnDefinition
+                {
+                    Name = "NewColumn",
+                    Type = DbType.DateTime,
+                    DefaultValue = SystemMethods.CurrentDateTimeOffset
+                },
+                TableName = "NewTable"
+            };
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE [dbo].[NewTable] ADD [NewColumn] DATETIME NOT NULL CONSTRAINT [DF__NewColumn] DEFAULT SYSDATETIMEOFFSET()");
+        }
+
+        [Test]
         public void CanInsertScopeIdentity()
         {
             var expression = new InsertDataExpression {TableName = "TestTable"};

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2012/SqlServer2012ContraintsTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2012/SqlServer2012ContraintsTests.cs
@@ -1,0 +1,46 @@
+﻿using FluentMigrator.Runner.Generators.SqlServer;
+using NUnit.Framework;
+using NUnit.Should;
+using System;
+
+namespace FluentMigrator.Tests.Unit.Generators.SqlServer2012
+{
+    public class SqlServer2012ConstraintsTests
+    {
+        protected SqlServer2012Generator Generator;
+
+        [SetUp]
+        public void Setup()
+        {
+            Generator = new SqlServer2012Generator();
+        }
+
+        [Test]
+        public void CanAlterDefaultConstraintWithCurrentDateTimeOffsetAsDefault()
+        {
+            var expression = GeneratorTestHelper.GetAlterDefaultConstraintExpression();
+            expression.DefaultValue = SystemMethods.CurrentDateTimeOffset;
+
+            string expected = "DECLARE @default sysname, @sql nvarchar(max);" + Environment.NewLine + Environment.NewLine +
+            "-- get name of default constraint" + Environment.NewLine +
+            "SELECT @default = name" + Environment.NewLine +
+            "FROM sys.default_constraints" + Environment.NewLine +
+            "WHERE parent_object_id = object_id('[dbo].[TestTable1]')" + Environment.NewLine +
+            "AND type = 'D'" + Environment.NewLine +
+            "AND parent_column_id = (" + Environment.NewLine +
+            "SELECT column_id" + Environment.NewLine +
+            "FROM sys.columns" + Environment.NewLine +
+            "WHERE object_id = object_id('[dbo].[TestTable1]')" + Environment.NewLine +
+            "AND name = 'TestColumn1'" + Environment.NewLine +
+            ");" + Environment.NewLine + Environment.NewLine +
+            "-- create alter table command to drop constraint as string and run it" + Environment.NewLine +
+            "SET @sql = N'ALTER TABLE [dbo].[TestTable1] DROP CONSTRAINT ' + @default;" + Environment.NewLine +
+            "EXEC sp_executesql @sql;" + Environment.NewLine + Environment.NewLine +
+            "-- create alter table command to create new default constraint as string and run it" + Environment.NewLine +
+            "ALTER TABLE [dbo].[TestTable1] WITH NOCHECK ADD CONSTRAINT [DF_TestTable1_TestColumn1] DEFAULT(SYSDATETIMEOFFSET()) FOR [TestColumn1];";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe(expected);
+        }
+    }
+}

--- a/src/FluentMigrator.Tests/Unit/Generators/SqlServer2012/SqlServer2012GeneratorTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Generators/SqlServer2012/SqlServer2012GeneratorTests.cs
@@ -1,0 +1,39 @@
+﻿using FluentMigrator.Expressions;
+using FluentMigrator.Model;
+using FluentMigrator.Runner.Generators.SqlServer;
+using NUnit.Framework;
+using NUnit.Should;
+using System.Data;
+
+namespace FluentMigrator.Tests.Unit.Generators.SqlServer2012
+{
+    [TestFixture]
+    public class SqlServer2012GeneratorTests
+    {
+        protected SqlServer2012Generator Generator;
+
+        [SetUp]
+        public void Setup()
+        {
+            Generator = new SqlServer2012Generator();
+        }
+
+        [Test]
+        public void CanUseSystemMethodCurrentDateTimeOffsetAsADefaultValueForAColumn()
+        {
+            var expression = new CreateColumnExpression
+            {
+                Column = new ColumnDefinition
+                {
+                    Name = "NewColumn",
+                    Type = DbType.DateTime,
+                    DefaultValue = SystemMethods.CurrentDateTimeOffset
+                },
+                TableName = "NewTable"
+            };
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE [dbo].[NewTable] ADD [NewColumn] DATETIME NOT NULL CONSTRAINT [DF__NewColumn] DEFAULT SYSDATETIMEOFFSET()");
+        }
+    }
+}

--- a/src/FluentMigrator/SystemMethods.cs
+++ b/src/FluentMigrator/SystemMethods.cs
@@ -6,6 +6,7 @@ namespace FluentMigrator
         NewGuid,
         NewSequentialId,
         CurrentDateTime,
+        CurrentDateTimeOffset,
         CurrentUTCDateTime,
         CurrentUser
     }


### PR DESCRIPTION
Solves #801 for SQL Server:
- Add SystemMethods.CurrentDateTimeOffset
- For SQL Server 2008 and newer, generate SYSDATETIMEOFFSET() to get values relative to the local time zone as opposed to GETUTCDATE().
- For SQL Server 2005 and older, fallback to GETUTCDATE() since that's the closest supported.

In addition, this PR fixes #802. 