### PR TITLE
Fix SQLite message about incorrect double quotes

### DIFF
--- a/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteProcessor.cs
+++ b/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteProcessor.cs
@@ -44,6 +44,8 @@ namespace FluentMigrator.Runner.Processors.SQLite
     {
         [CanBeNull]
         private readonly IServiceProvider _serviceProvider;
+        [NotNull]
+        private readonly SQLiteQuoter _quoter;
 
         public override string DatabaseType
         {
@@ -58,9 +60,11 @@ namespace FluentMigrator.Runner.Processors.SQLite
             IMigrationGenerator generator,
             IAnnouncer announcer,
             [NotNull] IMigrationProcessorOptions options,
-            IDbFactory factory)
+            IDbFactory factory,
+            [NotNull] SQLiteQuoter quoter)
             : base(connection, factory, generator, announcer, options)
         {
+            _quoter = quoter;
         }
 
         public SQLiteProcessor(
@@ -69,10 +73,12 @@ namespace FluentMigrator.Runner.Processors.SQLite
             [NotNull] ILogger<SQLiteProcessor> logger,
             [NotNull] IOptionsSnapshot<ProcessorOptions> options,
             [NotNull] IConnectionStringAccessor connectionStringAccessor,
-            [NotNull] IServiceProvider serviceProvider)
+            [NotNull] IServiceProvider serviceProvider,
+            [NotNull] SQLiteQuoter quoter)
             : base(() => factory.Factory, generator, logger, options.Value, connectionStringAccessor)
         {
             _serviceProvider = serviceProvider;
+            _quoter = quoter;
         }
 
         public override bool SchemaExists(string schemaName)
@@ -82,18 +88,18 @@ namespace FluentMigrator.Runner.Processors.SQLite
 
         public override bool TableExists(string schemaName, string tableName)
         {
-            return Exists("select count(*) from sqlite_master where name='{0}' and type='table'", tableName.Replace("'", "''"));
+            return Exists("select count(*) from sqlite_master where name={0} and type='table'", _quoter.QuoteValue(tableName));
         }
 
         public override bool ColumnExists(string schemaName, string tableName, string columnName)
         {
-            var dataSet = Read("PRAGMA table_info([{0}])", tableName);
+            var dataSet = Read("PRAGMA table_info({0})", _quoter.QuoteValue(tableName));
             if (dataSet.Tables.Count == 0)
                 return false;
             var table = dataSet.Tables[0];
             if (!table.Columns.Contains("Name"))
                 return false;
-            return table.Select(string.Format("Name='{0}'", columnName.Replace("'", "''"))).Length > 0;
+            return table.Select(string.Format("Name={0}", _quoter.QuoteValue(columnName))).Length > 0;
         }
 
         public override bool ConstraintExists(string schemaName, string tableName, string constraintName)
@@ -103,7 +109,7 @@ namespace FluentMigrator.Runner.Processors.SQLite
 
         public override bool IndexExists(string schemaName, string tableName, string indexName)
         {
-            return Exists("select count(*) from sqlite_master where name='{0}' and tbl_name='{1}' and type='index'", indexName, tableName);
+            return Exists("select count(*) from sqlite_master where name={0} and tbl_name={1} and type='index'", _quoter.QuoteValue(indexName), _quoter.QuoteValue(tableName));
         }
 
         public override bool SequenceExists(string schemaName, string sequenceName)
@@ -138,7 +144,7 @@ namespace FluentMigrator.Runner.Processors.SQLite
 
         public override DataSet ReadTableData(string schemaName, string tableName)
         {
-            return Read("select * from [{0}]", tableName);
+            return Read("select * from {0}", _quoter.QuoteTableName(tableName));
         }
 
         public override bool DefaultValueExists(string schemaName, string tableName, string columnName, object defaultValue)

--- a/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteProcessor.cs
+++ b/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteProcessor.cs
@@ -82,7 +82,7 @@ namespace FluentMigrator.Runner.Processors.SQLite
 
         public override bool TableExists(string schemaName, string tableName)
         {
-            return Exists("select count(*) from sqlite_master where name='{0}' and type='table'", tableName);
+            return Exists("select count(*) from sqlite_master where name='{0}' and type='table'", tableName.Replace("'", "''"));
         }
 
         public override bool ColumnExists(string schemaName, string tableName, string columnName)

--- a/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteProcessor.cs
+++ b/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteProcessor.cs
@@ -82,7 +82,7 @@ namespace FluentMigrator.Runner.Processors.SQLite
 
         public override bool TableExists(string schemaName, string tableName)
         {
-            return Exists("select count(*) from sqlite_master where name=\"{0}\" and type='table'", tableName);
+            return Exists("select count(*) from sqlite_master where name='{0}' and type='table'", tableName);
         }
 
         public override bool ColumnExists(string schemaName, string tableName, string columnName)

--- a/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteProcessorFactory.cs
+++ b/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteProcessorFactory.cs
@@ -43,7 +43,8 @@ namespace FluentMigrator.Runner.Processors.SQLite
         {
             var factory = new SQLiteDbFactory(_serviceProvider);
             var connection = factory.CreateConnection(connectionString);
-            return new SQLiteProcessor(connection, new SQLiteGenerator(new SQLiteQuoter()), announcer, options, factory);
+            var quoter = new SQLiteQuoter();
+            return new SQLiteProcessor(connection, new SQLiteGenerator(quoter), announcer, options, factory, quoter);
         }
     }
 }

--- a/test/FluentMigrator.Tests/Integration/ObsoleteIntegrationTestBase.cs
+++ b/test/FluentMigrator.Tests/Integration/ObsoleteIntegrationTestBase.cs
@@ -252,7 +252,7 @@ namespace FluentMigrator.Tests.Integration
                 connection.ConnectionString = serverOptions.ConnectionString;
                 connection.Open();
 
-                var processor = new SQLiteProcessor(connection, new SQLiteGenerator(), announcer, new ProcessorOptions(), factory);
+                var processor = new SQLiteProcessor(connection, new SQLiteGenerator(), announcer, new ProcessorOptions(), factory, new SQLiteQuoter());
                 test(processor);
 
                 if (tryRollback && !processor.WasCommitted)

--- a/test/FluentMigrator.Tests/Unit/Builders/IfDatabase/ObsoleteIfDatabaseExpressionRootTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Builders/IfDatabase/ObsoleteIfDatabaseExpressionRootTests.cs
@@ -24,6 +24,7 @@ using System.Linq;
 
 using FluentMigrator.Builders.IfDatabase;
 using FluentMigrator.Infrastructure;
+using FluentMigrator.Runner.Generators.SQLite;
 using FluentMigrator.Runner.Processors;
 using FluentMigrator.Runner.Processors.SQLite;
 
@@ -207,7 +208,8 @@ namespace FluentMigrator.Tests.Unit.Builders.IfDatabase
                     null,
                     null,
                     new ProcessorOptions(),
-                    new SQLiteDbFactory()),
+                    new SQLiteDbFactory(),
+                    new SQLiteQuoter()),
                 new SingleAssembly(GetType().Assembly),
                 null,
                 string.Empty);
@@ -234,7 +236,7 @@ namespace FluentMigrator.Tests.Unit.Builders.IfDatabase
             // Arrange
             var mock = new Mock<IDbConnection>(MockBehavior.Loose);
             mock.Setup(x => x.State).Returns(ConnectionState.Open);
-            var context = new MigrationContext(new SQLiteProcessor(mock.Object, null, null, new ProcessorOptions(), new SQLiteDbFactory()), new SingleAssembly(GetType().Assembly), null, "");
+            var context = new MigrationContext(new SQLiteProcessor(mock.Object, null, null, new ProcessorOptions(), new SQLiteDbFactory(), new SQLiteQuoter()), new SingleAssembly(GetType().Assembly), null, "");
 
             var expression = new IfDatabaseExpressionRoot(context, databaseTypePredicate);
 

--- a/test/FluentMigrator.Tests/Unit/Processors/SQLite/BatchParserTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Processors/SQLite/BatchParserTests.cs
@@ -62,7 +62,8 @@ namespace FluentMigrator.Tests.Unit.Processors.SQLite
                 logger,
                 opt,
                 MockedConnectionStringAccessor.Object,
-                serviceProvider);
+                serviceProvider,
+                new SQLiteQuoter());
         }
     }
 }


### PR DESCRIPTION
When migrating a SQLite DB I was getting the following warning out of SQLite
Message: double-quoted string literal: "VersionInfo"
Error code: 28