### PR TITLE
Ensures VersionLoader disposes the migration processor

### DIFF
--- a/src/FluentMigrator.Runner/ConnectionlessVersionLoader.cs
+++ b/src/FluentMigrator.Runner/ConnectionlessVersionLoader.cs
@@ -203,5 +203,10 @@ namespace FluentMigrator.Runner
                 new KeyValuePair<string, object>(VersionTableMetaData.DescriptionColumnName, description)
             };
         }
+
+        public void Dispose()
+        {
+            _processor.Dispose();
+        }
     }
 }

--- a/src/FluentMigrator.Runner/IMigrationRunner.cs
+++ b/src/FluentMigrator.Runner/IMigrationRunner.cs
@@ -26,7 +26,7 @@ namespace FluentMigrator.Runner
     /// <summary>
     /// The migration runner
     /// </summary>
-    public interface IMigrationRunner : IMigrationScopeStarter
+    public interface IMigrationRunner : IMigrationScopeStarter, IDisposable
     {
         /// <summary>
         /// Gets the migration processor used by this runner

--- a/src/FluentMigrator.Runner/IVersionLoader.cs
+++ b/src/FluentMigrator.Runner/IVersionLoader.cs
@@ -16,12 +16,14 @@
 //
 #endregion
 
+using System;
+
 namespace FluentMigrator.Runner
 {
     /// <summary>
     /// Manages the version table and the stored versions
     /// </summary>
-    public interface IVersionLoader
+    public interface IVersionLoader : IDisposable
     {
         /// <summary>
         /// Gets a value indicating whether the schema for the version table has been created (or already exited)

--- a/src/FluentMigrator.Runner/MigrationRunner.cs
+++ b/src/FluentMigrator.Runner/MigrationRunner.cs
@@ -995,5 +995,11 @@ namespace FluentMigrator.Runner
             AppliedMask = 3,
             Breaking = 4,
         }
+
+        public void Dispose()
+        {
+            _currentVersionLoader?.Dispose();
+            Processor.Dispose();
+        }
     }
 }

--- a/src/FluentMigrator.Runner/VersionLoader.cs
+++ b/src/FluentMigrator.Runner/VersionLoader.cs
@@ -240,5 +240,10 @@ namespace FluentMigrator.Runner
 
             return instance;
         }
+
+        public void Dispose()
+        {
+            _processor.Dispose();
+        }
     }
 }

--- a/test/FluentMigrator.Tests/Unit/TestVersionLoader.cs
+++ b/test/FluentMigrator.Tests/Unit/TestVersionLoader.cs
@@ -93,7 +93,6 @@ namespace FluentMigrator.Tests.Unit
 
         public List<long> Versions { get; private set; }
 
-        /// <inheritdoc />
         public void Dispose()
         {
             Runner?.Dispose();

--- a/test/FluentMigrator.Tests/Unit/TestVersionLoader.cs
+++ b/test/FluentMigrator.Tests/Unit/TestVersionLoader.cs
@@ -92,5 +92,11 @@ namespace FluentMigrator.Tests.Unit
         public IVersionTableMetaData VersionTableMetaData => _versionTableMetaData;
 
         public List<long> Versions { get; private set; }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Runner?.Dispose();
+        }
     }
 }


### PR DESCRIPTION
### Changes
Makes IMigrationRunner and IVersionLoader inherits IDisposable
 
### Explanation
Fixes an issue in VersionLoader, which was not disposing the migration processor.
As a result, the connection contained in GenericProcessorBase was not properly disposed, leading to a connection leak.
NB : the migration runner, containing both a migration processor and a version loader has to dispose them too.