### PR TITLE
Add option to output semicolon delimiter

### DIFF
--- a/src/FluentMigrator.Runner.Core/Logging/SqlScriptFluentMigratorLogger.cs
+++ b/src/FluentMigrator.Runner.Core/Logging/SqlScriptFluentMigratorLogger.cs
@@ -87,6 +87,8 @@ namespace FluentMigrator.Runner.Logging
             }
             else
             {
+                if (_options.OutputSemicolonDelimiter)
+                    sql += ";";
                 _writer.WriteLineDirect(sql);
                 if (_options.OutputGoBetweenStatements)
                     _writer.WriteLineDirect("GO");

--- a/src/FluentMigrator.Runner.Core/Logging/SqlScriptFluentMigratorLoggerOptions.cs
+++ b/src/FluentMigrator.Runner.Core/Logging/SqlScriptFluentMigratorLoggerOptions.cs
@@ -33,5 +33,10 @@ namespace FluentMigrator.Runner.Logging
         /// Gets or sets a value indicating whether a GO statement should be output between the SQL statements
         /// </summary>
         public bool OutputGoBetweenStatements { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether a semicolon (;) delimiter should be output on end the SQL statements
+        /// </summary>
+        public bool OutputSemicolonDelimiter { get; set; }
     }
 }

--- a/test/FluentMigrator.Tests/Unit/Loggers/TextWriterSemicolonDelimiterTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Loggers/TextWriterSemicolonDelimiterTests.cs
@@ -55,7 +55,7 @@ namespace FluentMigrator.Tests.Unit.Loggers
         }
 
         [Test]
-        public void WhenDisabledSqlShouldHaveSemicolonDelimiter()
+        public void WhenDisabledSqlShouldNotHaveSemicolonDelimiter()
         {
             options = new SqlScriptFluentMigratorLoggerOptions() { OutputSemicolonDelimiter = false };
             loggerFactory = new LoggerFactory();

--- a/test/FluentMigrator.Tests/Unit/Loggers/TextWriterSemicolonDelimiterTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Loggers/TextWriterSemicolonDelimiterTests.cs
@@ -1,0 +1,69 @@
+#region License
+//
+// Copyright (c) 2018, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+using System;
+using System.IO;
+
+using FluentMigrator.Runner;
+using FluentMigrator.Runner.Logging;
+
+using Microsoft.Extensions.Logging;
+
+using NUnit.Framework;
+
+using Shouldly;
+
+namespace FluentMigrator.Tests.Unit.Loggers
+{
+    public class TextWriterSemicolonDelimiter
+    {
+        private StringWriter stringWriter;
+        private SqlScriptFluentMigratorLoggerOptions options;
+        private ILoggerFactory loggerFactory;
+        private ILogger logger;
+
+        private string Output => stringWriter.ToString();
+
+        [SetUp]
+        public void SetUp() => stringWriter = new StringWriter();
+
+        [Test]
+        public void WhenEnabledSqlShouldHaveSemicolonDelimiter()
+        {
+            options = new SqlScriptFluentMigratorLoggerOptions() { OutputSemicolonDelimiter = true };
+            loggerFactory = new LoggerFactory();
+            loggerFactory.AddProvider(new SqlScriptFluentMigratorLoggerProvider(stringWriter, options));
+            logger = loggerFactory.CreateLogger("Test");
+
+            logger.LogSql("DELETE Blah");
+            Output.ShouldBe($"DELETE Blah;{Environment.NewLine}");
+        }
+
+        [Test]
+        public void WhenDisabledSqlShouldHaveSemicolonDelimiter()
+        {
+            options = new SqlScriptFluentMigratorLoggerOptions() { OutputSemicolonDelimiter = false };
+            loggerFactory = new LoggerFactory();
+            loggerFactory.AddProvider(new SqlScriptFluentMigratorLoggerProvider(stringWriter, options));
+            logger = loggerFactory.CreateLogger("Test");
+
+            logger.LogSql("DELETE Blah");
+            Output.ShouldNotContain(";");
+        }
+    }
+}

--- a/test/FluentMigrator.Tests/Unit/Loggers/TextWriterSemicolonDelimiterTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Loggers/TextWriterSemicolonDelimiterTests.cs
@@ -30,7 +30,7 @@ using Shouldly;
 
 namespace FluentMigrator.Tests.Unit.Loggers
 {
-    public class TextWriterSemicolonDelimiter
+    public class TextWriterSemicolonDelimiterTests
     {
         private StringWriter stringWriter;
         private SqlScriptFluentMigratorLoggerOptions options;


### PR DESCRIPTION
Implement Sql Script Logger Option to output semicolon delimiter
Implement semicolon output in WriteSql if option is enabled

It is useful for output Oracle Sql Script to file.
Tools - SQLPlus, DBeaver, etc... - need semicolon delimiter to execute Oracle scripts in file.
I ran into problems to execute Oracle Script files generated by Fluent Migrator in SQLPlus and DBeaver.

#765 