### PR TITLE
Add Support for MysqlConnector 1 namespace changes

### DIFF
--- a/src/FluentMigrator.Runner.MySql/Processors/MySql/MySqlDbFactory.cs
+++ b/src/FluentMigrator.Runner.MySql/Processors/MySql/MySqlDbFactory.cs
@@ -24,7 +24,7 @@ namespace FluentMigrator.Runner.Processors.MySql
         {
             new TestEntry("MySql.Data", "MySql.Data.MySqlClient.MySqlClientFactory"),
             new TestEntry("MySqlConnector", "MySql.Data.MySqlClient.MySqlClientFactory"),
-            new TestEntry("MySqlConnector", "MySqlConnector.MySqlConnectorFactory")
+            new TestEntry("MySqlConnector", "MySqlConnector.MySqlConnectorFactory"),
         };
 
         [Obsolete]

--- a/src/FluentMigrator.Runner.MySql/Processors/MySql/MySqlDbFactory.cs
+++ b/src/FluentMigrator.Runner.MySql/Processors/MySql/MySqlDbFactory.cs
@@ -24,6 +24,7 @@ namespace FluentMigrator.Runner.Processors.MySql
         {
             new TestEntry("MySql.Data", "MySql.Data.MySqlClient.MySqlClientFactory"),
             new TestEntry("MySqlConnector", "MySql.Data.MySqlClient.MySqlClientFactory"),
+            new TestEntry("MySqlConnector", "MySqlConnector.MySqlConnectorFactory")
         };
 
         [Obsolete]


### PR DESCRIPTION
MysqlConnector 1.0 broke namespaces so this supports that.

With .NET 5, I'm running into this.