### PR TITLE
Remove PoundSignSingleLineComment and add DoubleSlashSingleLineComment

### DIFF
--- a/src/FluentMigrator.Runner.Core/BatchParser/RangeSearchers/DoubleSlashSingleLineComment.cs
+++ b/src/FluentMigrator.Runner.Core/BatchParser/RangeSearchers/DoubleSlashSingleLineComment.cs
@@ -1,0 +1,32 @@
+#region License
+// Copyright (c) 2018, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace FluentMigrator.Runner.BatchParser.RangeSearchers
+{
+    /// <summary>
+    /// A single line comment starting with two slashes (<c>// comment</c>)
+    /// </summary>
+    public sealed class DoubleSlashSingleLineComment : SingleLineComment
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DoubleSlashSingleLineComment"/> class.
+        /// </summary>
+        public DoubleSlashSingleLineComment()
+            : base("//")
+        {
+        }
+    }
+}

--- a/src/FluentMigrator.Runner.SQLite/BatchParser/SQLiteBatchParser.cs
+++ b/src/FluentMigrator.Runner.SQLite/BatchParser/SQLiteBatchParser.cs
@@ -38,7 +38,6 @@ namespace FluentMigrator.Runner.BatchParser
         {
             new MultiLineComment(),
             new DoubleDashSingleLineComment(),
-            new PoundSignSingleLineComment(),
             new AnsiSqlIdentifier(),
             new SqlString(),
         };

--- a/src/FluentMigrator.Runner.SqlAnywhere/BatchParser/SqlAnywhereBatchParser.cs
+++ b/src/FluentMigrator.Runner.SqlAnywhere/BatchParser/SqlAnywhereBatchParser.cs
@@ -38,7 +38,7 @@ namespace FluentMigrator.Runner.BatchParser
         {
             new MultiLineComment(),
             new DoubleDashSingleLineComment(),
-            new PoundSignSingleLineComment(),
+            new DoubleSlashSingleLineComment(),
             new SqlString(),
             new AnsiSqlIdentifier(),
             new SqlServerIdentifier(),

--- a/src/FluentMigrator.Runner.SqlServer/BatchParser/SqlServerBatchParser.cs
+++ b/src/FluentMigrator.Runner.SqlServer/BatchParser/SqlServerBatchParser.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 // Copyright (c) 2018, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,7 +38,6 @@ namespace FluentMigrator.Runner.BatchParser
         {
             new MultiLineComment(),
             new DoubleDashSingleLineComment(),
-            new PoundSignSingleLineComment(),
             new SqlServerIdentifier(),
             new SqlString(),
         };

--- a/test/FluentMigrator.Tests/Unit/BatchParser/SqlAnywhereBatchParserTests.cs
+++ b/test/FluentMigrator.Tests/Unit/BatchParser/SqlAnywhereBatchParserTests.cs
@@ -1,0 +1,49 @@
+#region License
+// Copyright (c) 2018, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using FluentMigrator.Runner.BatchParser;
+using FluentMigrator.Runner.BatchParser.Sources;
+
+using NUnit.Framework;
+
+namespace FluentMigrator.Tests.Unit.BatchParser
+{
+    [Category("BatchParser")]
+    public class SqlAnywhereBatchParserTests
+    {
+        [TestCase("-- blah\nqweqwe", "\nqweqwe\n")]
+        [TestCase("// blah\nqweqwe", "\nqweqwe\n")]
+        [TestCase("qwe # blah\nqweqwe", "qwe # blah\nqweqwe\n")]
+        [TestCase("# blah\nqweqwe", "# blah\nqweqwe\n")] // #'s do not indicate comments. Leave as is
+        public void TestSqlStrippedSingleLineCommentAndSqlWithoutGo(string input, string expected)
+        {
+            var output = new List<string>();
+            var specialTokens = new List<string>();
+            var batchParser = new SqlAnywhereBatchParser("\n");
+            batchParser.SqlText += (sender, evt) => { output.Add(evt.SqlText); };
+            batchParser.SpecialToken += (sender, evt) => { specialTokens.Add(evt.Token); };
+            var source = new TextReaderSource(new StringReader(input));
+            batchParser.Process(source, true);
+            Assert.AreEqual(1, output.Count);
+            Assert.AreEqual(expected, output[0]);
+            Assert.AreEqual(0, specialTokens.Count);
+        }
+    }
+}

--- a/test/FluentMigrator.Tests/Unit/BatchParser/SqlServerBatchParserTests.cs
+++ b/test/FluentMigrator.Tests/Unit/BatchParser/SqlServerBatchParserTests.cs
@@ -232,8 +232,8 @@ namespace FluentMigrator.Tests.Unit.BatchParser
         }
 
         [TestCase("-- blah\nqweqwe", "\nqweqwe\n")]
-        [TestCase("# blah\nqweqwe", "\nqweqwe\n")]
         [TestCase("qwe # blah\nqweqwe", "qwe # blah\nqweqwe\n")]
+        [TestCase("# blah\nqweqwe", "# blah\nqweqwe\n")] // #'s do not indicate comments. Leave as is
         public void TestSqlStrippedSingleLineCommentAndSqlWithoutGo(string input, string expected)
         {
             var output = new List<string>();


### PR DESCRIPTION
Hash signs are not comments on SQL Server. The `PoundSignSingleLineComment` (pound?) was stripping out references to temporary tables in my migration scripts.

Same for SQLite https://www.sqlite.org/lang_comment.html

I see it's used in `SqlAnywhereBatchParser` too, but i'm unsure about whether a hash sign represents a comment on SQL Anywhere. From what I could find at http://dcx.sybase.com/1200/en/dbreference/syco.html it seems hash signs aren't comments, but double slashes are. So I added a commit for SqlAnywhere too.

Let me know if I need to change anything. Would be awesome if this could be released in a 3.1.4 version.