### PR TITLE
Fix for MySql4ProcessorFactory using MySql5Generator

### DIFF
--- a/src/FluentMigrator.Runner.MySql/Processors/MySql/MySql4ProcessorFactory.cs
+++ b/src/FluentMigrator.Runner.MySql/Processors/MySql/MySql4ProcessorFactory.cs
@@ -24,7 +24,7 @@ namespace FluentMigrator.Runner.Processors.MySql
         {
             var factory = new MySqlDbFactory();
             var connection = factory.CreateConnection(connectionString);
-            return new MySqlProcessor(connection, new MySql5Generator(), announcer, options, factory);
+            return new MySqlProcessor(connection, new MySql4Generator(), announcer, options, factory);
         }
     }
 }


### PR DESCRIPTION
The MySql4ProcessorFactory should return a MySqlProcessor using the MySql4Generator instead of the MySql5Generator