### PR TITLE
Add columns with expression

### DIFF
--- a/src/FluentMigrator.Abstractions/Infrastructure/Extensions/LambdaExpressionExtension.cs
+++ b/src/FluentMigrator.Abstractions/Infrastructure/Extensions/LambdaExpressionExtension.cs
@@ -1,0 +1,49 @@
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace FluentMigrator.Infrastructure.Extensions
+{
+    public static class LambdaExpressionExtension
+    {
+        public static string GetMemberName(this LambdaExpression memberSelector)
+        {
+            var currentExpression = memberSelector.Body;
+
+            while (true)
+            {
+                switch (currentExpression.NodeType)
+                {
+                    case ExpressionType.Parameter:
+                        return ((ParameterExpression)currentExpression).Name;
+                    case ExpressionType.MemberAccess:
+                        return GetMeberNameWithColumnAttribute(((MemberExpression)currentExpression).Member);
+                    case ExpressionType.Call:
+                        return ((MethodCallExpression)currentExpression).Method.Name;
+                    case ExpressionType.Convert:
+                    case ExpressionType.ConvertChecked:
+                        currentExpression = ((UnaryExpression)currentExpression).Operand;
+                        break;
+                    case ExpressionType.Invoke:
+                        currentExpression = ((InvocationExpression)currentExpression).Expression;
+                        break;
+                    case ExpressionType.ArrayLength:
+                        return "Length";
+                    default:
+                        throw new Exception("not a proper member selector");
+                }
+            }
+        }
+
+        public static string GetMeberNameWithColumnAttribute(MemberInfo memberInfo)
+        {
+            var columnAttribute = memberInfo.GetCustomAttribute(typeof(ColumnAttribute)) as ColumnAttribute;
+
+            if (columnAttribute != null)
+                return columnAttribute.Name;
+
+            return memberInfo.Name;
+        }
+    }
+}

--- a/src/FluentMigrator/Builders/Create/Table/CreateTableExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Create/Table/CreateTableExpressionBuilder.cs
@@ -16,11 +16,14 @@
 
 #endregion
 
+using System;
 using System.Data;
+using System.Linq.Expressions;
 
 using FluentMigrator.Expressions;
 using FluentMigrator.Infrastructure;
 using FluentMigrator.Model;
+using FluentMigrator.Infrastructure.Extensions;
 
 namespace FluentMigrator.Builders.Create.Table
 {
@@ -76,6 +79,16 @@ namespace FluentMigrator.Builders.Create.Table
             Expression.Columns.Add(column);
             CurrentColumn = column;
             return this;
+        }
+
+        /// <summary>
+        /// Defines a column using class property
+        /// </summary>
+        /// <param name="expression">Expression to define column</param>
+        public ICreateTableColumnAsTypeSyntax WithColumn<T>(Expression<Func<T, Object>> expression)
+        {
+            var nameColumn = expression.GetMemberName();
+            return WithColumn(nameColumn);
         }
 
         /// <inheritdoc />

--- a/test/FluentMigrator.Tests/Unit/Builders/Create/CreateTableExpressionBuilderTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Builders/Create/CreateTableExpressionBuilderTests.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Data;
 
 using FluentMigrator.Builders;
@@ -544,6 +545,44 @@ namespace FluentMigrator.Tests.Unit.Builders.Create
         }
 
         [Test]
+        public void CallingWithColumnAddsNewColumnToExpressionFunc()
+        {
+            const string name = "LastName";
+
+            var collectionMock = new Mock<IList<ColumnDefinition>>();
+
+            var expressionMock = new Mock<CreateTableExpression>();
+            expressionMock.SetupGet(e => e.Columns).Returns(collectionMock.Object);
+
+            var contextMock = new Mock<IMigrationContext>();
+
+            var builder = new CreateTableExpressionBuilder(expressionMock.Object, contextMock.Object);
+            builder.WithColumn<ModelToCreateTableFake>(x => x.LastName);
+
+            collectionMock.Verify(x => x.Add(It.Is<ColumnDefinition>(c => c.Name.Equals(name))));
+            expressionMock.VerifyGet(e => e.Columns);
+        }
+
+        [Test]
+        public void CallingWithColumnAddsNewColumnToExpressionFuncWithAlias()
+        {
+            const string name = "PrivateAddress";
+
+            var collectionMock = new Mock<IList<ColumnDefinition>>();
+
+            var expressionMock = new Mock<CreateTableExpression>();
+            expressionMock.SetupGet(e => e.Columns).Returns(collectionMock.Object);
+
+            var contextMock = new Mock<IMigrationContext>();
+
+            var builder = new CreateTableExpressionBuilder(expressionMock.Object, contextMock.Object);
+            builder.WithColumn<ModelToCreateTableFake>(x => x.Address);
+
+            collectionMock.Verify(x => x.Add(It.Is<ColumnDefinition>(c => c.Name.Equals(name))));
+            expressionMock.VerifyGet(e => e.Columns);
+        }
+
+        [Test]
         public void ColumnHelperSetOnCreation()
         {
             var expressionMock = new Mock<CreateTableExpression>();
@@ -663,5 +702,12 @@ namespace FluentMigrator.Tests.Unit.Builders.Create
 
             columnMock.VerifySet(c => c.Precision = expected);
         }
+    }
+
+    internal class ModelToCreateTableFake
+    {
+        public string LastName { get; set; }
+        [Column("PrivateAddress")]
+        public string Address { get; set; }
     }
 }


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

I added a method to add a column via expression func, to get errors at run time.  I added the ability for columns to be able to have the ColumnAttribute attribute of "System.ComponentModel.DataAnnotations"

```csharp
Create.Table("Project")
           .InSchema("Tenant")
           .WithColumn<ProjectDataModel>(x => x.Id).AsInt32().PrimaryKey().NotNullable()
           .WithColumn<ProjectDataModel>(x => x.Nome).AsString(10).NotNullable();
```