### PR TITLE
SQLite Processor: Query column without loading whole `table_info` 

### DIFF
--- a/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteProcessor.cs
+++ b/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteProcessor.cs
@@ -93,7 +93,7 @@ namespace FluentMigrator.Runner.Processors.SQLite
 
         public override bool ColumnExists(string schemaName, string tableName, string columnName)
         {
-            return Exists("select count(*) from sqlite_master AS t, pragma_table_info(t.name) AS c where t.type = 'table' AND t.name = {0} and c.name = {1}", _quoter.QuoteValue(tableName), _quoter.QuoteValue(columnName));
+            return Exists("select count(*) from sqlite_master AS t, pragma_table_info(t.name) AS c where t.type = 'table' AND t.name = {0} AND c.name = {1}", _quoter.QuoteValue(tableName), _quoter.QuoteValue(columnName));
         }
 
         public override bool ConstraintExists(string schemaName, string tableName, string constraintName)

--- a/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteProcessor.cs
+++ b/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteProcessor.cs
@@ -93,13 +93,7 @@ namespace FluentMigrator.Runner.Processors.SQLite
 
         public override bool ColumnExists(string schemaName, string tableName, string columnName)
         {
-            var dataSet = Read("PRAGMA table_info({0})", _quoter.QuoteValue(tableName));
-            if (dataSet.Tables.Count == 0)
-                return false;
-            var table = dataSet.Tables[0];
-            if (!table.Columns.Contains("Name"))
-                return false;
-            return table.Select(string.Format("Name={0}", _quoter.QuoteValue(columnName))).Length > 0;
+            return Exists("select count(*) from sqlite_master AS t, pragma_table_info(t.name) AS c where t.type = 'table' AND t.name = {0} and c.name = {1}", _quoter.QuoteValue(tableName), _quoter.QuoteValue(columnName));
         }
 
         public override bool ConstraintExists(string schemaName, string tableName, string constraintName)


### PR DESCRIPTION
This change performs an explicit column lookup with a single SQL statement to prevent the loading of the whole `table_info` into a DataSet as when used with `Microsoft.Data.Sqlite` this causes an exception when trying to load the `dflt_value` column.

    Type of value has a mismatch with column typeCouldn't store <0> in dflt_value Column. Expected type is Byte[].

Related issue https://github.com/fluentmigrator/fluentmigrator/issues/1389 and https://github.com/fluentmigrator/fluentmigrator/issues/1570

This is based on example code on the MS docs https://docs.microsoft.com/en-us/dotnet/standard/data/sqlite/metadata#schema-metadata