### PR TITLE
Display preview-only mode header when running migrate:down

### DIFF
--- a/src/FluentMigrator.Runner/MigrationRunner.cs
+++ b/src/FluentMigrator.Runner/MigrationRunner.cs
@@ -643,6 +643,12 @@ namespace FluentMigrator.Runner
                 throw new ArgumentNullException(nameof(migrationInfo));
             }
 
+            if (!_alreadyOutputPreviewOnlyModeWarning && _processorOptions.PreviewOnly)
+            {
+                _logger.LogHeader("PREVIEW-ONLY MODE");
+                _alreadyOutputPreviewOnlyModeWarning = true;
+            }
+
             var name = migrationInfo.GetName();
             _logger.LogHeader($"{name} reverting");
 

--- a/test/FluentMigrator.Tests/Unit/Runners/MigratorConsoleTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Runners/MigratorConsoleTests.cs
@@ -130,7 +130,7 @@ namespace FluentMigrator.Tests.Unit.Runners
         }
 
         [Test]
-        public void ConsoleAnnouncerHasOutputEvenIfMarkedAsPreviewOnly()
+        public void ConsoleAnnouncerHasOutputEvenIfMarkedAsPreviewOnlyMigrateUp()
         {
             var sb = new StringBuilder();
             var stringWriter = new StringWriter(sb);
@@ -145,6 +145,30 @@ namespace FluentMigrator.Tests.Unit.Runners
                 "/namespace", "FluentMigrator.Tests.Unit.Runners.Migrations",
                 "/verbose", "true",
                 "/task", "migrate:up",
+                "/preview");
+
+            var output = sb.ToString();
+            Assert.That(output.Contains("PREVIEW-ONLY MODE"));
+            Assert.AreNotEqual(0, output.Length);
+        }
+
+        [Test]
+        public void ConsoleAnnouncerHasOutputEvenIfMarkedAsPreviewOnlyMigrateDown()
+        {
+            var sb = new StringBuilder();
+            var stringWriter = new StringWriter(sb);
+
+            System.Console.SetOut(stringWriter);
+            System.Console.SetError(stringWriter);
+
+            new MigratorConsole().Run(
+                "/db", Database,
+                "/connection", Connection,
+                "/target", Target,
+                "/namespace", "FluentMigrator.Tests.Unit.Runners.Migrations",
+                "/verbose", "true",
+                "/task", "migrate:down",
+                "/version", "2",
                 "/preview");
 
             var output = sb.ToString();

--- a/test/FluentMigrator.Tests/Unit/Runners/MigratorConsoleTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Runners/MigratorConsoleTests.cs
@@ -143,7 +143,7 @@ namespace FluentMigrator.Tests.Unit.Runners
                 "/connection", Connection,
                 "/target", Target,
                 "/namespace", "FluentMigrator.Tests.Unit.Runners.Migrations",
-                "/verbose",
+                "/verbose", "true",
                 "/task", "migrate:up",
                 "/preview");
 


### PR DESCRIPTION
As I was testing fluent migrator, I noticed that the Preview-only mode header is only displayed for migrate:up commands. This lead to some confusion as to whether or not my migrations had been undone or not. This PR makes the preview-only header behavior the same for both migrate:up and migrate:down.