### PR TITLE
Properly quote byte array for SQLite

### DIFF
--- a/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteQuoter.cs
+++ b/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteQuoter.cs
@@ -25,7 +25,7 @@ namespace FluentMigrator.Runner.Generators.SQLite
 
         protected override string FormatByteArray(byte[] value)
         {
-            var hex = new System.Text.StringBuilder((value.Length * 2) + 2);
+            var hex = new System.Text.StringBuilder((value.Length * 2) + 3);
             hex.Append("X'");
             foreach (var b in value)
             {

--- a/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteQuoter.cs
+++ b/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteQuoter.cs
@@ -22,5 +22,18 @@ namespace FluentMigrator.Runner.Generators.SQLite
         {
             return string.Empty;
         }
+
+        protected override string FormatByteArray(byte[] value)
+        {
+            var hex = new System.Text.StringBuilder((value.Length * 2) + 2);
+            hex.Append("X'");
+            foreach (var b in value)
+            {
+                hex.AppendFormat("{0:x2}", b);
+            }
+            hex.Append("'");
+
+            return hex.ToString();
+        }
     }
 }


### PR DESCRIPTION
The default method doesn't work for SQLite, using the below change it's now possible to store `byte[]`.