### PR TITLE
Fix Oracle dialect create sequence NOCACHE

### DIFF
--- a/src/FluentMigrator.Runner.Core/Generators/Generic/GenericGenerator.cs
+++ b/src/FluentMigrator.Runner.Core/Generators/Generic/GenericGenerator.cs
@@ -415,9 +415,18 @@ namespace FluentMigrator.Runner.Generators.Generic
                 result.AppendFormat(" START WITH {0}", seq.StartWith);
             }
 
+            const long MINIMUM_CACHE_VALUE = 2;
             if (seq.Cache.HasValue)
             {
+                if (seq.Cache.Value < MINIMUM_CACHE_VALUE)
+                {
+                    return CompatibilityMode.HandleCompatibilty("Cache size must be greater than 1; if you intended to disable caching, set Cache to null.");
+                }
                 result.AppendFormat(" CACHE {0}", seq.Cache);
+            }
+            else
+            {
+                result.Append(" NO CACHE");
             }
 
             if (seq.Cycle)

--- a/src/FluentMigrator.Runner.Hana/Generators/Hana/HanaGenerator.cs
+++ b/src/FluentMigrator.Runner.Hana/Generators/Hana/HanaGenerator.cs
@@ -92,9 +92,18 @@ namespace FluentMigrator.Runner.Generators.Hana
                 result.AppendFormat(" START WITH {0}", seq.StartWith);
             }
 
+            const long MINIMUM_CACHE_VALUE = 2;
             if (seq.Cache.HasValue)
             {
+                if (seq.Cache.Value < MINIMUM_CACHE_VALUE)
+                {
+                    return CompatibilityMode.HandleCompatibilty("Cache size must be greater than 1; if you intended to disable caching, set Cache to null.");
+                }
                 result.AppendFormat(" CACHE {0}", seq.Cache);
+            }
+            else
+            {
+                result.Append(" NO CACHE");
             }
 
             if (seq.Cycle)

--- a/src/FluentMigrator.Runner.Oracle/Generators/Oracle/OracleGenerator.cs
+++ b/src/FluentMigrator.Runner.Oracle/Generators/Oracle/OracleGenerator.cs
@@ -124,16 +124,18 @@ namespace FluentMigrator.Runner.Generators.Oracle
                 result.AppendFormat(" START WITH {0}", seq.StartWith);
             }
 
+            const long MINIMUM_CACHE_VALUE = 2;
             if (seq.Cache.HasValue)
             {
-                if(seq.Cache == 1)
+                if (seq.Cache.Value < MINIMUM_CACHE_VALUE)
                 {
-                    result.Append(" NOCACHE");
+                    return CompatibilityMode.HandleCompatibilty("Oracle does not support Cache value equal to 1; if you intended to disable caching, set Cache to null. For information on Oracle limitations, see: https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/CREATE-SEQUENCE.html#GUID-E9C78A8C-615A-4757-B2A8-5E6EFB130571__GUID-7E390BE1-2F6C-4E5A-9D5C-5A2567D636FB");
                 }
-                else
-                {
-                    result.AppendFormat(" CACHE {0}", seq.Cache);
-                }
+                result.AppendFormat(" CACHE {0}", seq.Cache);
+            }
+            else
+            {
+                result.Append(" NOCACHE");
             }
 
             if (seq.Cycle)

--- a/src/FluentMigrator.Runner.Oracle/Generators/Oracle/OracleGenerator.cs
+++ b/src/FluentMigrator.Runner.Oracle/Generators/Oracle/OracleGenerator.cs
@@ -126,7 +126,14 @@ namespace FluentMigrator.Runner.Generators.Oracle
 
             if (seq.Cache.HasValue)
             {
-                result.AppendFormat(" CACHE {0}", seq.Cache);
+                if(seq.Cache == 1)
+                {
+                    result.Append(" NOCACHE");
+                }
+                else
+                {
+                    result.AppendFormat(" CACHE {0}", seq.Cache);
+                }
             }
 
             if (seq.Cycle)

--- a/src/FluentMigrator.Runner.Postgres/Generators/Postgres/PostgresGenerator.cs
+++ b/src/FluentMigrator.Runner.Postgres/Generators/Postgres/PostgresGenerator.cs
@@ -374,7 +374,50 @@ namespace FluentMigrator.Runner.Generators.Postgres
 
         public override string Generate(CreateSequenceExpression expression)
         {
-            return string.Format("{0};", base.Generate(expression));
+            var result = new StringBuilder("CREATE SEQUENCE ");
+            var seq = expression.Sequence;
+            result.AppendFormat(Quoter.QuoteSequenceName(seq.Name, seq.SchemaName));
+
+            if (seq.Increment.HasValue)
+            {
+                result.AppendFormat(" INCREMENT {0}", seq.Increment);
+            }
+
+            if (seq.MinValue.HasValue)
+            {
+                result.AppendFormat(" MINVALUE {0}", seq.MinValue);
+            }
+
+            if (seq.MaxValue.HasValue)
+            {
+                result.AppendFormat(" MAXVALUE {0}", seq.MaxValue);
+            }
+
+            if (seq.StartWith.HasValue)
+            {
+                result.AppendFormat(" START WITH {0}", seq.StartWith);
+            }
+
+            const long MINIMUM_CACHE_VALUE = 2;
+            if (seq.Cache.HasValue)
+            {
+                if (seq.Cache.Value < MINIMUM_CACHE_VALUE)
+                {
+                    return CompatibilityMode.HandleCompatibilty("Cache size must be greater than 1; if you intended to disable caching, set Cache to null.");
+                }
+                result.AppendFormat(" CACHE {0}", seq.Cache);
+            }
+            else
+            {
+                result.Append(" CACHE 1");
+            }
+
+            if (seq.Cycle)
+            {
+                result.Append(" CYCLE");
+            }
+
+            return string.Format("{0};", result.ToString());
         }
 
         public override string Generate(DeleteSequenceExpression expression)

--- a/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2012Generator.cs
+++ b/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2012Generator.cs
@@ -80,9 +80,18 @@ namespace FluentMigrator.Runner.Generators.SqlServer
                 result.AppendFormat(" START WITH {0}", seq.StartWith);
             }
 
+            const long MINIMUM_CACHE_VALUE = 2;
             if (seq.Cache.HasValue)
             {
+                if (seq.Cache.Value < MINIMUM_CACHE_VALUE)
+                {
+                    return CompatibilityMode.HandleCompatibilty("Cache size must be greater than 1; if you intended to disable caching, set Cache to null.");
+                }
                 result.AppendFormat(" CACHE {0}", seq.Cache);
+            }
+            else
+            {
+                result.Append(" NO CACHE");
             }
 
             if (seq.Cycle)

--- a/test/FluentMigrator.Tests/Unit/Generators/Oracle/OracleSequenceTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Oracle/OracleSequenceTests.cs
@@ -50,7 +50,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
         }
 
         [Test]
-        public void CanCreateSequenceWithCacheOneSchema()
+        public void CanNotCreateSequenceWithCacheOneSchema()
         {
             var expression = GeneratorTestHelper.GetCreateSequenceExpression();
             expression.Sequence.Cache = 1;

--- a/test/FluentMigrator.Tests/Unit/Generators/Oracle/OracleSequenceTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Oracle/OracleSequenceTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentMigrator.Runner.Generators.Oracle;
+using FluentMigrator.Runner.Generators.Oracle;
 using NUnit.Framework;
 
 using Shouldly;
@@ -33,6 +33,16 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
 
             var result = Generator.Generate(expression);
             result.ShouldBe("CREATE SEQUENCE Sequence INCREMENT BY 2 MINVALUE 0 MAXVALUE 100 START WITH 2 CACHE 10 CYCLE");
+        }
+
+        [Test]
+        public void CanCreateSequenceWithNocacheSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateSequenceExpression();
+            expression.Sequence.Cache = 1;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE SEQUENCE Sequence INCREMENT BY 2 MINVALUE 0 MAXVALUE 100 START WITH 2 NOCACHE CYCLE");
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/Oracle/OracleSequenceTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Oracle/OracleSequenceTests.cs
@@ -1,3 +1,4 @@
+using FluentMigrator.Exceptions;
 using FluentMigrator.Runner.Generators.Oracle;
 using NUnit.Framework;
 
@@ -13,7 +14,10 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
         [SetUp]
         public void Setup()
         {
-            Generator = new OracleGenerator();
+            Generator = new OracleGenerator()
+            {
+                CompatibilityMode = Runner.CompatibilityMode.STRICT,
+            };
         }
 
         [Test]
@@ -39,10 +43,22 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
         public void CanCreateSequenceWithNocacheSchema()
         {
             var expression = GeneratorTestHelper.GetCreateSequenceExpression();
-            expression.Sequence.Cache = 1;
+            expression.Sequence.Cache = null;
 
             var result = Generator.Generate(expression);
             result.ShouldBe("CREATE SEQUENCE Sequence INCREMENT BY 2 MINVALUE 0 MAXVALUE 100 START WITH 2 NOCACHE CYCLE");
+        }
+
+        [Test]
+        public void CanCreateSequenceWithCacheOneSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateSequenceExpression();
+            expression.Sequence.Cache = 1;
+
+            Should.Throw<DatabaseOperationNotSupportedException>(
+                () => Generator.Generate(expression),
+                "Oracle does not support Cache value equal to 1; if you intended to disable caching, set Cache to null. For information on Oracle limitations, see: https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/CREATE-SEQUENCE.html#GUID-E9C78A8C-615A-4757-B2A8-5E6EFB130571__GUID-7E390BE1-2F6C-4E5A-9D5C-5A2567D636FB"
+            );
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/SqlServer2012/SqlServer2012SequenceTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SqlServer2012/SqlServer2012SequenceTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentMigrator.Runner.Generators.SqlServer;
+using FluentMigrator.Exceptions;
+using FluentMigrator.Runner.Generators.SqlServer;
 using NUnit.Framework;
 
 using Shouldly;
@@ -13,7 +14,10 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2012
         [SetUp]
         public void Setup()
         {
-            Generator = new SqlServer2012Generator();
+            Generator = new SqlServer2012Generator()
+            {
+                CompatibilityMode = Runner.CompatibilityMode.STRICT,
+            };
         }
 
 
@@ -34,6 +38,28 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2012
 
             var result = Generator.Generate(expression);
             result.ShouldBe("CREATE SEQUENCE [dbo].[Sequence] INCREMENT BY 2 MINVALUE 0 MAXVALUE 100 START WITH 2 CACHE 10 CYCLE");
+        }
+
+        [Test]
+        public void CanCreateSequenceWithNocache()
+        {
+            var expression = GeneratorTestHelper.GetCreateSequenceExpression();
+            expression.Sequence.Cache = null;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE SEQUENCE [dbo].[Sequence] INCREMENT BY 2 MINVALUE 0 MAXVALUE 100 START WITH 2 NO CACHE CYCLE");
+        }
+
+        [Test]
+        public void CanNotCreateSequenceWithCacheOne()
+        {
+            var expression = GeneratorTestHelper.GetCreateSequenceExpression();
+            expression.Sequence.Cache = 1;
+
+            Should.Throw<DatabaseOperationNotSupportedException>(
+                () => Generator.Generate(expression),
+                "Cache size must be greater than 1; if you intended to disable caching, set Cache to null."
+            );
         }
 
         [Test]


### PR DESCRIPTION
Oracle raise error when below.
```csharp
Create.Sequence().Cache(1);
```
`ORA-04010 the number of values to CACHE must be greater than 1`
Need's to be
```sql
CREATE SEQUENCE [sequence_name] NOCACHE
```
[Docs](https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/CREATE-SEQUENCE.html#GUID-E9C78A8C-615A-4757-B2A8-5E6EFB130571)