### PR TITLE
Oracle 12C supports object name max length = 128

### DIFF
--- a/src/FluentMigrator.Runner.Oracle/Generators/Oracle/Oracle12CColumn.cs
+++ b/src/FluentMigrator.Runner.Oracle/Generators/Oracle/Oracle12CColumn.cs
@@ -25,6 +25,8 @@ namespace FluentMigrator.Runner.Generators.Oracle
 {
     internal class Oracle12CColumn : OracleColumn
     {
+        protected override int OracleObjectNameMaxLength => 128;
+
         /// <inheritdoc />
         public Oracle12CColumn(IQuoter quoter) : base(quoter)
         {

--- a/src/FluentMigrator.Runner.Oracle/Generators/Oracle/OracleColumn.cs
+++ b/src/FluentMigrator.Runner.Oracle/Generators/Oracle/OracleColumn.cs
@@ -25,7 +25,7 @@ namespace FluentMigrator.Runner.Generators.Oracle
 {
     internal class OracleColumn : ColumnBase
     {
-        private const int OracleObjectNameMaxLength = 30;
+        protected virtual int OracleObjectNameMaxLength => 30;
 
         public OracleColumn(IQuoter quoter)
             : base(new OracleTypeMap(), quoter)


### PR DESCRIPTION
Please consider this in next version.
https://oracle-base.com/articles/12c/long-identifiers-12cr2