### PR TITLE
AddFluentMigratorCore() - Only register default IConventionSet if none registered yet

### DIFF
--- a/src/FluentMigrator.Runner/FluentMigratorServiceCollectionExtensions.cs
+++ b/src/FluentMigrator.Runner/FluentMigratorServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ using FluentMigrator.Validation;
 
 using JetBrains.Annotations;
 
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -99,8 +100,12 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddScoped<IConventionSetAccessor, AssemblySourceConventionSetAccessor>()
 
                 // The default set of conventions to be applied to migration expressions
-                .AddScoped(sp => sp.GetRequiredService<IConventionSetAccessor>().GetConventionSet() ?? ActivatorUtilities.CreateInstance<DefaultConventionSet>(sp))
+                .TryAddScoped(sp =>
+                    sp.GetRequiredService<IConventionSetAccessor>().GetConventionSet()
+                    ?? ActivatorUtilities.CreateInstance<DefaultConventionSet>(sp)
+                    );
 
+            services
                 // Configure the accessor for the version table metadata
                 .AddScoped<IVersionTableMetaDataAccessor, AssemblySourceVersionTableMetaDataAccessor>()
 

--- a/test/FluentMigrator.Tests/Unit/Initialization/ConventionSetTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Initialization/ConventionSetTests.cs
@@ -67,12 +67,8 @@ namespace FluentMigrator.Tests.Unit.Initialization
             Assert.AreEqual(null, expr.SchemaName);
         }
 
-        /// <summary>Demonstrate that AddFluentMigratorCore() always registers a class to handle
-        /// IConventionSet; even when one has already been registered in the services collection.
-        /// Because the ServiceCollection is LIFO, the last one registered is the one that gets
-        /// used.</summary>
         [Test]
-        public void RegisterOnlyOneConventionSet()
+        public void RegisterOnlyOneConventionSetIfRegisteredBeforeAddCall()
         {
             const string schemaName = "RegTestSchemaA";
 
@@ -83,6 +79,8 @@ namespace FluentMigrator.Tests.Unit.Initialization
                     defaultSchemaName: schemaName,
                     workingDirectory: null
                 ));
+
+            // The AddFluentMigratorCore should not register a 2nd IConventionSet
 
             services
                 .AddFluentMigratorCore()


### PR DESCRIPTION
 #1194

Use `TryAddScoped()` instead of `AddScoped()`.  (Unfortunately, the method is not chainable.)

Assumptions:

1. The `AddFluentMigratorCore()` call should not register an additional `IConventionSet` if one has already been registered by the calling program in the `IServicesCollection`.
2. The FluentMigrator code uses `GetService/GetRequiredService` and is pulling only the last registered `IConventionSet` out of the DI/IoC `ServiceProvider`.

Note: If the caller registers their `IConventionSet` *after* the call to `AddFluentMigratorCore()`, there will be two copies of `IConventionSet` registered; but the caller's `IConventionSet` is what will be returned by  `GetService/GetRequiredService`. This is to be expected and is normal.

Refs:
- [TryAddScoped in the MS documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection?view=aspnetcore-3.1#service-registration-methods)
- [stackoverflow answer](https://stackoverflow.com/a/48187842)

