### PR TITLE
Fix for https://github.com/fluentmigrator/fluentmigrator/issues/957.

### DIFF
--- a/src/FluentMigrator.Runner/MigrationScopeHandler.cs
+++ b/src/FluentMigrator.Runner/MigrationScopeHandler.cs
@@ -34,12 +34,18 @@ namespace FluentMigrator.Runner
         public IMigrationScope BeginScope()
         {
             GuardAgainstActiveMigrationScope();
-            CurrentScope = new TransactionalMigrationScope(_processor, ()=> CurrentScope = null);
+            CurrentScope = new TransactionalMigrationScope(_processor, () => CurrentScope = null);
             return CurrentScope;
         }
 
         public IMigrationScope CreateOrWrapMigrationScope(bool transactional = true)
         {
+            //prevent connection from being opened when --no-connection is specified in preview mode
+            if (_processor.Options.PreviewOnly)
+            {
+                return new NoOpMigrationScope();
+            }
+
             if (HasActiveMigrationScope) return new NoOpMigrationScope();
             if (transactional) return BeginScope();
             return new NoOpMigrationScope();


### PR DESCRIPTION
This allows --no-connection to work when used in conjunction with --preview.

There is a deeper issue in which the --no-connection options is not passed to the MigrationScopeHandler to prevent a connection attempt when creating a transaction. 

Ideally we could just check for a null connection string but the lazy connection string initialization assigns the provider name as the connection string. I was unable to determine if this was done for a particular reason.