### PR TITLE
Add "Sparse" column option for SQL 2008+

### DIFF
--- a/src/FluentMigrator.Extensions.SqlServer/SqlServer/SqlServerExtensions.cs
+++ b/src/FluentMigrator.Extensions.SqlServer/SqlServer/SqlServerExtensions.cs
@@ -35,6 +35,7 @@ namespace FluentMigrator.SqlServer
         public const string RowGuidColumn = "SqlServerRowGuidColumn";
         public const string IndexColumnNullsDistinct = "SqlServerIndexColumnNullsDistinct";
         public const string SchemaAuthorization = "SqlServerSchemaAuthorization";
+        public const string SparseColumn = "SqlServerSparseColumn";
 
         /// <summary>
         /// Inserts data using Sql Server's IDENTITY INSERT feature.
@@ -72,6 +73,14 @@ namespace FluentMigrator.SqlServer
             var columnExpression = expression as IColumnExpressionBuilder ??
                 throw new InvalidOperationException(UnsupportedMethodMessage(nameof(RowGuid), nameof(IColumnExpressionBuilder)));
             columnExpression.Column.AdditionalFeatures[RowGuidColumn] = true;
+            return expression;
+        }
+
+        public static ICreateTableColumnOptionOrWithColumnSyntax Sparse(this ICreateTableColumnOptionOrWithColumnSyntax expression)
+        {
+            var columnExpression = expression as IColumnExpressionBuilder ??
+                throw new InvalidOperationException(UnsupportedMethodMessage(nameof(Sparse), nameof(IColumnExpressionBuilder)));
+            columnExpression.Column.AdditionalFeatures[SparseColumn] = true;
             return expression;
         }
 

--- a/src/FluentMigrator.Extensions.SqlServer/SqlServer/SqlServerExtensions.cs
+++ b/src/FluentMigrator.Extensions.SqlServer/SqlServer/SqlServerExtensions.cs
@@ -26,16 +26,16 @@ namespace FluentMigrator.SqlServer
 {
     public static partial class SqlServerExtensions
     {
-        public const string IdentityInsert = "SqlServerIdentityInsert";
-        public const string IdentitySeed = "SqlServerIdentitySeed";
-        public const string IdentityIncrement = "SqlServerIdentityIncrement";
-        public const string ConstraintType = "SqlServerConstraintType";
-        public const string IncludesList = "SqlServerIncludes";
-        public const string OnlineIndex = "SqlServerOnlineIndex";
-        public const string RowGuidColumn = "SqlServerRowGuidColumn";
-        public const string IndexColumnNullsDistinct = "SqlServerIndexColumnNullsDistinct";
-        public const string SchemaAuthorization = "SqlServerSchemaAuthorization";
-        public const string SparseColumn = "SqlServerSparseColumn";
+        public static readonly string IdentityInsert = "SqlServerIdentityInsert";
+        public static readonly string IdentitySeed = "SqlServerIdentitySeed";
+        public static readonly string IdentityIncrement = "SqlServerIdentityIncrement";
+        public static readonly string ConstraintType = "SqlServerConstraintType";
+        public static readonly string IncludesList = "SqlServerIncludes";
+        public static readonly string OnlineIndex = "SqlServerOnlineIndex";
+        public static readonly string RowGuidColumn = "SqlServerRowGuidColumn";
+        public static readonly string IndexColumnNullsDistinct = "SqlServerIndexColumnNullsDistinct";
+        public static readonly string SchemaAuthorization = "SqlServerSchemaAuthorization";
+        public static readonly string SparseColumn = "SqlServerSparseColumn";
 
         /// <summary>
         /// Inserts data using Sql Server's IDENTITY INSERT feature.

--- a/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2008Column.cs
+++ b/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2008Column.cs
@@ -1,0 +1,47 @@
+#region License
+// Copyright (c) 2007-2018, Sean Chambers and the FluentMigrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using FluentMigrator.Model;
+using FluentMigrator.SqlServer;
+
+namespace FluentMigrator.Runner.Generators.SqlServer
+{
+    internal class SqlServer2008Column : SqlServer2005Column
+    {
+        public SqlServer2008Column(ITypeMap typeMap, IQuoter quoter)
+           : base(typeMap, quoter)
+        {
+            ClauseOrder.Add(FormatSparse);
+        }
+
+        /// <summary>
+        /// Add <c>SPARSE</c> when <see cref="SqlServerExtensions.SparseColumn"/> is set.
+        /// </summary>
+        /// <param name="column">The column to create the definition part for</param>
+        /// <returns>The generated SQL string part</returns>
+        protected virtual string FormatSparse(ColumnDefinition column)
+        {
+            if (column.AdditionalFeatures.ContainsKey(SqlServerExtensions.SparseColumn)
+                && (column.IsNullable ?? false))
+            {
+                return "SPARSE";
+            }
+
+            return string.Empty;
+        }
+
+    }
+}

--- a/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2008Generator.cs
+++ b/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2008Generator.cs
@@ -52,7 +52,7 @@ namespace FluentMigrator.Runner.Generators.SqlServer
             [NotNull] SqlServer2008Quoter quoter,
             [NotNull] IOptions<GeneratorOptions> generatorOptions)
             : this(
-                new SqlServer2005Column(new SqlServer2008TypeMap(), quoter),
+                new SqlServer2008Column(new SqlServer2008TypeMap(), quoter),
                 quoter,
                 new SqlServer2005DescriptionGenerator(),
                 generatorOptions)

--- a/test/FluentMigrator.Tests/Unit/Generators/SqlServer2008/SqlServer2008TableTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SqlServer2008/SqlServer2008TableTests.cs
@@ -1,0 +1,390 @@
+#region License
+//
+// Copyright (c) 2018, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+using FluentMigrator.Builders.Create;
+using FluentMigrator.Builders.Create.Table;
+using FluentMigrator.Expressions;
+using FluentMigrator.Infrastructure;
+using FluentMigrator.Runner;
+using FluentMigrator.Runner.Generators.SqlServer;
+using FluentMigrator.SqlServer;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Moq;
+
+using NUnit.Framework;
+
+using Shouldly;
+
+namespace FluentMigrator.Tests.Unit.Generators.SqlServer2008
+{
+    [TestFixture]
+    public class SqlServer2008TableTests : BaseTableTests
+    {
+        protected SqlServer2008Generator Generator;
+
+        [SetUp]
+        public void Setup()
+        {
+            Generator = new SqlServer2008Generator();
+        }
+
+        [Test]
+        public void CanCreateTableWithSparseCol()
+        {
+            var expression = new CreateTableExpression()
+            {
+                TableName = "TestTable1",
+            };
+
+            var serviceProvider = new ServiceCollection().BuildServiceProvider();
+            var querySchema = new Mock<IQuerySchema>();
+            new CreateTableExpressionBuilder(expression, new MigrationContext(querySchema.Object, serviceProvider))
+                .WithColumn("Id").AsGuid().PrimaryKey()
+                .WithColumn("TestSparse").AsString(255).Nullable().Sparse();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE TABLE [dbo].[TestTable1] ([Id] UNIQUEIDENTIFIER NOT NULL, [TestSparse] NVARCHAR(255) SPARSE, PRIMARY KEY ([Id]))");
+        }
+
+        [Test]
+        public void CanCreateTableWithSparseColNullableNotSpecified()
+        {
+            var expression = new CreateTableExpression()
+            {
+                TableName = "TestTable1",
+            };
+
+            var serviceProvider = new ServiceCollection().BuildServiceProvider();
+            var querySchema = new Mock<IQuerySchema>();
+            new CreateTableExpressionBuilder(expression, new MigrationContext(querySchema.Object, serviceProvider))
+                .WithColumn("Id").AsGuid().PrimaryKey()
+                .WithColumn("TestSparse").AsString(255).Sparse();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE TABLE [dbo].[TestTable1] ([Id] UNIQUEIDENTIFIER NOT NULL, [TestSparse] NVARCHAR(255) NOT NULL, PRIMARY KEY ([Id]))");
+        }
+
+
+        [Test]
+        public void CanCreateTableWithSparseColNotNullable()
+        {
+            var expression = new CreateTableExpression()
+            {
+                TableName = "TestTable1",
+            };
+
+            var serviceProvider = new ServiceCollection().BuildServiceProvider();
+            var querySchema = new Mock<IQuerySchema>();
+            new CreateTableExpressionBuilder(expression, new MigrationContext(querySchema.Object, serviceProvider))
+                .WithColumn("Id").AsGuid().PrimaryKey()
+                .WithColumn("TestSparse").AsString(255).Sparse();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE TABLE [dbo].[TestTable1] ([Id] UNIQUEIDENTIFIER NOT NULL, [TestSparse] NVARCHAR(255) NOT NULL, PRIMARY KEY ([Id]))");
+        }
+
+        #region BaseTable tests
+
+        [Test]
+        public override void CanCreateTableWithCustomColumnTypeWithCustomSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableExpression();
+            expression.SchemaName = "TestSchema";
+            expression.Columns[0].IsPrimaryKey = true;
+            expression.Columns[1].Type = null;
+            expression.Columns[1].CustomType = "[timestamp]";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE TABLE [TestSchema].[TestTable1] ([TestColumn1] NVARCHAR(255) NOT NULL, [TestColumn2] [timestamp] NOT NULL, PRIMARY KEY ([TestColumn1]))");
+        }
+
+        [Test]
+        public override void CanCreateTableWithCustomColumnTypeWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableExpression();
+            expression.Columns[0].IsPrimaryKey = true;
+            expression.Columns[1].Type = null;
+            expression.Columns[1].CustomType = "[timestamp]";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE TABLE [dbo].[TestTable1] ([TestColumn1] NVARCHAR(255) NOT NULL, [TestColumn2] [timestamp] NOT NULL, PRIMARY KEY ([TestColumn1]))");
+        }
+
+        [Test]
+        public override void CanCreateTableWithCustomSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableExpression();
+            expression.SchemaName = "TestSchema";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE TABLE [TestSchema].[TestTable1] ([TestColumn1] NVARCHAR(255) NOT NULL, [TestColumn2] INT NOT NULL)");
+        }
+
+        [Test]
+        public override void CanCreateTableWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableExpression();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE TABLE [dbo].[TestTable1] ([TestColumn1] NVARCHAR(255) NOT NULL, [TestColumn2] INT NOT NULL)");
+        }
+
+        [Test]
+        public override void CanCreateTableWithDefaultValueExplicitlySetToNullWithCustomSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableExpression();
+            expression.SchemaName = "TestSchema";
+            expression.Columns[0].DefaultValue = null;
+            expression.Columns[0].TableName = expression.TableName;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE TABLE [TestSchema].[TestTable1] ([TestColumn1] NVARCHAR(255) NOT NULL CONSTRAINT [DF_TestTable1_TestColumn1] DEFAULT NULL, [TestColumn2] INT NOT NULL)");
+        }
+
+        [Test]
+        public override void CanCreateTableWithDefaultValueExplicitlySetToNullWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableExpression();
+            expression.Columns[0].DefaultValue = null;
+            expression.Columns[0].TableName = expression.TableName;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE TABLE [dbo].[TestTable1] ([TestColumn1] NVARCHAR(255) NOT NULL CONSTRAINT [DF_TestTable1_TestColumn1] DEFAULT NULL, [TestColumn2] INT NOT NULL)");
+        }
+
+        [Test]
+        public override void CanCreateTableWithDefaultValueWithCustomSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableWithDefaultValue();
+            expression.SchemaName = "TestSchema";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE TABLE [TestSchema].[TestTable1] ([TestColumn1] NVARCHAR(255) NOT NULL CONSTRAINT [DF_TestTable1_TestColumn1] DEFAULT N'Default', [TestColumn2] INT NOT NULL CONSTRAINT [DF_TestTable1_TestColumn2] DEFAULT 0)");
+        }
+
+        [Test]
+        public override void CanCreateTableWithDefaultValueWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableWithDefaultValue();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE TABLE [dbo].[TestTable1] ([TestColumn1] NVARCHAR(255) NOT NULL CONSTRAINT [DF_TestTable1_TestColumn1] DEFAULT N'Default', [TestColumn2] INT NOT NULL CONSTRAINT [DF_TestTable1_TestColumn2] DEFAULT 0)");
+        }
+
+        [Test]
+        public override void CanCreateTableWithIdentityWithCustomSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableWithAutoIncrementExpression();
+            expression.SchemaName = "TestSchema";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE TABLE [TestSchema].[TestTable1] ([TestColumn1] INT NOT NULL IDENTITY(1,1), [TestColumn2] INT NOT NULL)");
+        }
+
+        [Test]
+        public override void CanCreateTableWithIdentityWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableWithAutoIncrementExpression();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE TABLE [dbo].[TestTable1] ([TestColumn1] INT NOT NULL IDENTITY(1,1), [TestColumn2] INT NOT NULL)");
+        }
+
+        [Test]
+        public override void CanCreateTableWithMultiColumnPrimaryKeyWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableWithMultiColumnPrimaryKeyExpression();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE TABLE [dbo].[TestTable1] ([TestColumn1] NVARCHAR(255) NOT NULL, [TestColumn2] INT NOT NULL, PRIMARY KEY ([TestColumn1], [TestColumn2]))");
+        }
+
+        [Test]
+        public override void CanCreateTableWithMultiColumnPrimaryKeyWithCustomSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableWithMultiColumnPrimaryKeyExpression();
+            expression.SchemaName = "TestSchema";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE TABLE [TestSchema].[TestTable1] ([TestColumn1] NVARCHAR(255) NOT NULL, [TestColumn2] INT NOT NULL, PRIMARY KEY ([TestColumn1], [TestColumn2]))");
+        }
+
+        [Test]
+        public override void CanCreateTableWithNamedMultiColumnPrimaryKeyWithCustomSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableWithNamedMultiColumnPrimaryKeyExpression();
+            expression.SchemaName = "TestSchema";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE TABLE [TestSchema].[TestTable1] ([TestColumn1] NVARCHAR(255) NOT NULL, [TestColumn2] INT NOT NULL, CONSTRAINT [TestKey] PRIMARY KEY ([TestColumn1], [TestColumn2]))");
+        }
+
+        [Test]
+        public override void CanCreateTableWithNamedMultiColumnPrimaryKeyWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableWithNamedMultiColumnPrimaryKeyExpression();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE TABLE [dbo].[TestTable1] ([TestColumn1] NVARCHAR(255) NOT NULL, [TestColumn2] INT NOT NULL, CONSTRAINT [TestKey] PRIMARY KEY ([TestColumn1], [TestColumn2]))");
+        }
+
+        [Test]
+        public override void CanCreateTableWithNamedPrimaryKeyWithCustomSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableWithNamedPrimaryKeyExpression();
+            expression.SchemaName = "TestSchema";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE TABLE [TestSchema].[TestTable1] ([TestColumn1] NVARCHAR(255) NOT NULL, [TestColumn2] INT NOT NULL, CONSTRAINT [TestKey] PRIMARY KEY ([TestColumn1]))");
+        }
+
+        [Test]
+        public override void CanCreateTableWithNamedPrimaryKeyWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableWithNamedPrimaryKeyExpression();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE TABLE [dbo].[TestTable1] ([TestColumn1] NVARCHAR(255) NOT NULL, [TestColumn2] INT NOT NULL, CONSTRAINT [TestKey] PRIMARY KEY ([TestColumn1]))");
+        }
+
+        [Test]
+        public override void CanCreateTableWithNullableFieldWithCustomSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableExpression();
+            expression.SchemaName = "TestSchema";
+            expression.Columns[0].IsNullable = true;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE TABLE [TestSchema].[TestTable1] ([TestColumn1] NVARCHAR(255), [TestColumn2] INT NOT NULL)");
+        }
+
+        [Test]
+        public override void CanCreateTableWithNullableFieldWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableExpression();
+            expression.Columns[0].IsNullable = true;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE TABLE [dbo].[TestTable1] ([TestColumn1] NVARCHAR(255), [TestColumn2] INT NOT NULL)");
+        }
+
+        [Test]
+        public override void CanCreateTableWithPrimaryKeyWithCustomSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableWithPrimaryKeyExpression();
+            expression.SchemaName = "TestSchema";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE TABLE [TestSchema].[TestTable1] ([TestColumn1] NVARCHAR(255) NOT NULL, [TestColumn2] INT NOT NULL, PRIMARY KEY ([TestColumn1]))");
+        }
+
+        [Test]
+        public override void CanCreateTableWithPrimaryKeyWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateTableWithPrimaryKeyExpression();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE TABLE [dbo].[TestTable1] ([TestColumn1] NVARCHAR(255) NOT NULL, [TestColumn2] INT NOT NULL, PRIMARY KEY ([TestColumn1]))");
+        }
+
+        [Test]
+        public void CanCreateTableWithForeignKeyColumnWithDefaultSchema()
+        {
+            var expressions = new List<IMigrationExpression>();
+            var migrationContexMock = new Mock<IMigrationContext>();
+            migrationContexMock.SetupGet(mc => mc.Expressions).Returns(expressions);
+            var migrationContext = migrationContexMock.Object;
+            new CreateExpressionRoot(migrationContext)
+                .Table("FooTable")
+                .WithColumn("FooColumn").AsInt32().ForeignKey("BarTable", "BarColumn");
+            var createTableExpression = migrationContext.Expressions.OfType<CreateTableExpression>().First();
+            var createForeignKeyExpression = migrationContext.Expressions.OfType<CreateForeignKeyExpression>().First();
+
+            var processed = createForeignKeyExpression.Apply(ConventionSets.NoSchemaName);
+            string createTableResult = Generator.Generate(createTableExpression);
+            string createForeignKeyResult = Generator.Generate(processed);
+            createTableResult.ShouldBe("CREATE TABLE [dbo].[FooTable] ([FooColumn] INT NOT NULL)");
+            createForeignKeyResult.ShouldBe("ALTER TABLE [dbo].[FooTable] ADD CONSTRAINT [FK_FooTable_FooColumn_BarTable_BarColumn] FOREIGN KEY ([FooColumn]) REFERENCES [dbo].[BarTable] ([BarColumn])");
+        }
+
+        [Test]
+        public void CanCreateTableWithForeignKeyColumnWithCustomSchema()
+        {
+            var expressions = new List<IMigrationExpression>();
+            var migrationContexMock = new Mock<IMigrationContext>();
+            migrationContexMock.SetupGet(mc => mc.Expressions).Returns(expressions);
+            var migrationContext = migrationContexMock.Object;
+            new CreateExpressionRoot(migrationContext)
+                .Table("FooTable").InSchema("FooSchema")
+                .WithColumn("FooColumn").AsInt32().ForeignKey("fk_bar_foo", "BarSchema", "BarTable", "BarColumn");
+            var createTableExpression = migrationContext.Expressions.OfType<CreateTableExpression>().First();
+            var createForeignKeyExpression = migrationContext.Expressions.OfType<CreateForeignKeyExpression>().First();
+
+            string createTableResult = Generator.Generate(createTableExpression);
+            string createForeignKeyResult = Generator.Generate(createForeignKeyExpression);
+            createTableResult.ShouldBe("CREATE TABLE [FooSchema].[FooTable] ([FooColumn] INT NOT NULL)");
+            createForeignKeyResult.ShouldBe("ALTER TABLE [FooSchema].[FooTable] ADD CONSTRAINT [fk_bar_foo] FOREIGN KEY ([FooColumn]) REFERENCES [BarSchema].[BarTable] ([BarColumn])");
+        }
+
+        [Test]
+        public override void CanDropTableWithCustomSchema()
+        {
+            var expression = GeneratorTestHelper.GetDeleteTableExpression();
+            expression.SchemaName = "TestSchema";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DROP TABLE [TestSchema].[TestTable1]");
+        }
+
+        [Test]
+        public override void CanDropTableWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetDeleteTableExpression();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DROP TABLE [dbo].[TestTable1]");
+        }
+
+        [Test]
+        public override void CanRenameTableWithCustomSchema()
+        {
+            var expression = GeneratorTestHelper.GetRenameTableExpression();
+            expression.SchemaName = "TestSchema";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("sp_rename N'[TestSchema].[TestTable1]', N'TestTable2'");
+        }
+
+        [Test]
+        public override void CanRenameTableWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetRenameTableExpression();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("sp_rename N'[dbo].[TestTable1]', N'TestTable2'");
+        }
+
+        #endregion
+    }
+}
+


### PR DESCRIPTION
Added Sparse column option for SQL 2008+.  Started using Fluentmigrator on a project I'm working on, and we have a table that has sparse columns.  Thought it would be useful to have instead of using a custom column definition.  If the column is not nullable, it does nothing, following the pattern of the RowGuidColumn.