### PR TITLE
Fixes error to create a index with index method

### DIFF
--- a/src/FluentMigrator.Runner.Postgres/Generators/Postgres/PostgresGenerator.cs
+++ b/src/FluentMigrator.Runner.Postgres/Generators/Postgres/PostgresGenerator.cs
@@ -195,15 +195,15 @@ namespace FluentMigrator.Runner.Generators.Postgres
             throw new NotSupportedException("The current version doesn't support include index. Please use Postgres 11.");
         }
 
-        protected virtual string GetUsingAlgorithm(CreateIndexExpression expression)
+        protected virtual Algorithm GetIndexMethod(CreateIndexExpression expression)
         {
             var algorithm = expression.GetAdditionalFeature<PostgresIndexAlgorithmDefinition>(PostgresExtensions.IndexAlgorithm);
             if (algorithm == null)
             {
-                return string.Empty;
+                return Algorithm.BTree;
             }
 
-            return $" USING {algorithm.Algorithm.ToString().ToUpper()}";
+            return algorithm.Algorithm;
         }
 
         protected virtual string GetFilter(CreateIndexExpression expression)
@@ -250,12 +250,14 @@ namespace FluentMigrator.Runner.Generators.Postgres
                 result.Append(" UNIQUE");
             }
 
+            var indexMethod = GetIndexMethod(expression);
+
             result.AppendFormat(" INDEX{0} {1} ON{2} {3}{4} (",
                 GetAsConcurrently(expression),
                 Quoter.QuoteIndexName(expression.Index.Name),
                 GetAsOnly(expression),
                 Quoter.QuoteTableName(expression.Index.TableName, expression.Index.SchemaName),
-                GetUsingAlgorithm(expression));
+                $" USING {indexMethod.ToString().ToUpper()}");
 
             var first = true;
             foreach (var column in expression.Index.Columns)
@@ -270,6 +272,18 @@ namespace FluentMigrator.Runner.Generators.Postgres
                 }
 
                 result.Append(Quoter.QuoteColumnName(column.Name));
+
+                switch (indexMethod)
+                {
+                    // Doesn't support ASC/DESC neither nulls sorts
+                    case Algorithm.Spgist:
+                    case Algorithm.Gist:
+                    case Algorithm.Gin:
+                    case Algorithm.Brin:
+                    case Algorithm.Hash:
+                        continue;
+                }
+
                 result.Append(column.Direction == Direction.Ascending ? " ASC" : " DESC");
             }
 

--- a/src/FluentMigrator.Runner.Postgres/Generators/Postgres/PostgresGenerator.cs
+++ b/src/FluentMigrator.Runner.Postgres/Generators/Postgres/PostgresGenerator.cs
@@ -257,7 +257,8 @@ namespace FluentMigrator.Runner.Generators.Postgres
                 Quoter.QuoteIndexName(expression.Index.Name),
                 GetAsOnly(expression),
                 Quoter.QuoteTableName(expression.Index.TableName, expression.Index.SchemaName),
-                $" USING {indexMethod.ToString().ToUpper()}");
+                // B-Tree is default index method
+                indexMethod == Algorithm.BTree ? string.Empty : $" USING {indexMethod.ToString().ToUpper()}");
 
             var first = true;
             foreach (var column in expression.Index.Columns)

--- a/test/FluentMigrator.Tests/Unit/Generators/Postgres/PostgresIndexTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Postgres/PostgresIndexTests.cs
@@ -125,8 +125,8 @@ namespace FluentMigrator.Tests.Unit.Generators.Postgres
             result.ShouldBe("DROP INDEX \"public\".\"TestIndex\";");
         }
 
+        // This index method doesn't support ASC/DES neither NULLS sort
         [TestCase(Algorithm.Brin)]
-        [TestCase(Algorithm.BTree)]
         [TestCase(Algorithm.Gin)]
         [TestCase(Algorithm.Gist)]
         [TestCase(Algorithm.Hash)]
@@ -141,7 +141,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Postgres
 
 
             var result = Generator.Generate(expression);
-            result.ShouldBe($"CREATE INDEX \"TestIndex\" ON \"public\".\"TestTable1\" USING {algorithm.ToString().ToUpper()} (\"TestColumn1\" ASC);");
+            result.ShouldBe($"CREATE INDEX \"TestIndex\" ON \"public\".\"TestTable1\" USING {algorithm.ToString().ToUpper()} (\"TestColumn1\");");
         }
 
         [Test]


### PR DESCRIPTION
FluentMigrator is generating invalid query when is using a index method different of B-Tree 😢 

Index method (not the B-Tree) doesn't support ASC/DES and nulls sorts also some of them doesn't support multi-column either (maybe in the feature could be support in the future).

The fixes is to not put ASC/DESC on query (when index method isn't B-tree) and the index method doesn't support multi-column I'm letting the postgres decide it.