### PR TITLE
Fixes SQLite FormatIdentity bug 1456

### DIFF
--- a/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteColumn.cs
+++ b/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteColumn.cs
@@ -29,14 +29,19 @@ namespace FluentMigrator.Runner.Generators.SQLite
         /// <inheritdoc />
         protected override string FormatIdentity(ColumnDefinition column)
         {
-            // SQLite only supports the concept of Identity in combination with a single integer primary key
-            // see: http://www.sqlite.org/syntaxdiagrams.html#column-constraint syntax details
-            if (column.IsIdentity && !column.IsPrimaryKey && (!column.Type.HasValue || GetTypeMap(column.Type.Value, null, null) != "INTEGER"))
+            if (column.IsIdentity)
             {
-                throw new ArgumentException("SQLite only supports identity on a single integer, primary key coulmns");
+                // SQLite only supports the concept of Identity in combination with a single integer primary key
+                // see: http://www.sqlite.org/syntaxdiagrams.html#column-constraint syntax details
+                if (!column.IsPrimaryKey && (!column.Type.HasValue || GetTypeMap(column.Type.Value, null, null) != "INTEGER"))
+                {
+                    throw new ArgumentException("SQLite only supports identity on a single integer, primary key coulmns");
+                }
+
+                return "AUTOINCREMENT";
             }
 
-            return "AUTOINCREMENT";
+            return string.Empty;
         }
 
         /// <inheritdoc />
@@ -50,12 +55,7 @@ namespace FluentMigrator.Runner.Generators.SQLite
         /// <inheritdoc />
         protected override string FormatPrimaryKey(ColumnDefinition column)
         {
-            if (!column.IsPrimaryKey)
-            {
-                return string.Empty;
-            }
-
-            return column.IsIdentity ? "PRIMARY KEY AUTOINCREMENT" : string.Empty;
+            return column.IsPrimaryKey ? "PRIMARY KEY" : string.Empty;
         }
     }
 }

--- a/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteColumn.cs
+++ b/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteColumn.cs
@@ -29,14 +29,14 @@ namespace FluentMigrator.Runner.Generators.SQLite
         /// <inheritdoc />
         protected override string FormatIdentity(ColumnDefinition column)
         {
-            //SQLite only supports the concept of Identity in combination with a single primary key
-            //see: http://www.sqlite.org/syntaxdiagrams.html#column-constraint syntax details
-            if (column.IsIdentity && !column.IsPrimaryKey && column.Type != DbType.Int32)
+            // SQLite only supports the concept of Identity in combination with a single integer primary key
+            // see: http://www.sqlite.org/syntaxdiagrams.html#column-constraint syntax details
+            if (column.IsIdentity && !column.IsPrimaryKey && (!column.Type.HasValue || GetTypeMap(column.Type.Value, null, null) != "INTEGER"))
             {
-                throw new ArgumentException("SQLite only supports identity on single integer, primary key coulmns");
+                throw new ArgumentException("SQLite only supports identity on a single integer, primary key coulmns");
             }
 
-            return string.Empty;
+            return "AUTOINCREMENT";
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Fixes #1456

The previous implementation of `FormatIdentity` incorrectly limited identity support to `DbType.Int32` when in reality, it should be allowed for anything that maps to "INTEGER".

I've updated it so it checks the DbType against the TypeMap and have also separated it from the `FormatPrimaryKey` function as you should be able to have a primary key without identity too.