### PR TITLE
Add Generator and ProcessorFactory for SqlServer2016

### DIFF
--- a/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
+++ b/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Generators\Hana\HanaGenerator.cs" />
     <Compile Include="Generators\Hana\HanaQuoter.cs" />
     <Compile Include="Generators\Hana\HanaTypeMap.cs" />
+    <Compile Include="Generators\SqlServer\SqlServer2016Generator.cs" />
     <Compile Include="Generators\SqlServer\SqlServerCeColumn.cs" />
     <Compile Include="MaintenanceLoader.cs" />
     <Compile Include="IMaintenanceLoader.cs" />
@@ -265,6 +266,7 @@
     <Compile Include="Processors\SqlServer\SqlServer2000Processor.cs" />
     <Compile Include="Processors\SqlServer\SqlServer2012ProcessorFactory.cs" />
     <Compile Include="Processors\SqlServer\SqlServer2014ProcessorFactory.cs" />
+    <Compile Include="Processors\SqlServer\SqlServer2016ProcessorFactory.cs" />
     <Compile Include="Processors\SqlServer\SqlServerCeDbFactory.cs" />
     <Compile Include="Processors\SqlServer\SqlServerDbFactory.cs" />
     <Compile Include="Processors\SqlServer\SqlServerCeProcessor.cs" />

--- a/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2016Generator.cs
+++ b/src/FluentMigrator.Runner/Generators/SqlServer/SqlServer2016Generator.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FluentMigrator.Runner.Generators.SqlServer
+{
+    public class SqlServer2016Generator : SqlServer2014Generator
+    {
+
+    }
+}

--- a/src/FluentMigrator.Runner/Processors/SqlServer/SqlServer2016ProcessorFactory.cs
+++ b/src/FluentMigrator.Runner/Processors/SqlServer/SqlServer2016ProcessorFactory.cs
@@ -1,0 +1,14 @@
+﻿using FluentMigrator.Runner.Generators.SqlServer;
+
+namespace FluentMigrator.Runner.Processors.SqlServer
+{
+    public class SqlServer2016ProcessorFactory : MigrationProcessorFactory
+    {
+        public override IMigrationProcessor Create(string connectionString, IAnnouncer announcer, IMigrationProcessorOptions options)
+        {
+            var factory = new SqlServerDbFactory();
+            var connection = factory.CreateConnection(connectionString);
+            return new SqlServerProcessor(connection, new SqlServer2016Generator(), announcer, options, factory);
+        }
+    }
+}

--- a/src/FluentMigrator.Tests/Unit/Runners/MigrationProcessorFactoryProviderTests.cs
+++ b/src/FluentMigrator.Tests/Unit/Runners/MigrationProcessorFactoryProviderTests.cs
@@ -79,6 +79,13 @@ namespace FluentMigrator.Tests.Unit.Runners
         }
 
         [Test]
+        public void CanRetrieveSqlServer2016FactoryWithArgumentString()
+        {
+            IMigrationProcessorFactory factory = migrationProcessorFactoryProvider.GetFactory("SqlServer2016");
+            Assert.IsTrue(factory.GetType() == typeof(SqlServer2016ProcessorFactory));
+        }
+
+        [Test]
         public void RetrievesSqlServerProcessorFactoryIfArgumentIsSqlServer()
         {
             IMigrationProcessorFactory factory = migrationProcessorFactoryProvider.GetFactory("SqlServer");


### PR DESCRIPTION
No special features for SQL Server 2016, just adds generator and factory to support 
`migate db=SqlServer2016`.

Fixes #732. 
Replaces #763, which can now be closed since the rest of that PR is implemented in #788 for SQL Server 2005 and up.