### PR TITLE
Oracle: Log SQL on error

### DIFF
--- a/src/FluentMigrator.Runner.Oracle/Processors/DotConnectOracle/DotConnectOracleProcessor.cs
+++ b/src/FluentMigrator.Runner.Oracle/Processors/DotConnectOracle/DotConnectOracleProcessor.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.IO;
 
 using FluentMigrator.Expressions;
 using FluentMigrator.Runner.Generators.Oracle;
@@ -208,7 +209,24 @@ namespace FluentMigrator.Runner.Processors.DotConnectOracle
             EnsureConnectionIsOpen();
 
             using (var command = CreateCommand(sql))
-                command.ExecuteNonQuery();
+            {
+                try
+                {
+                    command.ExecuteNonQuery();
+                }
+                catch (Exception ex)
+                {
+                    using (var message = new StringWriter())
+                    {
+                        message.WriteLine("An error occured executing the following sql:");
+                        message.WriteLine(sql);
+                        message.WriteLine("The error was {0}", ex.Message);
+
+                        throw new Exception(message.ToString(), ex);
+                    }
+                }
+
+            }
         }
     }
 }

--- a/src/FluentMigrator.Runner.Oracle/Processors/Oracle/OracleProcessorBase.cs
+++ b/src/FluentMigrator.Runner.Oracle/Processors/Oracle/OracleProcessorBase.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -297,7 +298,21 @@ namespace FluentMigrator.Runner.Processors.Oracle
             {
                 using (var command = CreateCommand(batch))
                 {
-                    command.ExecuteNonQuery();
+                    try
+                    {
+                        command.ExecuteNonQuery();
+                    }
+                    catch (Exception ex)
+                    {
+                        using (var message = new StringWriter())
+                        {
+                            message.WriteLine("An error occured executing the following sql:");
+                            message.WriteLine(batch);
+                            message.WriteLine("The error was {0}", ex.Message);
+
+                            throw new Exception(message.ToString(), ex);
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Currently SQL Server and PostgreSQL runners log SQL when an error occurs.
This change will make Oracle follow the same pattern.