### PR TITLE
Partially revert "Upgrade sqlite version", which added unnecessary Microsoft.Data.Sqlite dependencies to a lot of the projects.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -79,3 +79,4 @@ You can also see contributors via https://github.com/fluentmigrator/fluentmigrat
 * [daniellee](https://github.com/daniellee) (Daniel Lee)
 * [tommarien](https://github.com/tommarien) (Tom Marien)
 * [schambers](https://github.com/schambers) (Sean Chambers)
+* [igitur](https://github.com/igitur) (Francois Botha)

--- a/samples/FluentMigrator.Example.Migrations/FluentMigrator.Example.Migrations.csproj
+++ b/samples/FluentMigrator.Example.Migrations/FluentMigrator.Example.Migrations.csproj
@@ -18,7 +18,4 @@
   <ItemGroup>
     <EmbeddedResource Include="**/*.sql" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
-  </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Abstractions/FluentMigrator.Abstractions.csproj
+++ b/src/FluentMigrator.Abstractions/FluentMigrator.Abstractions.csproj
@@ -42,7 +42,6 @@
     <XliffResource Include="MultilingualResources/*.xlf" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.1" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>

--- a/src/FluentMigrator.Extensions.Oracle/FluentMigrator.Extensions.Oracle.csproj
+++ b/src/FluentMigrator.Extensions.Oracle/FluentMigrator.Extensions.Oracle.csproj
@@ -15,9 +15,6 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Abstractions\FluentMigrator.Abstractions.csproj" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Extensions.Postgres/FluentMigrator.Extensions.Postgres.csproj
+++ b/src/FluentMigrator.Extensions.Postgres/FluentMigrator.Extensions.Postgres.csproj
@@ -12,9 +12,6 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Abstractions\FluentMigrator.Abstractions.csproj" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Extensions.SqlAnywhere/FluentMigrator.Extensions.SqlAnywhere.csproj
+++ b/src/FluentMigrator.Extensions.SqlAnywhere/FluentMigrator.Extensions.SqlAnywhere.csproj
@@ -15,9 +15,6 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Abstractions\FluentMigrator.Abstractions.csproj" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Extensions.SqlServer/FluentMigrator.Extensions.SqlServer.csproj
+++ b/src/FluentMigrator.Extensions.SqlServer/FluentMigrator.Extensions.SqlServer.csproj
@@ -15,9 +15,6 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Abstractions\FluentMigrator.Abstractions.csproj" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.MSBuild/FluentMigrator.MSBuild.csproj
+++ b/src/FluentMigrator.MSBuild/FluentMigrator.MSBuild.csproj
@@ -11,9 +11,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Runner\FluentMigrator.Runner.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/src/FluentMigrator.Runner.Core/FluentMigrator.Runner.Core.csproj
+++ b/src/FluentMigrator.Runner.Core/FluentMigrator.Runner.Core.csproj
@@ -17,7 +17,6 @@
     <Folder Include="BatchParser" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.1" />

--- a/src/FluentMigrator.Runner.Db2/FluentMigrator.Runner.Db2.csproj
+++ b/src/FluentMigrator.Runner.Db2/FluentMigrator.Runner.Db2.csproj
@@ -12,9 +12,6 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.Firebird/FluentMigrator.Runner.Firebird.csproj
+++ b/src/FluentMigrator.Runner.Firebird/FluentMigrator.Runner.Firebird.csproj
@@ -15,7 +15,6 @@
     <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.1" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.Hana/FluentMigrator.Runner.Hana.csproj
+++ b/src/FluentMigrator.Runner.Hana/FluentMigrator.Runner.Hana.csproj
@@ -12,9 +12,6 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.Jet/FluentMigrator.Runner.Jet.csproj
+++ b/src/FluentMigrator.Runner.Jet/FluentMigrator.Runner.Jet.csproj
@@ -12,9 +12,6 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.MySql/FluentMigrator.Runner.MySql.csproj
+++ b/src/FluentMigrator.Runner.MySql/FluentMigrator.Runner.MySql.csproj
@@ -12,9 +12,6 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.Oracle/FluentMigrator.Runner.Oracle.csproj
+++ b/src/FluentMigrator.Runner.Oracle/FluentMigrator.Runner.Oracle.csproj
@@ -12,9 +12,6 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Extensions.Oracle\FluentMigrator.Extensions.Oracle.csproj" />
     <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
   </ItemGroup>

--- a/src/FluentMigrator.Runner.Postgres/FluentMigrator.Runner.Postgres.csproj
+++ b/src/FluentMigrator.Runner.Postgres/FluentMigrator.Runner.Postgres.csproj
@@ -12,9 +12,6 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Extensions.Postgres\FluentMigrator.Extensions.Postgres.csproj" />
     <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
   </ItemGroup>

--- a/src/FluentMigrator.Runner.Redshift/FluentMigrator.Runner.Redshift.csproj
+++ b/src/FluentMigrator.Runner.Redshift/FluentMigrator.Runner.Redshift.csproj
@@ -12,9 +12,6 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.SQLite/FluentMigrator.Runner.SQLite.csproj
+++ b/src/FluentMigrator.Runner.SQLite/FluentMigrator.Runner.SQLite.csproj
@@ -12,9 +12,6 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.SqlAnywhere/FluentMigrator.Runner.SqlAnywhere.csproj
+++ b/src/FluentMigrator.Runner.SqlAnywhere/FluentMigrator.Runner.SqlAnywhere.csproj
@@ -19,7 +19,4 @@
     <Folder Include="Generators\" />
     <Folder Include="Processors\" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
-  </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.SqlServer/FluentMigrator.Runner.SqlServer.csproj
+++ b/src/FluentMigrator.Runner.SqlServer/FluentMigrator.Runner.SqlServer.csproj
@@ -23,7 +23,4 @@
   <ItemGroup>
     <Folder Include="BatchParser" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
-  </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.SqlServerCe/FluentMigrator.Runner.SqlServerCe.csproj
+++ b/src/FluentMigrator.Runner.SqlServerCe/FluentMigrator.Runner.SqlServerCe.csproj
@@ -48,7 +48,4 @@
       <HintPath>..\..\lib\SQLServerCE4\System.Data.SqlServerCe.dll</HintPath>
     </Reference>
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
-  </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
+++ b/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
@@ -31,7 +31,6 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.1" />
   </ItemGroup>

--- a/src/FluentMigrator/FluentMigrator.csproj
+++ b/src/FluentMigrator/FluentMigrator.csproj
@@ -18,7 +18,6 @@
     <ProjectReference Include="..\FluentMigrator.Abstractions\FluentMigrator.Abstractions.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.1" />
   </ItemGroup>


### PR DESCRIPTION
This partially reverts commit 12bf2f165b6eca6b469ef8ec2012e4110289513d.

As discussed, this reverts the accidental addition of `Microsoft.Data.Sqlite` dependencies to some projects.

I couldn't figure out how you build the `.nupkg` files in order to verify that the dependencies are dropped in those files too. Will you please double-check that when you release the next version?