### PR TITLE
Added support to default schema name for VersionInfo table [dotnet fm --default-schema-name]

### DIFF
--- a/src/FluentMigrator.DotNet.Cli/Commands/MigrationCommand.cs
+++ b/src/FluentMigrator.DotNet.Cli/Commands/MigrationCommand.cs
@@ -46,5 +46,8 @@ namespace FluentMigrator.DotNet.Cli.Commands
 
         [Option("-b|--allow-breaking-changes", Description = "Allows execution of migrations marked as breaking changes.")]
         public bool AllowBreakingChanges { get; }
+
+        [Option("--default-schema-name", Description = "Set default Schema Name for VersionInfo table")]
+        public string SchemaName { get; internal set; } = null;
     }
 }

--- a/src/FluentMigrator.DotNet.Cli/MigratorOptions.cs
+++ b/src/FluentMigrator.DotNet.Cli/MigratorOptions.cs
@@ -56,6 +56,7 @@ namespace FluentMigrator.DotNet.Cli
         public bool Output { get; private set; }
         public string OutputFileName { get; private set; }
         public bool AllowBreakingChanges { get; private set; }
+        public string SchemaName { get; private set; }
 
         public static MigratorOptions CreateListMigrations(ListMigrations cmd)
         {
@@ -138,6 +139,7 @@ namespace FluentMigrator.DotNet.Cli
             WorkingDirectory = cmd.WorkingDirectory;
             Tags = cmd.Tags?.ToList() ?? new List<string>();
             AllowBreakingChanges = cmd.AllowBreakingChanges;
+            SchemaName = cmd.SchemaName;
             return this;
         }
     }

--- a/src/FluentMigrator.DotNet.Cli/Setup.cs
+++ b/src/FluentMigrator.DotNet.Cli/Setup.cs
@@ -44,7 +44,7 @@ namespace FluentMigrator.DotNet.Cli
 
         private static IServiceProvider ConfigureServices(IServiceCollection services, MigratorOptions options, IConsole console)
         {
-            var conventionSet = new DefaultConventionSet(defaultSchemaName: null, options.WorkingDirectory);
+            var conventionSet = new DefaultConventionSet(defaultSchemaName: options.SchemaName, options.WorkingDirectory);
 
             var targetIsSqlServer = !string.IsNullOrEmpty(options.ProcessorType)
              && options.ProcessorType.StartsWith("sqlserver", StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
When I was using the Cli to create Pogo.User and Pogo.EatenBanana, the dbo.VersionInfo table was created or conflicted with other dbo.VersionInfo table. 

dotnet $Cli list migrations -p SqlServer2016 -a $Assembly -c $ConnectionString --namespace $Namespace --default-schema-name $DefaultSchemaName