### PR TITLE
using the oracle beta driver that is compatible with dotnet core.

### DIFF
--- a/src/FluentMigrator.Console/FluentMigrator.Console.csproj
+++ b/src/FluentMigrator.Console/FluentMigrator.Console.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="5.12.1" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="2.0.1" />
-    <PackageReference Include="Oracle.ManagedDataAccess" Version="12.2.1100" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.12.0-beta2" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="MySql.Data" Version="8.0.11" />

--- a/src/FluentMigrator.DotNet.Cli/FluentMigrator.DotNet.Cli.csproj
+++ b/src/FluentMigrator.DotNet.Cli/FluentMigrator.DotNet.Cli.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.1" />
     <PackageReference Include="MySql.Data" Version="8.0.11" />
     <PackageReference Include="Npgsql" Version="3.2.7" />
-    <PackageReference Include="Oracle.ManagedDataAccess" Version="12.2.1100" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.12.0-beta2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Runner\FluentMigrator.Runner.csproj" />


### PR DESCRIPTION
In order for oracle driver to work with dotnet core you have to use the beta version of the driver, this will obviously need to be updated when they release the final version, last word from oracle is 3rd quarter 2018