### PR TITLE
add breaking change identification

### DIFF
--- a/src/FluentMigrator.Console/MigratorConsole.cs
+++ b/src/FluentMigrator.Console/MigratorConsole.cs
@@ -52,6 +52,7 @@ namespace FluentMigrator.Console
         public bool NoConnection;
         public string WorkingDirectory;
         public bool TransactionPerSession;
+        public bool AllowBreakingChange;
         public string ProviderSwitches;
 
         public RunnerContext RunnerContext { get; private set;}
@@ -187,6 +188,11 @@ namespace FluentMigrator.Console
                                             "transaction-per-session|tps",
                                             "Overrides the transaction behavior of migrations, so that all migrations to be executed will run in one transaction.",
                                             v => { TransactionPerSession = true; }
+                                            },
+                                        {
+                                            "allow-breaking-changes|abc",
+                                            "Allows execution of migrations marked as breaking changes.",
+                                            v => { AllowBreakingChange = true; }
                                             }
                                     };
 
@@ -315,7 +321,8 @@ namespace FluentMigrator.Console
                 ApplicationContext = ApplicationContext,
                 Tags = Tags,
                 TransactionPerSession = TransactionPerSession,
-                ProviderSwitches = ProviderSwitches
+                ProviderSwitches = ProviderSwitches,
+                AllowBreakingChange = AllowBreakingChange
             };
 
             new TaskExecutor(RunnerContext).Execute();

--- a/src/FluentMigrator.Runner/Initialization/IRunnerContext.cs
+++ b/src/FluentMigrator.Runner/Initialization/IRunnerContext.cs
@@ -43,6 +43,7 @@ namespace FluentMigrator.Runner.Initialization
         string ProviderSwitches { get; set; }
 
         bool TransactionPerSession { get; set; }
+        bool AllowBreakingChange { get; set; }
 
         /// <summary>The arbitrary application context passed to the task runner.</summary>
         object ApplicationContext { get; set; }

--- a/src/FluentMigrator.Runner/Initialization/RunnerContext.cs
+++ b/src/FluentMigrator.Runner/Initialization/RunnerContext.cs
@@ -27,6 +27,7 @@ namespace FluentMigrator.Runner.Initialization
         public string ConnectionStringConfigPath { get; set; }
         public IEnumerable<string> Tags { get; set; }
         public bool TransactionPerSession { get; set; }
+        public bool AllowBreakingChange { get; set; }
         public string ProviderSwitches { get; set; }
 
         public IAnnouncer Announcer

--- a/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/src/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -202,6 +202,7 @@
     <Compile Include="Integration\Migrations\Tagged\3_NormalTable.cs" />
     <Compile Include="Integration\Migrations\Tagged\4_TenantAandBTable.cs" />
     <Compile Include="Integration\Migrations\Tagged\TenantABaseMigration.cs" />
+    <Compile Include="Integration\Migrations\TestBreakingMigration.cs" />
     <Compile Include="Integration\Migrations\TestEmptyMigration.cs" />
     <Compile Include="Integration\Migrations\TestMigration.cs" />
     <Compile Include="Integration\Migrations\TestSetExistingRowValuesMigration.cs" />

--- a/src/FluentMigrator.Tests/Integration/Migrations/TestBreakingMigration.cs
+++ b/src/FluentMigrator.Tests/Integration/Migrations/TestBreakingMigration.cs
@@ -1,0 +1,14 @@
+namespace FluentMigrator.Tests.Integration.Migrations
+{
+    [Migration(6, BreakingChange = true)]
+    public class TestBreakingMigration : Migration
+    {
+        public override void Up()
+        {
+        }
+
+        public override void Down()
+        {
+        }
+    }
+}

--- a/src/FluentMigrator.Tests/Unit/MigrationInfoTests.cs
+++ b/src/FluentMigrator.Tests/Unit/MigrationInfoTests.cs
@@ -39,7 +39,7 @@ namespace FluentMigrator.Tests.Unit
 
         private MigrationInfo Create(TransactionBehavior behavior = TransactionBehavior.Default)
         {
-            return new MigrationInfo(_expectedVersion, behavior, _migration);
+            return new MigrationInfo(_expectedVersion, behavior, false, _migration);
         }
 
         [Test]

--- a/src/FluentMigrator.Tests/Unit/VersionOrderInvalidExceptionTests.cs
+++ b/src/FluentMigrator.Tests/Unit/VersionOrderInvalidExceptionTests.cs
@@ -31,8 +31,8 @@ namespace FluentMigrator.Tests.Unit
         {
             var migrations = new[]
                                  {
-                                     new KeyValuePair<long,IMigrationInfo>(1, new MigrationInfo(1, TransactionBehavior.Default, new TestMigration1())),
-                                     new KeyValuePair<long,IMigrationInfo>(2, new MigrationInfo(2, TransactionBehavior.Default, new TestMigration2()))
+                                     new KeyValuePair<long,IMigrationInfo>(1, new MigrationInfo(1, TransactionBehavior.Default, false, new TestMigration1())),
+                                     new KeyValuePair<long,IMigrationInfo>(2, new MigrationInfo(2, TransactionBehavior.Default, false, new TestMigration2()))
                                  };
 
 
@@ -46,8 +46,8 @@ namespace FluentMigrator.Tests.Unit
         {
             var migrations = new[]
                                  {
-                                     new KeyValuePair<long,IMigrationInfo>(1, new MigrationInfo(1, TransactionBehavior.Default, new TestMigration1())),
-                                     new KeyValuePair<long,IMigrationInfo>(2, new MigrationInfo(2, TransactionBehavior.Default, new TestMigration2()))
+                                     new KeyValuePair<long,IMigrationInfo>(1, new MigrationInfo(1, TransactionBehavior.Default, false, new TestMigration1())),
+                                     new KeyValuePair<long,IMigrationInfo>(2, new MigrationInfo(2, TransactionBehavior.Default, false, new TestMigration2()))
                                  };
 
             var exception = new VersionOrderInvalidException(migrations);

--- a/src/FluentMigrator/Infrastructure/DefaultMigrationConventions.cs
+++ b/src/FluentMigrator/Infrastructure/DefaultMigrationConventions.cs
@@ -102,7 +102,7 @@ namespace FluentMigrator.Infrastructure
         {
             var migrationAttribute = migrationType.GetOneAttribute<MigrationAttribute>();
             Func<IMigration> migrationFunc = () => (IMigration)migrationType.Assembly.CreateInstance(migrationType.FullName);
-            var migrationInfo = new MigrationInfo(migrationAttribute.Version, migrationAttribute.Description, migrationAttribute.TransactionBehavior, migrationFunc);
+            var migrationInfo = new MigrationInfo(migrationAttribute.Version, migrationAttribute.Description, migrationAttribute.TransactionBehavior, migrationAttribute.BreakingChange, migrationFunc);
 
             foreach (MigrationTraitAttribute traitAttribute in migrationType.GetAllAttributes<MigrationTraitAttribute>())
                 migrationInfo.AddTrait(traitAttribute.Name, traitAttribute.Value);

--- a/src/FluentMigrator/Infrastructure/IMigrationInfo.cs
+++ b/src/FluentMigrator/Infrastructure/IMigrationInfo.cs
@@ -26,6 +26,7 @@ namespace FluentMigrator.Infrastructure
         IMigration Migration { get; }
         object Trait(string name);
         bool HasTrait(string name);
+        bool IsBreakingChange { get; }
         string GetName();
     }
 }

--- a/src/FluentMigrator/Infrastructure/MigrationInfo.cs
+++ b/src/FluentMigrator/Infrastructure/MigrationInfo.cs
@@ -25,13 +25,14 @@ namespace FluentMigrator.Infrastructure
     {
         private readonly Dictionary<string, object> _traits = new Dictionary<string, object>();
         private LazyLoader<IMigration> _lazyMigration;
+        private readonly bool _isBreakingChange;
 
-        public MigrationInfo(long version, TransactionBehavior transactionBehavior, IMigration migration)
-            : this(version, null, transactionBehavior, () => migration)
+        public MigrationInfo(long version, TransactionBehavior transactionBehavior, bool isBreakingChange, IMigration migration)
+            : this(version, null, transactionBehavior, isBreakingChange, () => migration)
         {
         }
 
-        public MigrationInfo(long version, string description, TransactionBehavior transactionBehavior, Func<IMigration> migrationFunc)
+        public MigrationInfo(long version, string description, TransactionBehavior transactionBehavior, bool isBreakingChange, Func<IMigration> migrationFunc)
         {
             if (migrationFunc == null) throw new ArgumentNullException("migrationFunc");
 
@@ -39,6 +40,7 @@ namespace FluentMigrator.Infrastructure
             Description = description;
             TransactionBehavior = transactionBehavior;
             _lazyMigration = new LazyLoader<IMigration>(migrationFunc);
+            _isBreakingChange = isBreakingChange;
         }
 
         public long Version { get; private set; }
@@ -60,6 +62,11 @@ namespace FluentMigrator.Infrastructure
         public bool HasTrait(string name)
         {
             return _traits.ContainsKey(name);
+        }
+
+        public bool IsBreakingChange
+        {
+            get { return _isBreakingChange; }
         }
 
         public string GetName()

--- a/src/FluentMigrator/Infrastructure/NonAttributedMigrationToMigrationInfoAdapter.cs
+++ b/src/FluentMigrator/Infrastructure/NonAttributedMigrationToMigrationInfoAdapter.cs
@@ -55,6 +55,14 @@ namespace FluentMigrator.Infrastructure
             return false;
         }
 
+        public bool IsBreakingChange
+        {
+            get
+            {
+                return false;
+            }
+        }
+
         public string GetName()
         {
             return string.Format("{0}", Migration.GetType().Name);

--- a/src/FluentMigrator/MigrationAttribute.cs
+++ b/src/FluentMigrator/MigrationAttribute.cs
@@ -50,5 +50,6 @@ namespace FluentMigrator
         public long Version { get; private set; }
         public TransactionBehavior TransactionBehavior { get; private set; }
         public string Description { get; private set; }
+        public bool BreakingChange { get; set; }
     }
 }


### PR DESCRIPTION
This change should allow developers to mark migrations as breaking changes.  These changes are not run by default but can be enabled by passing the flag --allow-breaking-changes / --abc. We have been using this for a while to identify changes that require special deployment steps, though our initial implementation was done against the 1.0.6 tag since we needed to keep transaction-per-session behavior.  Closing the loop now since transaction-per-session option has become available.