### PR TITLE
Fixed nunit tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ script:
   - dpkg -L libfbembed2.5
   - for f in $(dpkg -L libfbembed2.5 | grep libfbembed.so); do cp $f ./src/FluentMigrator.Tests/bin/Debug; done
   - for f in $(dpkg -L libfbembed2.5 | grep libfbembed.so); do cp $f ./src/FluentMigrator.Tests/bin/Debug/libfbembed.so; done
-  - nunit-console ./src/FluentMigrator.Tests/bin/Debug/FluentMigrator.Tests.dll -exclude Integration,NotWorkingOnMono
+  - nunit-console -framework=4.0 ./src/FluentMigrator.Tests/bin/Debug/FluentMigrator.Tests.dll -exclude Integration,NotWorkingOnMono


### PR DESCRIPTION
Due to Travis switched default test image, I've updated (hack) the script, so the NUnit tests will run again, as discussed in #825.

I will do a better and more correct fix, but those changes depends on that we're running on ONE sln file (#777 and #779 for the start). 
