### PR TITLE
Enhance description to disable flag that has default value = true

### DIFF
--- a/src/FluentMigrator.Console/MigratorConsole.cs
+++ b/src/FluentMigrator.Console/MigratorConsole.cs
@@ -263,7 +263,7 @@ namespace FluentMigrator.Console
                     },
                     {
                         "strip|strip-comments",
-                        "Strip comments from the SQL scripts. Default is true.",
+                        "Strip comments from the SQL scripts. Default is true. To disable, use --strip- or --strip-comments-",
                         v => { StripComments = v != null; }
                     },
                     {
@@ -368,6 +368,10 @@ namespace FluentMigrator.Console
             System.Console.WriteLine(@"  migrate [OPTIONS]");
             System.Console.WriteLine(@"Example:");
             System.Console.WriteLine(@"  migrate -a bin\debug\MyMigrations.dll -db SqlServer2008 -conn ""SEE_BELOW"" -profile ""Debug""");
+            System.Console.WriteLine(@"   ");
+            System.Console.WriteLine(@"Boolean options/flags (those without '=' or ':' in the option format string)");
+            System.Console.WriteLine(@"are explicitly enabled if they are followed with '+', and explicitly");
+            System.Console.WriteLine(@"disabled if they are followed with '-'.");
             System.Console.Out.WriteHorizontalRuler();
             System.Console.WriteLine(@"Example Connection Strings:");
             System.Console.WriteLine(@"  MySql: Data Source=172.0.0.1;Database=Foo;User Id=USERNAME;Password=BLAH");


### PR DESCRIPTION
It's impossible to know how to disable a flag with a default value of `true` in `FluentMigrator.Console` without digging through the source code comments in `Options.cs`. 

This PR adds some text to enlighten the user as to how to disable it. 

At the moment, this is relevant only to the stripping of comments. Currently `--strip` or `--strip-comments` defaults to `true`. In order to disable the stripping of comments, the user will have to pass `--strip-` or `--strip-comments-`. 