### PR TITLE
MySQL/MariaDB alternative connector

### DIFF
--- a/src/FluentMigrator.Runner.MySql/Processors/MySql/MySqlDbFactory.cs
+++ b/src/FluentMigrator.Runner.MySql/Processors/MySql/MySqlDbFactory.cs
@@ -23,6 +23,7 @@ namespace FluentMigrator.Runner.Processors.MySql
         private static readonly TestEntry[] _entries =
         {
             new TestEntry("MySql.Data", "MySql.Data.MySqlClient.MySqlClientFactory"),
+            new TestEntry("MySqlConnector", "MySql.Data.MySqlClient.MySqlClientFactory")
         };
 
         [Obsolete]


### PR DESCRIPTION
Included new TestEntry to use MySqlConnector as an alternative way to connect to MySQL/MariaDB;