### PR TITLE
Update to Oracle.ManagedDataAccess.Core (v2.19.3)

### DIFF
--- a/src/FluentMigrator.Console/FluentMigrator.Console.csproj
+++ b/src/FluentMigrator.Console/FluentMigrator.Console.csproj
@@ -23,8 +23,8 @@
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="5.12.1" />
     <PackageReference Include="FSharp.Core" Version="4.6.2" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="2.0.1" />
-    <PackageReference Include="Oracle.ManagedDataAccess" Version="12.2.1100" />
     <PackageReference Include="MySql.Data" Version="8.0.11" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.3" />
   </ItemGroup>
   <ItemGroup Condition=" '$(Platform)' == 'x86' ">
     <PackageReference Include="Oracle.DataAccess.x86.4" Version="4.112.3" />


### PR DESCRIPTION
The Oracle Managed driver for .NET Core 2 has been out for some time. It should be suitable for your needs. This is related to an existing Issue (https://github.com/fluentmigrator/fluentmigrator/issues/890) and PR (https://github.com/fluentmigrator/fluentmigrator/pull/891), but they were dismissed at that time due to using the beta driver.