### PR TITLE
Fixing failing unit tests

### DIFF
--- a/src/FluentMigrator.Runner.Postgres/Generators/Postgres/PostgresGenerator.cs
+++ b/src/FluentMigrator.Runner.Postgres/Generators/Postgres/PostgresGenerator.cs
@@ -380,7 +380,7 @@ namespace FluentMigrator.Runner.Generators.Postgres
 
             if (seq.Increment.HasValue)
             {
-                result.AppendFormat(" INCREMENT {0}", seq.Increment);
+                result.AppendFormat(" INCREMENT BY {0}", seq.Increment);
             }
 
             if (seq.MinValue.HasValue)

--- a/test/FluentMigrator.Tests/Unit/Generators/Postgres/PostgresSequenceTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Postgres/PostgresSequenceTests.cs
@@ -30,7 +30,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Postgres
             expression.Sequence.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE SEQUENCE \"TestSchema\".\"Sequence\" INCREMENT 2 MINVALUE 0 MAXVALUE 100 START WITH 2 CACHE 10 CYCLE;");
+            result.ShouldBe("CREATE SEQUENCE \"TestSchema\".\"Sequence\" INCREMENT BY 2 MINVALUE 0 MAXVALUE 100 START WITH 2 CACHE 10 CYCLE;");
         }
 
         [Test]
@@ -39,7 +39,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Postgres
             var expression = GeneratorTestHelper.GetCreateSequenceExpression();
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE SEQUENCE \"Sequence\" INCREMENT 2 MINVALUE 0 MAXVALUE 100 START WITH 2 CACHE 10 CYCLE;");
+            result.ShouldBe("CREATE SEQUENCE \"Sequence\" INCREMENT BY 2 MINVALUE 0 MAXVALUE 100 START WITH 2 CACHE 10 CYCLE;");
         }
 
         [Test]


### PR DESCRIPTION
Looks like postgres implementation in this commit
[https://github.com/fluentmigrator/fluentmigrator/commit/5641439503611097380f1734571622ac6816ee37](commit) broke 1 unit test.
There was inconsistency, some tests were looking for INCREMENT BY X and some for INCREMENT X. Both options are correct in case of PostgreSQL but I decided to go with INCREMENT BY X.