### PR TITLE
Fix version number of Console and Tools NuGet packages

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,19 +85,11 @@ steps:
     Contents: '**'
     TargetFolder: '$(Build.ArtifactStagingDirectory)/publish'
 
-- task: NuGetCommand@2
-  inputs:
-    command: 'pack'
-    packagesToPack: '$(Build.ArtifactStagingDirectory)/publish/FluentMigrator.Console.nuspec'
-    versioningScheme: 'byBuildNumber'
-    buildProperties: '-OutputDirectory "$(Build.ArtifactStagingDirectory)/output" -Properties Configuration=$(buildConfiguration)'
-
-- task: NuGetCommand@2
-  inputs:
-    command: 'pack'
-    packagesToPack: '$(Build.ArtifactStagingDirectory)/publish/FluentMigrator.Tools.nuspec'
-    versioningScheme: 'byBuildNumber'
-    buildProperties: '-OutputDirectory "$(Build.ArtifactStagingDirectory)/output" -Properties Configuration=$(buildConfiguration)'
+- script: nuget.exe pack $(Build.ArtifactStagingDirectory)/publish/FluentMigrator.Console.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory) -version $(build.buildNumber)
+  displayName: NuGet pack FluentMigrator.Console
+  
+- script: nuget.exe pack $(Build.ArtifactStagingDirectory)/publish/FluentMigrator.Tools.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory) -version $(build.buildNumber)
+  displayName: NuGet pack FluentMigrator.Tools
 
 - task: PublishBuildArtifacts@1
   inputs:


### PR DESCRIPTION
Fixes issue #1146 

Replace NuGetCommand task with script task to be able to set the correct version number - the same version number as other NuGet packages get.

The NuGetCommand task won't accept version number formats that makes NuGet packages tagged as pre-releases. After many attempts to set version number correctly, it's just better to call **nuget.exe pack** manually in a script task.