### PR TITLE
update default-schema-name argument to properly accept a value

### DIFF
--- a/src/FluentMigrator.Console/MigratorConsole.cs
+++ b/src/FluentMigrator.Console/MigratorConsole.cs
@@ -275,7 +275,7 @@ namespace FluentMigrator.Console
                         v => { AllowBreakingChange = v != null; }
                     },
                     {
-                        "default-schema-name",
+                        "default-schema-name=",
                         "Set default schema name for the VersionInfo table and the migrations.",
                         v => { DefaultSchemaName = v; }
                     },


### PR DESCRIPTION
It looks as though the new default-schema-name argument was improperly implemented.
Currently the value being used for the default schema is "default-schema-name" no matter what you pass to the argument.
Convention appears to dictate that in OptionSet, arguments that accept a value must be programmed with an equal sign on the end e.g. "default-schema-name=" for the argument parsing engine to accept a value.