### PR TITLE
Fix not working password mask when connection string contains whitespace

### DIFF
--- a/src/FluentMigrator.Runner/Logging/PasswordMaskUtility.cs
+++ b/src/FluentMigrator.Runner/Logging/PasswordMaskUtility.cs
@@ -4,7 +4,7 @@ namespace FluentMigrator.Runner.Logging
 {
     public class PasswordMaskUtility : IPasswordMaskUtility
     {
-        private static readonly Regex _matchPwd = new Regex("(?<Prefix>.*)(?<Key>PWD=|PASSWORD=)(?<OptionalValue>((?<None>(;|;$|$))|(?<Value>(([^;]+$|[^;]+)))(?<ValueTerminator>$|;)))(?<Postfix>.*)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex _matchPwd = new Regex("(?<Prefix>.*)(?<Key>PWD\\s*=\\s*|PASSWORD\\s*=\\s*)(?<OptionalValue>((?<None>(;|;$|$))|(?<Value>(([^;]+$|[^;]+)))(?<ValueTerminator>$|;)))(?<Postfix>.*)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         public string ApplyMask(string connectionString)
         {

--- a/test/FluentMigrator.Tests/Unit/Loggers/PasswordMaskUtilityTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Loggers/PasswordMaskUtilityTests.cs
@@ -1,4 +1,5 @@
 using FluentMigrator.Runner.Logging;
+
 using NUnit.Framework;
 
 namespace FluentMigrator.Tests.Unit.Loggers
@@ -31,14 +32,23 @@ namespace FluentMigrator.Tests.Unit.Loggers
             return new TestInputExpected[]
             {
                 new TestInputExpected() { Input = @"Password=pass@123", Expected = $@"Password={mask}" },
+                new TestInputExpected() { Input = @"Password = pass@123", Expected = $@"Password = {mask}" },
                 new TestInputExpected() { Input = @"Password=pass@123;", Expected = $@"Password={mask};" },
+                new TestInputExpected() { Input = @"Password = pass@123;", Expected = $@"Password = {mask};" },
                 new TestInputExpected() { Input = @"Password=pass@123;;", Expected = $@"Password={mask};;" },
+                new TestInputExpected() { Input = @"Password = pass@123;;", Expected = $@"Password = {mask};;" },
                 new TestInputExpected() { Input = @"Password=", Expected = $@"Password={mask}" },
+                new TestInputExpected() { Input = @"Password = ", Expected = $@"Password = {mask}" },
                 new TestInputExpected() { Input = @"Password=;", Expected = $@"Password={mask};" },
+                new TestInputExpected() { Input = @"Password = ;", Expected = $@"Password = {mask};" },
                 new TestInputExpected() { Input = @"Password=;;", Expected = $@"Password={mask};;" },
+                new TestInputExpected() { Input = @"Password = ;;", Expected = $@"Password = {mask};;" },
                 new TestInputExpected() { Input = @"Password=;User Id =;", Expected = $@"Password={mask};User Id =;" },
+                new TestInputExpected() { Input = @"Password = ;User Id =;", Expected = $@"Password = {mask};User Id =;" },
                 new TestInputExpected() { Input = @"Server=127.0.0.1;Database=FluentMigrator;User Id=MyUser;Password=pass@123", Expected = $@"Server=127.0.0.1;Database=FluentMigrator;User Id=MyUser;Password={mask}" },
-                new TestInputExpected() { Input = @"Server=127.0.0.1;Database=FluentMigrator;Password=pass@123;User Id=MyUser", Expected = $@"Server=127.0.0.1;Database=FluentMigrator;Password={mask};User Id=MyUser" }
+                new TestInputExpected() { Input = @"Server = 127.0.0.1;Database = FluentMigrator;User Id = MyUser;Password = pass@123", Expected = $@"Server = 127.0.0.1;Database = FluentMigrator;User Id = MyUser;Password = {mask}" },
+                new TestInputExpected() { Input = @"Server=127.0.0.1;Database=FluentMigrator;Password=pass@123;User Id=MyUser", Expected = $@"Server=127.0.0.1;Database=FluentMigrator;Password={mask};User Id=MyUser" },
+                new TestInputExpected() { Input = @"Server = 127.0.0.1;Database = FluentMigrator;Password = pass@123;User Id = MyUser", Expected = $@"Server = 127.0.0.1;Database = FluentMigrator;Password = {mask};User Id = MyUser" }
             };
         }
 


### PR DESCRIPTION
When connection string contained whitespace around equality character (ex. 'Password = examplepassword'), password masking didn't work properly, thus plain text password was appearing in the logs.