### PR TITLE
Update Max Decimal for MySql

### DIFF
--- a/src/FluentMigrator.Runner/Generators/MySql/MySqlTypeMap.cs
+++ b/src/FluentMigrator.Runner/Generators/MySql/MySqlTypeMap.cs
@@ -11,7 +11,7 @@ namespace FluentMigrator.Runner.Generators.MySql
         public const int TextCapacity = 65535;
         public const int MediumTextCapacity = 16777215;
         public const int LongTextCapacity = int.MaxValue;
-        public const int DecimalCapacity = 19;
+        public const int DecimalCapacity = 65;
 
         protected override void SetupTypeMaps()
         {


### PR DESCRIPTION
Update Maximum Decimal Size for MySQL based on documentation stated [here](https://dev.mysql.com/doc/refman/5.7/en/precision-math-decimal-characteristics.html)

This is to fix issue #823 