### PR TITLE
Added additional tool TFMs

### DIFF
--- a/src/FluentMigrator.DotNet.Cli/FluentMigrator.DotNet.Cli.csproj
+++ b/src/FluentMigrator.DotNet.Cli/FluentMigrator.DotNet.Cli.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <ToolCommandName>dotnet-fm</ToolCommandName>
     <PackAsTool>true</PackAsTool>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
The assembly loading workaround (https://github.com/fluentmigrator/fluentmigrator/blob/cb674f4c8cf47b93068ae9a93430a38fde7a00d9/src/FluentMigrator.DotNet.Cli/Program.cs#L42) currently makes using other TFMs difficult as it will use the runtime directory of whatever the tool is running under.

This change adds a couple of additional targets, meaning that if a migration project targets .NET 5, it should still work as any dependencies would search the .NET 5 runtime folder and find compatible assemblies.