### PR TITLE
Remove default connection timeout. Use provider's default instead.

### DIFF
--- a/src/FluentMigrator.Console/MigratorConsole.cs
+++ b/src/FluentMigrator.Console/MigratorConsole.cs
@@ -45,7 +45,7 @@ namespace FluentMigrator.Console
         public List<string> Tags = new List<string>();
         public string TargetAssembly;
         public string Task;
-        public int Timeout;
+        public int? Timeout;
         public bool Verbose;
         public long Version;
         public long StartVersion;

--- a/src/FluentMigrator.MSBuild/Migrate.cs
+++ b/src/FluentMigrator.MSBuild/Migrate.cs
@@ -79,7 +79,7 @@ namespace FluentMigrator.MSBuild
 
         public string WorkingDirectory { get; set; }
 
-        public int Timeout { get; set; }
+        public int? Timeout { get; set; }
 
         public string Profile { get; set; }
 

--- a/src/FluentMigrator.NAnt/MigrateTask.cs
+++ b/src/FluentMigrator.NAnt/MigrateTask.cs
@@ -68,7 +68,7 @@ namespace FluentMigrator.NAnt
         public string Tags { get; set; }
 
         [TaskAttribute("timeout")]
-        public int Timeout { get; set; }
+        public int? Timeout { get; set; }
 
         [TaskAttribute("output")]
         public bool Output { get; set; }

--- a/src/FluentMigrator.Runner/Initialization/IRunnerContext.cs
+++ b/src/FluentMigrator.Runner/Initialization/IRunnerContext.cs
@@ -37,7 +37,7 @@ namespace FluentMigrator.Runner.Initialization
         string Profile { get; set; }
         IAnnouncer Announcer { get; }
         IStopWatch StopWatch { get; }
-        int Timeout { get; set; }
+        int? Timeout { get; set; }
         string ConnectionStringConfigPath { get; set; }
         IEnumerable<string> Tags { get; set; }
         string ProviderSwitches { get; set; }

--- a/src/FluentMigrator.Runner/Initialization/RunnerContext.cs
+++ b/src/FluentMigrator.Runner/Initialization/RunnerContext.cs
@@ -23,7 +23,7 @@ namespace FluentMigrator.Runner.Initialization
         public int Steps { get; set; }
         public string WorkingDirectory { get; set; }
         public string Profile { get; set; }
-        public int Timeout { get; set; }
+        public int? Timeout { get; set; }
         public string ConnectionStringConfigPath { get; set; }
         public IEnumerable<string> Tags { get; set; }
         public bool TransactionPerSession { get; set; }

--- a/src/FluentMigrator.Runner/Initialization/TaskExecutor.cs
+++ b/src/FluentMigrator.Runner/Initialization/TaskExecutor.cs
@@ -132,12 +132,6 @@ namespace FluentMigrator.Runner.Initialization
 
         private IMigrationProcessor InitializeProcessor(IAssemblyCollection assemblyCollection)
         {
-
-            if (RunnerContext.Timeout == 0)
-            {
-                RunnerContext.Timeout = 30; // Set default timeout for command
-            }
-
             var connectionString = LoadConnectionString(assemblyCollection);
             var processorFactory = ProcessorFactoryProvider.GetFactory(RunnerContext.Database);
 

--- a/src/FluentMigrator.Runner/Processors/Db2/Db2Processor.cs
+++ b/src/FluentMigrator.Runner/Processors/Db2/Db2Processor.cs
@@ -77,7 +77,7 @@
         {
             this.EnsureConnectionIsOpen();
 
-            using (var command = Factory.CreateCommand(string.Format(template, args), Connection, Transaction))
+            using (var command = Factory.CreateCommand(string.Format(template, args), Connection, Transaction, Options))
             using (var reader = command.ExecuteReader())
             {
                 return reader.Read();
@@ -118,7 +118,7 @@
             this.EnsureConnectionIsOpen();
 
             var ds = new DataSet();
-            using (var command = Factory.CreateCommand(string.Format(template, args), Connection, Transaction))
+            using (var command = Factory.CreateCommand(string.Format(template, args), Connection, Transaction, Options))
             {
                 var adapter = Factory.CreateDataAdapter(command);
                 adapter.Fill(ds);
@@ -160,9 +160,8 @@
 
             this.EnsureConnectionIsOpen();
 
-            using (var command = Factory.CreateCommand(sql, Connection))
+            using (var command = Factory.CreateCommand(sql, Connection, Options))
             {
-                command.CommandTimeout = Options.Timeout;
                 command.ExecuteNonQuery();
             }
         }

--- a/src/FluentMigrator.Runner/Processors/DbFactoryBase.cs
+++ b/src/FluentMigrator.Runner/Processors/DbFactoryBase.cs
@@ -64,11 +64,12 @@ namespace FluentMigrator.Runner.Processors
             return connection;
         }
 
-        public IDbCommand CreateCommand(string commandText, IDbConnection connection, IDbTransaction transaction)
+        public virtual IDbCommand CreateCommand(string commandText, IDbConnection connection, IDbTransaction transaction, IMigrationProcessorOptions options)
         {
             var command = connection.CreateCommand();
             command.CommandText = commandText;
             if (transaction != null) command.Transaction = transaction;
+            if (options != null && options.Timeout.HasValue) command.CommandTimeout = options.Timeout.Value;
             return command;
         }
 
@@ -79,9 +80,9 @@ namespace FluentMigrator.Runner.Processors
             return dataAdapter;
         }
 
-        public IDbCommand CreateCommand(string commandText, IDbConnection connection)
+        public IDbCommand CreateCommand(string commandText, IDbConnection connection, IMigrationProcessorOptions options)
         {
-            return CreateCommand(commandText, connection, null);
+            return CreateCommand(commandText, connection, null, options);
         }
 
         #endregion

--- a/src/FluentMigrator.Runner/Processors/DotConnectOracle/DotConnectOracleProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/DotConnectOracle/DotConnectOracleProcessor.cs
@@ -128,7 +128,7 @@ namespace FluentMigrator.Runner.Processors.DotConnectOracle
 
             EnsureConnectionIsOpen();
 
-            using (var command = Factory.CreateCommand(String.Format(template, args), Connection))
+            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Options))
             {
                 command.ExecuteNonQuery();
             }
@@ -141,7 +141,7 @@ namespace FluentMigrator.Runner.Processors.DotConnectOracle
 
             EnsureConnectionIsOpen();
 
-            using (var command = Factory.CreateCommand(String.Format(template, args), Connection))
+            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Options))
             using (var reader = command.ExecuteReader())
             {
                 return reader.Read();
@@ -167,7 +167,7 @@ namespace FluentMigrator.Runner.Processors.DotConnectOracle
             EnsureConnectionIsOpen();
 
             var result = new DataSet();
-            using (var command = Factory.CreateCommand(String.Format(template, args), Connection))
+            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Options))
             {
                 var adapter = Factory.CreateDataAdapter(command);
                 adapter.Fill(result);
@@ -192,7 +192,7 @@ namespace FluentMigrator.Runner.Processors.DotConnectOracle
 
             EnsureConnectionIsOpen();
 
-            using (var command = Factory.CreateCommand(sql, Connection))
+            using (var command = Factory.CreateCommand(sql, Connection, Options))
                 command.ExecuteNonQuery();
         }
     }

--- a/src/FluentMigrator.Runner/Processors/Firebird/FirebirdProcessedExpression.cs
+++ b/src/FluentMigrator.Runner/Processors/Firebird/FirebirdProcessedExpression.cs
@@ -411,9 +411,8 @@ namespace FluentMigrator.Runner.Processors.Firebird
             if (String.IsNullOrEmpty(sql))
                 return;
             Processor.Announcer.Sql(sql);
-            using (var command = Processor.Factory.CreateCommand(sql, connection, transaction))
+            using (var command = Processor.Factory.CreateCommand(sql, connection, transaction, Processor.Options))
             {
-                command.CommandTimeout = Processor.Options.Timeout;
                 command.ExecuteNonQuery();
             }
         }

--- a/src/FluentMigrator.Runner/Processors/Firebird/FirebirdProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/Firebird/FirebirdProcessor.cs
@@ -106,7 +106,7 @@ namespace FluentMigrator.Runner.Processors.Firebird
             //Announcer.Sql(String.Format(template,args));
 
             var ds = new DataSet();
-            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Transaction))
+            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Transaction, Options))
             {
                 var adapter = Factory.CreateDataAdapter(command);
                 adapter.Fill(ds);
@@ -123,7 +123,7 @@ namespace FluentMigrator.Runner.Processors.Firebird
         {
             EnsureConnectionIsOpen();
 
-            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Transaction))
+            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Transaction, Options))
             using (var reader = command.ExecuteReader())
             {
                 return reader.Read();
@@ -397,9 +397,8 @@ namespace FluentMigrator.Runner.Processors.Firebird
                 {
                     string sql = (Generator as FirebirdGenerator).GenerateSetNull(colDef);
                     Announcer.Sql(sql);
-                    using (var cmd = Factory.CreateCommand(sql, connection, transaction))
+                    using (var cmd = Factory.CreateCommand(sql, connection, transaction, Options))
                     {
-                        cmd.CommandTimeout = Options.Timeout;
                         cmd.ExecuteNonQuery();
                     }
                 };
@@ -481,9 +480,8 @@ namespace FluentMigrator.Runner.Processors.Firebird
                 {
                     string sql = (Generator as FirebirdGenerator).GenerateSetType(colDef);
                     Announcer.Sql(sql);
-                    using (var cmd = Factory.CreateCommand(sql, connection, transaction))
+                    using (var cmd = Factory.CreateCommand(sql, connection, transaction, Options))
                     {
-                        cmd.CommandTimeout = Options.Timeout;
                         cmd.ExecuteNonQuery();
                     }
                 };
@@ -847,11 +845,10 @@ namespace FluentMigrator.Runner.Processors.Firebird
 
             EnsureConnectionIsOpen();
 
-            using (var command = Factory.CreateCommand(sql, Connection, Transaction))
+            using (var command = Factory.CreateCommand(sql, Connection, Transaction, Options))
             {
                 try
                 {
-                    command.CommandTimeout = Options.Timeout;
                     command.ExecuteNonQuery();
                 }
                 catch (Exception ex)
@@ -990,9 +987,8 @@ namespace FluentMigrator.Runner.Processors.Firebird
                      triggerBody
                      );
                 Announcer.Sql(triggerSql);
-                using (var cmd = Factory.CreateCommand(triggerSql, connection, transaction))
+                using (var cmd = Factory.CreateCommand(triggerSql, connection, transaction, Options))
                 {
-                    cmd.CommandTimeout = Options.Timeout;
                     cmd.ExecuteNonQuery();
                 }
             };
@@ -1010,9 +1006,8 @@ namespace FluentMigrator.Runner.Processors.Firebird
             {
                 string triggerSql = String.Format("DROP TRIGGER {0}", quoter.Quote(triggerName));
                 Announcer.Sql(triggerSql);
-                using (var cmd = Factory.CreateCommand(triggerSql, connection, transaction))
+                using (var cmd = Factory.CreateCommand(triggerSql, connection, transaction, Options))
                 {
-                    cmd.CommandTimeout = Options.Timeout;
                     cmd.ExecuteNonQuery();
                 }
             };

--- a/src/FluentMigrator.Runner/Processors/Hana/HanaProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/Hana/HanaProcessor.cs
@@ -119,7 +119,7 @@ namespace FluentMigrator.Runner.Processors.Hana
 
             Announcer.Sql(string.Format("{0};", querySql));
 
-            using (var command = Factory.CreateCommand(String.Format(template, args), Connection))
+            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Options))
             using (var reader = command.ExecuteReader())
             {
                 return reader.Read();
@@ -145,7 +145,7 @@ namespace FluentMigrator.Runner.Processors.Hana
             EnsureConnectionIsOpen();
 
             var result = new DataSet();
-            using (var command = Factory.CreateCommand(String.Format(template, args), Connection))
+            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Options))
             {
                 var adapter = Factory.CreateDataAdapter(command);
                 adapter.Fill(result);
@@ -185,7 +185,7 @@ namespace FluentMigrator.Runner.Processors.Hana
                     ? batch.Remove(batch.Length - 1) 
                     : batch;
 
-                using (var command = Factory.CreateCommand(batchCommand, Connection))
+                using (var command = Factory.CreateCommand(batchCommand, Connection, Options))
                     command.ExecuteNonQuery();
             }
         }

--- a/src/FluentMigrator.Runner/Processors/IDbFactory.cs
+++ b/src/FluentMigrator.Runner/Processors/IDbFactory.cs
@@ -5,8 +5,8 @@ namespace FluentMigrator.Runner.Processors
     public interface IDbFactory
     {
         IDbConnection CreateConnection(string connectionString);
-        IDbCommand CreateCommand(string commandText, IDbConnection connection, IDbTransaction transaction);
+        IDbCommand CreateCommand(string commandText, IDbConnection connection, IDbTransaction transaction, IMigrationProcessorOptions options);
         IDbDataAdapter CreateDataAdapter(IDbCommand command);
-        IDbCommand CreateCommand(string commandText, IDbConnection connection);
+        IDbCommand CreateCommand(string commandText, IDbConnection connection, IMigrationProcessorOptions options);
     }
 }

--- a/src/FluentMigrator.Runner/Processors/MySql/MySqlProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/MySql/MySqlProcessor.cs
@@ -95,9 +95,8 @@ namespace FluentMigrator.Runner.Processors.MySql
 
             EnsureConnectionIsOpen();
 
-            using (var command = Factory.CreateCommand(String.Format(template, args), Connection))
+            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Options))
             {
-                command.CommandTimeout = Options.Timeout;
                 command.ExecuteNonQuery();
             }
         }
@@ -106,9 +105,8 @@ namespace FluentMigrator.Runner.Processors.MySql
         {
             EnsureConnectionIsOpen();
 
-            using (var command = Factory.CreateCommand(String.Format(template, args), Connection))
+            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Options))
             {
-                command.CommandTimeout = Options.Timeout;
                 using (var reader = command.ExecuteReader())
                 {
                     try
@@ -133,10 +131,8 @@ namespace FluentMigrator.Runner.Processors.MySql
             EnsureConnectionIsOpen();
 
             var ds = new DataSet();
-            using (var command = Factory.CreateCommand(String.Format(template, args), Connection))
+            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Options))
             {
-                command.CommandTimeout = Options.Timeout;
-
                 var adapter = Factory.CreateDataAdapter(command);
                 adapter.Fill(ds);
                 return ds;
@@ -152,9 +148,8 @@ namespace FluentMigrator.Runner.Processors.MySql
 
             EnsureConnectionIsOpen();
 
-            using (var command = Factory.CreateCommand(sql, Connection))
+            using (var command = Factory.CreateCommand(sql, Connection, Options))
             {
-                command.CommandTimeout = Options.Timeout;
                 command.ExecuteNonQuery();
             }
         }

--- a/src/FluentMigrator.Runner/Processors/Oracle/OracleProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/Oracle/OracleProcessor.cs
@@ -149,7 +149,7 @@ namespace FluentMigrator.Runner.Processors.Oracle
             EnsureConnectionIsOpen();
 
             Announcer.Sql(String.Format(template, args));
-            using (var command = Factory.CreateCommand(String.Format(template, args), Connection))
+            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Options))
             using (var reader = command.ExecuteReader())
             {
                 return reader.Read();
@@ -175,7 +175,7 @@ namespace FluentMigrator.Runner.Processors.Oracle
             EnsureConnectionIsOpen();
 
             var result = new DataSet();
-            using (var command = Factory.CreateCommand(String.Format(template, args), Connection))
+            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Options))
             {
                 var adapter = Factory.CreateDataAdapter(command);
                 adapter.Fill(result);
@@ -206,7 +206,7 @@ namespace FluentMigrator.Runner.Processors.Oracle
 
             foreach (var batch in batches)
             {
-                using (var command = Factory.CreateCommand(batch, Connection))
+                using (var command = Factory.CreateCommand(batch, Connection, Options))
                     command.ExecuteNonQuery();
             }
         }

--- a/src/FluentMigrator.Runner/Processors/Postgres/PostgresProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/Postgres/PostgresProcessor.cs
@@ -80,7 +80,7 @@ namespace FluentMigrator.Runner.Processors.Postgres
             EnsureConnectionIsOpen();
 
             var ds = new DataSet();
-            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Transaction))
+            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Transaction, Options))
             {
                 var adapter = Factory.CreateDataAdapter(command);
                 adapter.Fill(ds);
@@ -92,7 +92,7 @@ namespace FluentMigrator.Runner.Processors.Postgres
         {
             EnsureConnectionIsOpen();
 
-            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Transaction))
+            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Transaction, Options))
             using (var reader = command.ExecuteReader())
             {
                 return reader.Read();
@@ -108,11 +108,10 @@ namespace FluentMigrator.Runner.Processors.Postgres
 
             EnsureConnectionIsOpen();
 
-            using (var command = Factory.CreateCommand(sql, Connection, Transaction))
+            using (var command = Factory.CreateCommand(sql, Connection, Transaction, Options))
             {
                 try
                 {
-                    command.CommandTimeout = Options.Timeout;
                     command.ExecuteNonQuery();
                 }
                 catch (Exception ex)

--- a/src/FluentMigrator.Runner/Processors/ProcessorOptions.cs
+++ b/src/FluentMigrator.Runner/Processors/ProcessorOptions.cs
@@ -3,7 +3,7 @@
     public class ProcessorOptions : IMigrationProcessorOptions
     {
         public bool PreviewOnly { get; set; }
-        public int Timeout { get; set; }
+        public int? Timeout { get; set; }
         public string ProviderSwitches  { get; set; }
     }
 }

--- a/src/FluentMigrator.Runner/Processors/SQLite/SQLiteProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/SQLite/SQLiteProcessor.cs
@@ -77,7 +77,7 @@ namespace FluentMigrator.Runner.Processors.SQLite
         {
             EnsureConnectionIsOpen();
 
-            using (var command = Factory.CreateCommand(String.Format(template, args), Connection))
+            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Options))
             using (var reader = command.ExecuteReader())
             {
                 try
@@ -140,7 +140,7 @@ namespace FluentMigrator.Runner.Processors.SQLite
 
         private void ExecuteNonQuery(string sql)
         {
-            using (var command = Factory.CreateCommand(sql, Connection))
+            using (var command = Factory.CreateCommand(sql, Connection, Options))
             {
                 try
                 {
@@ -158,7 +158,7 @@ namespace FluentMigrator.Runner.Processors.SQLite
             sql += "\nGO";   // make sure last batch is executed.
             string sqlBatch = string.Empty;
 
-            using (var command = Factory.CreateCommand(sql, Connection))
+            using (var command = Factory.CreateCommand(sql, Connection, Options))
             {
                 try
                 {
@@ -191,7 +191,7 @@ namespace FluentMigrator.Runner.Processors.SQLite
             EnsureConnectionIsOpen();
 
             var ds = new DataSet();
-            using (var command = Factory.CreateCommand(String.Format(template, args), Connection))
+            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Options))
             {
                 var adapter = Factory.CreateDataAdapter(command);
                 adapter.Fill(ds);

--- a/src/FluentMigrator.Runner/Processors/SqlServer/SqlServer2000Processor.cs
+++ b/src/FluentMigrator.Runner/Processors/SqlServer/SqlServer2000Processor.cs
@@ -102,7 +102,7 @@ namespace FluentMigrator.Runner.Processors.SqlServer
             EnsureConnectionIsOpen();
 
             var ds = new DataSet();
-            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Transaction))
+            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Transaction, Options))
             {
                 var adapter = Factory.CreateDataAdapter(command);
                 adapter.Fill(ds);
@@ -114,7 +114,7 @@ namespace FluentMigrator.Runner.Processors.SqlServer
         {
             EnsureConnectionIsOpen();
 
-            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Transaction))
+            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Transaction, Options))
             using (var reader = command.ExecuteReader())
             {
                 return reader.Read();
@@ -148,11 +148,10 @@ namespace FluentMigrator.Runner.Processors.SqlServer
 
         private void ExecuteNonQuery(string sql)
         {
-            using (var command = Factory.CreateCommand(sql, Connection, Transaction))
+            using (var command = Factory.CreateCommand(sql, Connection, Transaction, Options))
             {
                 try
                 {
-                    command.CommandTimeout = Options.Timeout;
                     command.ExecuteNonQuery();
                 }
                 catch (Exception ex)
@@ -174,7 +173,7 @@ namespace FluentMigrator.Runner.Processors.SqlServer
             sql += "\nGO";   // make sure last batch is executed.
             string sqlBatch = string.Empty;
 
-            using (var command = Factory.CreateCommand(string.Empty, Connection, Transaction))
+            using (var command = Factory.CreateCommand(string.Empty, Connection, Transaction, Options))
             {
                 try
                 {

--- a/src/FluentMigrator.Runner/Processors/SqlServer/SqlServerCeDbFactory.cs
+++ b/src/FluentMigrator.Runner/Processors/SqlServer/SqlServerCeDbFactory.cs
@@ -1,3 +1,5 @@
+using System.Data;
+
 namespace FluentMigrator.Runner.Processors.SqlServer
 {
     public class SqlServerCeDbFactory : ReflectionBasedDbFactory
@@ -5,6 +7,18 @@ namespace FluentMigrator.Runner.Processors.SqlServer
         public SqlServerCeDbFactory()
             : base("System.Data.SqlServerCe", "System.Data.SqlServerCe.SqlCeProviderFactory")
         {
+        }
+
+        public override IDbCommand CreateCommand(string commandText, IDbConnection connection, IDbTransaction transaction, IMigrationProcessorOptions options)
+        {
+            var command = base.CreateCommand(commandText, connection, transaction, options);
+
+            if (command.CommandTimeout != 0)
+            {
+                command.CommandTimeout = 0; // SQL Server CE does not support non-zero command timeout values!! :/
+            }
+
+            return command;
         }
     }
 }

--- a/src/FluentMigrator.Runner/Processors/SqlServer/SqlServerCeProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/SqlServer/SqlServerCeProcessor.cs
@@ -94,7 +94,7 @@ namespace FluentMigrator.Runner.Processors.SqlServer
         {
             EnsureConnectionIsOpen();
 
-            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Transaction))
+            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Transaction, Options))
             using (var reader = command.ExecuteReader())
             {
                 return reader.Read();
@@ -111,7 +111,7 @@ namespace FluentMigrator.Runner.Processors.SqlServer
             EnsureConnectionIsOpen();
 
             var ds = new DataSet();
-            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Transaction))
+            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Transaction, Options))
             {
                 var adapter = Factory.CreateDataAdapter(command);
                 adapter.Fill(ds);
@@ -128,14 +128,13 @@ namespace FluentMigrator.Runner.Processors.SqlServer
 
             EnsureConnectionIsOpen();
 
-            using (var command = Factory.CreateCommand("", Connection, Transaction))
+            using (var command = Factory.CreateCommand("", Connection, Transaction, Options))
             {
                 foreach (string statement in SplitIntoSingleStatements(sql))
                 {
                     try
                     {
                         command.CommandText = statement;
-                        command.CommandTimeout = 0; // SQL Server CE does not support non-zero command timeout values!! :/
                         command.ExecuteNonQuery();
                     }
                     catch (Exception ex)

--- a/src/FluentMigrator.Runner/Processors/SqlServer/SqlServerProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/SqlServer/SqlServerProcessor.cs
@@ -119,7 +119,7 @@ namespace FluentMigrator.Runner.Processors.SqlServer
         {
             EnsureConnectionIsOpen();
 
-            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Transaction))
+            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Transaction, Options))
             {
                 var result = command.ExecuteScalar();
                 return DBNull.Value != result && Convert.ToInt32(result) == 1;
@@ -136,7 +136,7 @@ namespace FluentMigrator.Runner.Processors.SqlServer
             EnsureConnectionIsOpen();
 
             var ds = new DataSet();
-            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Transaction))
+            using (var command = Factory.CreateCommand(String.Format(template, args), Connection, Transaction, Options))
             {
                 var adapter = Factory.CreateDataAdapter(command);
                 adapter.Fill(ds);
@@ -166,11 +166,10 @@ namespace FluentMigrator.Runner.Processors.SqlServer
 
         private void ExecuteNonQuery(string sql)
         {
-            using (var command = Factory.CreateCommand(sql, Connection, Transaction))
+            using (var command = Factory.CreateCommand(sql, Connection, Transaction, Options))
             {
                 try
                 {
-                    command.CommandTimeout = Options.Timeout;
                     command.ExecuteNonQuery();
                 }
                 catch (Exception ex)
@@ -192,7 +191,7 @@ namespace FluentMigrator.Runner.Processors.SqlServer
             sql += "\nGO";   // make sure last batch is executed.
             string sqlBatch = string.Empty;
 
-            using (var command = Factory.CreateCommand(string.Empty, Connection, Transaction))
+            using (var command = Factory.CreateCommand(string.Empty, Connection, Transaction, Options))
             {
                 try
                 {
@@ -203,7 +202,6 @@ namespace FluentMigrator.Runner.Processors.SqlServer
                             if (!string.IsNullOrEmpty(sqlBatch))
                             {
                                 command.CommandText = sqlBatch;
-                                command.CommandTimeout = Options.Timeout;
                                 command.ExecuteNonQuery();
                                 sqlBatch = string.Empty;
                             }

--- a/src/FluentMigrator.Tests/Helpers/Db2TestTable.cs
+++ b/src/FluentMigrator.Tests/Helpers/Db2TestTable.cs
@@ -9,12 +9,14 @@
     using FluentMigrator.Runner.Generators.DB2;
     using FluentMigrator.Runner.Processors;
     using FluentMigrator.Runner.Processors.DB2;
+    using Unit;
 
     public class Db2TestTable : IDisposable
     {
         #region Fields
 
         private readonly Db2Quoter quoter = new Db2Quoter();
+        private IMigrationProcessorOptions Options { get; set; }
 
         private List<string> constraints = new List<string>();
         private string _schema;
@@ -25,6 +27,7 @@
 
         public Db2TestTable(Db2Processor processor, string schema, params string[] columnDefinitions)
         {
+            Options = new TestMigrationProcessorOptions();
             Connection = processor.Connection;
             Transaction = processor.Transaction;
             Processor = processor;
@@ -105,7 +108,7 @@
             var columns = string.Join(", ", columnDefinitions);
             sb.AppendFormat("CREATE TABLE {0} ({1})", NameWithSchema, columns);
 
-            using (var command = Factory.CreateCommand(sb.ToString(), Connection, Transaction))
+            using (var command = Factory.CreateCommand(sb.ToString(), Connection, Transaction, Options))
             {
                 command.ExecuteNonQuery();
             }
@@ -120,7 +123,7 @@
         {
             var tableCommand = string.Format("DROP TABLE {0}", NameWithSchema);
 
-            using (var command = Factory.CreateCommand(tableCommand, Connection, Transaction))
+            using (var command = Factory.CreateCommand(tableCommand, Connection, Transaction, Options))
             {
                 command.ExecuteNonQuery();
             }
@@ -129,7 +132,7 @@
             {
                 var schemaCommand = string.Format("DROP SCHEMA {0} RESTRICT", quoter.QuoteSchemaName(_schema));
 
-                using (var commandToo = Factory.CreateCommand(schemaCommand, Connection, Transaction))
+                using (var commandToo = Factory.CreateCommand(schemaCommand, Connection, Transaction, Options))
                 {
                     commandToo.ExecuteNonQuery();
                 }
@@ -144,7 +147,7 @@
                 quoter.QuoteColumnName(column)
                 );
 
-            using (var command = Factory.CreateCommand(query, Connection, Transaction))
+            using (var command = Factory.CreateCommand(query, Connection, Transaction, Options))
             {
                 command.ExecuteNonQuery();
             }
@@ -160,7 +163,7 @@
                 quoter.QuoteColumnName(column)
             );
 
-            using (var command = Factory.CreateCommand(query, Connection, Transaction))
+            using (var command = Factory.CreateCommand(query, Connection, Transaction, Options))
             {
                 command.ExecuteNonQuery();
             }

--- a/src/FluentMigrator.Tests/Integration/Processors/Oracle/OracleProcessorTestsBase.cs
+++ b/src/FluentMigrator.Tests/Integration/Processors/Oracle/OracleProcessorTestsBase.cs
@@ -12,20 +12,23 @@ using FluentMigrator.Tests.Helpers;
 
 using NUnit.Framework;
 using NUnit.Should;
+using FluentMigrator.Tests.Unit;
 
 namespace FluentMigrator.Tests.Integration.Processors.Oracle {
 	[Category("Integration")]
 	public abstract class OracleProcessorTestsBase
 	{
 		private const string SchemaName = "test";
-		private IDbConnection Connection { get; set; }
+        private IMigrationProcessorOptions Options { get; set; }
+        private IDbConnection Connection { get; set; }
 		private OracleProcessor Processor { get; set; }
 		private IDbFactory Factory { get; set; }
 		private IQuoter Quoter { get { return this.Processor.Quoter; } }
 
 		protected void SetUp(IDbFactory dbFactory)
 		{
-			this.Factory = dbFactory;
+            Options = new TestMigrationProcessorOptions();
+            this.Factory = dbFactory;
 			this.Connection = this.Factory.CreateConnection(IntegrationTestOptions.Oracle.ConnectionString);
 			this.Processor = new OracleProcessor(this.Connection, new OracleGenerator(), new TextWriterAnnouncer(System.Console.Out), new ProcessorOptions(), this.Factory);
 			this.Connection.Open();
@@ -96,7 +99,7 @@ namespace FluentMigrator.Tests.Integration.Processors.Oracle {
 		{
 			string sql = "SELECT SYSDATE FROM " + this.Quoter.QuoteTableName("DUAL");
 			var ds = new DataSet();
-			using (var command = this.Factory.CreateCommand(sql, this.Connection))
+			using (var command = this.Factory.CreateCommand(sql, this.Connection, Options))
 			{
 				var adapter = this.Factory.CreateDataAdapter(command);
 				adapter.Fill(ds);

--- a/src/FluentMigrator.Tests/Unit/VersionLoaderTests.cs
+++ b/src/FluentMigrator.Tests/Unit/VersionLoaderTests.cs
@@ -17,7 +17,7 @@ namespace FluentMigrator.Tests.Unit
             get { return false; }
         }
 
-        public int Timeout
+        public int? Timeout
         {
             get { return 30; }
         }

--- a/src/FluentMigrator/IMigrationProcessorOptions.cs
+++ b/src/FluentMigrator/IMigrationProcessorOptions.cs
@@ -3,7 +3,7 @@ namespace FluentMigrator
     public interface IMigrationProcessorOptions
     {
         bool PreviewOnly { get; }
-        int Timeout { get; }
+        int? Timeout { get; }
         string ProviderSwitches { get; }
     }
 }


### PR DESCRIPTION
To fix issue #810 I've made Timeout property of configurations nullable. The value is no longer set to a default value by FluentMigrator. When null, a connection's Timeout property doesn't get set, resulting in the provider's default timeout to be used.

In case of SQL Server, setting Timeout to 0 now results in an infinite timeout as requested in the issue.
