### PR TITLE
Limit SQLite type mappings to the 4 core data types

### DIFF
--- a/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteTypeMap.cs
+++ b/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteTypeMap.cs
@@ -44,22 +44,22 @@ namespace FluentMigrator.Runner.Generators.SQLite
             SetTypeMap(DbType.UInt16, "INTEGER");
             SetTypeMap(DbType.UInt32, "INTEGER");
             SetTypeMap(DbType.UInt64, "INTEGER");
-            SetTypeMap(DbType.Currency, "NUMERIC");
-            SetTypeMap(DbType.Decimal, "NUMERIC");
-            SetTypeMap(DbType.Double, "NUMERIC");
-            SetTypeMap(DbType.Single, "NUMERIC");
-            SetTypeMap(DbType.VarNumeric, "NUMERIC");
+            SetTypeMap(DbType.Currency, "TEXT");
+            SetTypeMap(DbType.Decimal, "TEXT");
+            SetTypeMap(DbType.Double, "REAL");
+            SetTypeMap(DbType.Single, "REAL");
+            SetTypeMap(DbType.VarNumeric, "TEXT");
             SetTypeMap(DbType.AnsiString, "TEXT");
             SetTypeMap(DbType.String, "TEXT");
             SetTypeMap(DbType.AnsiStringFixedLength, "TEXT");
             SetTypeMap(DbType.StringFixedLength, "TEXT");
 
-            SetTypeMap(DbType.Date, "DATETIME");
-            SetTypeMap(DbType.DateTime, "DATETIME");
-            SetTypeMap(DbType.DateTime2, "DATETIME");
-            SetTypeMap(DbType.Time, "DATETIME");
+            SetTypeMap(DbType.Date, "TEXT");
+            SetTypeMap(DbType.DateTime, "TEXT");
+            SetTypeMap(DbType.DateTime2, "TEXT");
+            SetTypeMap(DbType.Time, "TEXT");
             SetTypeMap(DbType.Boolean, "INTEGER");
-            SetTypeMap(DbType.Guid, "UNIQUEIDENTIFIER");
+            SetTypeMap(DbType.Guid, "TEXT");
         }
 
         public override string GetTypeMap(DbType type, int? size, int? precision)

--- a/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteColumnTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteColumnTests.cs
@@ -123,7 +123,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expressions = GeneratorTestHelper.GetCreateColumnWithSystemMethodExpression("TestSchema");
             var result = string.Join(Environment.NewLine, expressions.Select(x => (string)Generator.Generate((dynamic)x)));
             result.ShouldBe(
-                @"ALTER TABLE ""TestTable1"" ADD COLUMN ""TestColumn1"" DATETIME" + Environment.NewLine +
+                @"ALTER TABLE ""TestTable1"" ADD COLUMN ""TestColumn1"" TEXT" + Environment.NewLine +
                 @"UPDATE ""TestTable1"" SET ""TestColumn1"" = (datetime('now','localtime')) WHERE 1 = 1");
         }
 
@@ -133,7 +133,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expressions = GeneratorTestHelper.GetCreateColumnWithSystemMethodExpression();
             var result = string.Join(Environment.NewLine, expressions.Select(x => (string)Generator.Generate((dynamic)x)));
             result.ShouldBe(
-                @"ALTER TABLE ""TestTable1"" ADD COLUMN ""TestColumn1"" DATETIME" + Environment.NewLine +
+                @"ALTER TABLE ""TestTable1"" ADD COLUMN ""TestColumn1"" TEXT" + Environment.NewLine +
                 @"UPDATE ""TestTable1"" SET ""TestColumn1"" = (datetime('now','localtime')) WHERE 1 = 1");
         }
 
@@ -144,7 +144,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("ALTER TABLE \"TestTable1\" ADD COLUMN \"TestColumn1\" NUMERIC NOT NULL");
+            result.ShouldBe("ALTER TABLE \"TestTable1\" ADD COLUMN \"TestColumn1\" TEXT NOT NULL");
         }
 
         [Test]
@@ -153,7 +153,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetCreateDecimalColumnExpression();
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("ALTER TABLE \"TestTable1\" ADD COLUMN \"TestColumn1\" NUMERIC NOT NULL");
+            result.ShouldBe("ALTER TABLE \"TestTable1\" ADD COLUMN \"TestColumn1\" TEXT NOT NULL");
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteGeneratorTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteGeneratorTests.cs
@@ -133,7 +133,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.Columns.Add(new ColumnDefinition { Name = "DateTimeCol", Type = DbType.DateTime, DefaultValue = SystemMethods.CurrentDateTime});
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE TABLE \"TestTable1\" (\"DateTimeCol\" DATETIME NOT NULL DEFAULT (datetime('now','localtime')))");
+            result.ShouldBe("CREATE TABLE \"TestTable1\" (\"DateTimeCol\" TEXT NOT NULL DEFAULT (datetime('now','localtime')))");
         }
 
         [Test]
@@ -143,7 +143,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.Columns.Add(new ColumnDefinition { Name = "DateTimeCol", Type = DbType.DateTime, DefaultValue = SystemMethods.CurrentUTCDateTime });
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE TABLE \"TestTable1\" (\"DateTimeCol\" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP)");
+            result.ShouldBe("CREATE TABLE \"TestTable1\" (\"DateTimeCol\" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)");
         }
         [Test]
         public void CanRenameColumnInStrictMode()


### PR DESCRIPTION
SQLite only really supports 4 core data types `INTEGER, REAL, TEXT, and BLOB` (See https://www.sqlite.org/datatype3.html#storage_classes_and_datatypes) but uses type affinity to allow a form of `alising` (See https://www.sqlite.org/datatype3.html#type_affinity)

Unfortunately `Microsoft.Data.Sqlite` only really supports the 4 core ones (See documentation here https://docs.microsoft.com/en-us/dotnet/standard/data/sqlite/types)

> We recommend only using the four primitive SQLite type names: INTEGER, REAL, TEXT, and BLOB.

...so I think for broader compatibility this type list should be limited to the 4 core supported types. I've updated these definitions as per the MS link above.