### PR TITLE
add schemaName to sql for create index expressions

### DIFF
--- a/src/FluentMigrator.Runner.Oracle/Generators/Oracle/OracleGenerator.cs
+++ b/src/FluentMigrator.Runner.Oracle/Generators/Oracle/OracleGenerator.cs
@@ -271,6 +271,26 @@ namespace FluentMigrator.Runner.Generators.Oracle
             return WrapInBlock(alterColumnWithDescriptionBuilder.ToString());
         }
 
+        public override string Generate(CreateIndexExpression expression)
+        {
+            var indexColumns = new string[expression.Index.Columns.Count];
+
+            for (var i = 0; i < expression.Index.Columns.Count; i++)
+            {
+                var columnDef = expression.Index.Columns.ElementAt(i);
+
+                var direction = columnDef.Direction == Direction.Ascending ? "ASC" : "DESC";
+                indexColumns[i] = $"{Quoter.QuoteColumnName(columnDef.Name)} {direction}";
+            }
+
+            return string.Format(CreateIndex
+                , GetUniqueString(expression)
+                , GetClusterTypeString(expression)
+                , Quoter.QuoteIndexName(expression.Index.Name, expression.Index.SchemaName)
+                , Quoter.QuoteTableName(expression.Index.TableName, expression.Index.SchemaName)
+                , string.Join(", ", indexColumns));
+        }
+
         public override string Generate(InsertDataExpression expression)
         {
             var columnNames = new List<string>();

--- a/src/FluentMigrator.Runner.Oracle/Generators/Oracle/OracleQuoterBase.cs
+++ b/src/FluentMigrator.Runner.Oracle/Generators/Oracle/OracleQuoterBase.cs
@@ -69,6 +69,11 @@ namespace FluentMigrator.Runner.Generators.Oracle
             return result;
         }
 
+        public override string QuoteIndexName(string indexName, string schemaName)
+        {
+            return CreateSchemaPrefixedQuotedIdentifier(QuoteSchemaName(schemaName), IsQuoted(indexName) ? indexName : Quote(indexName));
+        }
+
         public override string FromTimeSpan(TimeSpan value)
         {
             return string.Format("{0}{1} {2}:{3}:{4}.{5}{0}"

--- a/test/FluentMigrator.Tests/Unit/Generators/Oracle/OracleIndexTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Oracle/OracleIndexTests.cs
@@ -23,7 +23,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
             expression.Index.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE INDEX TestIndex ON TestSchema.TestTable1 (TestColumn1 ASC)");
+            result.ShouldBe("CREATE INDEX TestSchema.TestIndex ON TestSchema.TestTable1 (TestColumn1 ASC)");
         }
 
         [Test]
@@ -42,7 +42,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
             expression.Index.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE INDEX TestIndex ON TestSchema.TestTable1 (TestColumn1 ASC, TestColumn2 DESC)");
+            result.ShouldBe("CREATE INDEX TestSchema.TestIndex ON TestSchema.TestTable1 (TestColumn1 ASC, TestColumn2 DESC)");
         }
 
         [Test]
@@ -61,7 +61,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
             expression.Index.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE UNIQUE INDEX TestIndex ON TestSchema.TestTable1 (TestColumn1 ASC, TestColumn2 DESC)");
+            result.ShouldBe("CREATE UNIQUE INDEX TestSchema.TestIndex ON TestSchema.TestTable1 (TestColumn1 ASC, TestColumn2 DESC)");
         }
 
         [Test]
@@ -80,7 +80,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
             expression.Index.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE UNIQUE INDEX TestIndex ON TestSchema.TestTable1 (TestColumn1 ASC)");
+            result.ShouldBe("CREATE UNIQUE INDEX TestSchema.TestIndex ON TestSchema.TestTable1 (TestColumn1 ASC)");
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/OracleWithQuotedIdentifier/OracleIndexTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/OracleWithQuotedIdentifier/OracleIndexTests.cs
@@ -23,7 +23,7 @@ namespace FluentMigrator.Tests.Unit.Generators.OracleWithQuotedIdentifier
             expression.Index.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE INDEX \"TestIndex\" ON \"TestSchema\".\"TestTable1\" (\"TestColumn1\" ASC)");
+            result.ShouldBe("CREATE INDEX \"TestSchema\".\"TestIndex\" ON \"TestSchema\".\"TestTable1\" (\"TestColumn1\" ASC)");
         }
 
         [Test]
@@ -42,7 +42,7 @@ namespace FluentMigrator.Tests.Unit.Generators.OracleWithQuotedIdentifier
             expression.Index.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE INDEX \"TestIndex\" ON \"TestSchema\".\"TestTable1\" (\"TestColumn1\" ASC, \"TestColumn2\" DESC)");
+            result.ShouldBe("CREATE INDEX \"TestSchema\".\"TestIndex\" ON \"TestSchema\".\"TestTable1\" (\"TestColumn1\" ASC, \"TestColumn2\" DESC)");
         }
 
         [Test]
@@ -61,7 +61,7 @@ namespace FluentMigrator.Tests.Unit.Generators.OracleWithQuotedIdentifier
             expression.Index.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE UNIQUE INDEX \"TestIndex\" ON \"TestSchema\".\"TestTable1\" (\"TestColumn1\" ASC, \"TestColumn2\" DESC)");
+            result.ShouldBe("CREATE UNIQUE INDEX \"TestSchema\".\"TestIndex\" ON \"TestSchema\".\"TestTable1\" (\"TestColumn1\" ASC, \"TestColumn2\" DESC)");
         }
 
         [Test]
@@ -80,7 +80,7 @@ namespace FluentMigrator.Tests.Unit.Generators.OracleWithQuotedIdentifier
             expression.Index.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE UNIQUE INDEX \"TestIndex\" ON \"TestSchema\".\"TestTable1\" (\"TestColumn1\" ASC)");
+            result.ShouldBe("CREATE UNIQUE INDEX \"TestSchema\".\"TestIndex\" ON \"TestSchema\".\"TestTable1\" (\"TestColumn1\" ASC)");
         }
 
         [Test]


### PR DESCRIPTION
I add schemaName to create index and create constraint expressions.
Our case:
1. we run migration in oracle with system user
2. we create index or constraint in migration in user schema
bug №1 - index created in system schema
bug №2 - IndexExists query does not work because index located in system schema