### PR TITLE
Removing GUID from test project as it's not needed since VS 15.7

### DIFF
--- a/test/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/test/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -92,7 +92,4 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Its resolving issue #1219 

Tested on VS 2017 and 2019 - GUID is not being added back

https://github.com/microsoft/vstest/issues/472

