### PR TITLE
Postgres xml typemap missing. Should fix issue #950.

### DIFF
--- a/src/FluentMigrator.Runner.Postgres/Generators/Postgres/PostgresTypeMap.cs
+++ b/src/FluentMigrator.Runner.Postgres/Generators/Postgres/PostgresTypeMap.cs
@@ -57,6 +57,7 @@ namespace FluentMigrator.Runner.Generators.Postgres
             SetTypeMap(DbType.String, "varchar($size)", PostgresMaxVarcharSize);
             SetTypeMap(DbType.String, "text", int.MaxValue);
             SetTypeMap(DbType.Time, "time");
+            SetTypeMap(DbType.Xml, "xml");
         }
     }
 }


### PR DESCRIPTION
Relates to #950

Postgres has had support for an XML column type since 8.3 (https://www.postgresql.org/docs/8.3/datatype-xml.html). 

I've had a bit of a poke around to see it more is required to get this to work, but this seems to be it. Let me know. 
