### PR TITLE
Dotnet 3.0

### DIFF
--- a/src/FluentMigrator.DotNet.Cli/FluentMigrator.DotNet.Cli.csproj
+++ b/src/FluentMigrator.DotNet.Cli/FluentMigrator.DotNet.Cli.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
     <ToolCommandName>dotnet-fm</ToolCommandName>
     <PackAsTool>true</PackAsTool>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
You seem to be busy migrating to new CI environment etc but I'd still like to suggest adding new .NET core version to the target frameworks. With this change we could hopefully use FluentMigrator in Docker container that has only 3.0 sdk installed. Currently we need to install both in order to use FM package from MyGet.