### PR TITLE
Another attempt at building .NET Standard 2.0 assemblies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
-language: c
-
+language: csharp
+dotnet: 2.1.4
 install:
   - sudo apt-get update -qq
-  - sudo apt-get install -y mono-devel mono-gmcs nunit-console libfbembed2.5
+  - sudo apt-get install -y nunit-console libfbembed2.5
 
 script:
   - xbuild CI.proj
+  - dotnet build ./FluentMigrator.NetStandard.sln
   - sudo cp /var/lib/firebird/2.5/system/default-security2.fdb /var/lib/firebird/2.5/system/security2.fdb
   - sudo chmod a+rw /var/lib/firebird/2.5/system/security2.fdb
   - dpkg -L libfbembed2.5

--- a/FluentMigrator.NetStandard.sln
+++ b/FluentMigrator.NetStandard.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2027
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FluentMigrator.NetStandard", "src\FluentMigrator\FluentMigrator.NetStandard.csproj", "{658B1572-14A4-4E73-978D-9E49DE5D6E34}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FluentMigrator.Runner.NetStandard", "src\FluentMigrator.Runner\FluentMigrator.Runner.NetStandard.csproj", "{959D10C7-95F1-43AC-920C-C70E8BE73F60}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{658B1572-14A4-4E73-978D-9E49DE5D6E34}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{658B1572-14A4-4E73-978D-9E49DE5D6E34}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{658B1572-14A4-4E73-978D-9E49DE5D6E34}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{658B1572-14A4-4E73-978D-9E49DE5D6E34}.Release|Any CPU.Build.0 = Release|Any CPU
+		{959D10C7-95F1-43AC-920C-C70E8BE73F60}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{959D10C7-95F1-43AC-920C-C70E8BE73F60}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{959D10C7-95F1-43AC-920C-C70E8BE73F60}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{959D10C7-95F1-43AC-920C-C70E8BE73F60}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D2D4C654-3EC7-44C5-835C-8EDC2D0C62B2}
+	EndGlobalSection
+EndGlobal

--- a/src/FluentMigrator.Runner/FluentMigrator.Runner.NetStandard.csproj
+++ b/src/FluentMigrator.Runner/FluentMigrator.Runner.NetStandard.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <AssemblyName>FluentMigrator.Runner</AssemblyName>
+    <RootNamespace>FluentMigrator.Runner</RootNamespace>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>../FluentMigrator.snk</AssemblyOriginatorKeyFile>
+    <Copyright>Copyright - Sean Chambers 2008-2016</Copyright>
+    <Product>FluentMigrator</Product>
+    <Version>1.6.2.0</Version>
+    <Authors>FluentMigrator</Authors>
+    <Company>FluentMigrator</Company>
+    <PackageProjectUrl>https://github.com/fluentmigrator/fluentmigrator/wiki</PackageProjectUrl>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/fluentmigrator/fluentmigrator</RepositoryUrl>
+    <PackageLicenseUrl>https://github.com/fluentmigrator/fluentmigrator/blob/master/LICENSE.txt</PackageLicenseUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**\*.cs" Exclude="Properties\AssemblyInfo.cs;obj\**\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FluentMigrator\FluentMigrator.NetStandard.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
+++ b/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
@@ -294,12 +294,6 @@
     <Compile Include="VersionOrderInvalidException.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\FluentMigrator\FluentMigrator.csproj">
-      <Project>{FD9410F9-6FEA-47F7-A78E-B4F6FB0539B8}</Project>
-      <Name>FluentMigrator</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <None Include="..\FluentMigrator.snk">
       <Link>FluentMigrator.snk</Link>
     </None>
@@ -377,7 +371,12 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="..\FluentMigrator\FluentMigrator.csproj">
+      <Project>{fd9410f9-6fea-47f7-a78e-b4f6fb0539b8}</Project>
+      <Name>FluentMigrator</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/src/FluentMigrator.Runner/Processors/Hana/HanaDbFactory.cs
+++ b/src/FluentMigrator.Runner/Processors/Hana/HanaDbFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.Data.Common;
+﻿#if !NETSTANDARD2_0
+using System.Data.Common;
 
 namespace FluentMigrator.Runner.Processors.Hana
 {
@@ -10,3 +11,4 @@ namespace FluentMigrator.Runner.Processors.Hana
         }
     }
 }
+#endif

--- a/src/FluentMigrator.Runner/Processors/Hana/HanaProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/Hana/HanaProcessor.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !NETSTANDARD2_0
+using System;
 using System.Data;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -192,3 +193,4 @@ namespace FluentMigrator.Runner.Processors.Hana
 
     }
 }
+#endif

--- a/src/FluentMigrator.Runner/Processors/Hana/HanaProcessorFactory.cs
+++ b/src/FluentMigrator.Runner/Processors/Hana/HanaProcessorFactory.cs
@@ -1,4 +1,5 @@
-﻿using FluentMigrator.Runner.Generators.Hana;
+﻿#if !NETSTANDARD2_0
+using FluentMigrator.Runner.Generators.Hana;
 
 namespace FluentMigrator.Runner.Processors.Hana
 {
@@ -14,3 +15,4 @@ namespace FluentMigrator.Runner.Processors.Hana
         }
     }
 }
+#endif

--- a/src/FluentMigrator.Runner/Processors/Jet/JetProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/Jet/JetProcessor.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !NETSTANDARD2_0
+using System;
 using System.Data;
 using System.Data.OleDb;
 using FluentMigrator.Builders.Execute;
@@ -220,3 +221,4 @@ namespace FluentMigrator.Runner.Processors.Jet
         }
     }
 }
+#endif

--- a/src/FluentMigrator.Runner/Processors/Jet/JetProcessorFactory.cs
+++ b/src/FluentMigrator.Runner/Processors/Jet/JetProcessorFactory.cs
@@ -1,4 +1,5 @@
-﻿namespace FluentMigrator.Runner.Processors.Jet
+﻿#if !NETSTANDARD2_0
+namespace FluentMigrator.Runner.Processors.Jet
 {
     using System.Data.OleDb;
     using Generators.Jet;
@@ -12,3 +13,4 @@
         }
     }
 }
+#endif

--- a/src/FluentMigrator.Runner/Processors/MySql/MySqlProcessor.cs
+++ b/src/FluentMigrator.Runner/Processors/MySql/MySqlProcessor.cs
@@ -193,7 +193,11 @@ SELECT CONCAT(
   FROM INFORMATION_SCHEMA.COLUMNS
  WHERE TABLE_NAME = '{0}' AND COLUMN_NAME = '{1}'", FormatHelper.FormatSqlEscape(expression.TableName), FormatHelper.FormatSqlEscape(expression.OldName));
 
+#if !NETSTANDARD2_0
             var columnDefinition = Read(columnDefinitionSql).Tables[0].Rows[0].Field<string>(0);
+#else
+            var columnDefinition = (string)Read(columnDefinitionSql).Tables[0].Rows[0].ItemArray[0];
+#endif
 
             Process(Generator.Generate(expression) + columnDefinition);
         }

--- a/src/FluentMigrator.Runner/Processors/ReflectionBasedDbFactory.cs
+++ b/src/FluentMigrator.Runner/Processors/ReflectionBasedDbFactory.cs
@@ -2,6 +2,7 @@ namespace FluentMigrator.Runner.Processors
 {
     using System;
     using System.Data.Common;
+    using System.Linq;
 
     public class ReflectionBasedDbFactory : DbFactoryBase
     {
@@ -16,7 +17,12 @@ namespace FluentMigrator.Runner.Processors
 
         protected override DbProviderFactory CreateFactory()
         {
+#if NETSTANDARD2_0
+            var factoryType = AppDomain.CurrentDomain.GetAssemblies().Where(a => a.FullName == assemblyName).First().GetType(dbProviderFactoryTypeName);
+            return (DbProviderFactory)Activator.CreateInstance(factoryType);
+#else
             return (DbProviderFactory)AppDomain.CurrentDomain.CreateInstanceAndUnwrap(assemblyName, dbProviderFactoryTypeName);
+#endif
         }
     }
 }

--- a/src/FluentMigrator/FluentMigrator.NetStandard.csproj
+++ b/src/FluentMigrator/FluentMigrator.NetStandard.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <AssemblyName>FluentMigrator</AssemblyName>
+    <RootNamespace>FluentMigrator</RootNamespace>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>../FluentMigrator.snk</AssemblyOriginatorKeyFile>
+    <Copyright>Copyright - Sean Chambers 2008-2016</Copyright>
+    <Product>FluentMigrator</Product>
+    <Version>1.6.2.0</Version>
+    <Authors>FluentMigrator</Authors>
+    <Company>FluentMigrator</Company>
+    <PackageProjectUrl>https://github.com/fluentmigrator/fluentmigrator/wiki</PackageProjectUrl>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/fluentmigrator/fluentmigrator</RepositoryUrl>
+    <PackageLicenseUrl>https://github.com/fluentmigrator/fluentmigrator/blob/master/LICENSE.txt</PackageLicenseUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**\*.cs" Exclude="Properties\AssemblyInfo.cs;obj\**\*.cs" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Minimal changes to try to build for .NET Standard 2.0 and .NET 3.5, ref latest comments in issue #712

This PR replaces #831, which became a mess. This one will probably also have to be updated several times before it can be merged into master. And maybe it's better to send it to a new branch instead.

Now I'm trying to reuse existing projects to build .NET 3.5 assemblies and just build .NET Standard assemblies from new csproj files to avoid breaking any of the existing build stuff. The ideal solution using .NET Standard projects with several target frameworks turned out to break the build, and forced an upgrade to .NET 4.5.2, which turned out to be more difficult than expected.