### PR TITLE
Add missing features to SQLite runner

### DIFF
--- a/samples/FluentMigrator.Example.Migrator/DefaultDatabaseConfigurations.cs
+++ b/samples/FluentMigrator.Example.Migrator/DefaultDatabaseConfigurations.cs
@@ -45,7 +45,7 @@ namespace FluentMigrator.Example.Migrator
 
             return new DatabaseConfiguration()
             {
-                ProcessorId = "sqlite",
+                ProcessorId = ProcessorId.SQLite,
                 ConnectionString = csb.ConnectionString,
             };
         }

--- a/samples/FluentMigrator.Example.Migrator/FluentMigrator.Example.Migrator.csproj
+++ b/samples/FluentMigrator.Example.Migrator/FluentMigrator.Example.Migrator.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.1" />
   </ItemGroup>

--- a/samples/FluentMigrator.Example.Migrator/FluentMigrator.Example.Migrator.csproj
+++ b/samples/FluentMigrator.Example.Migrator/FluentMigrator.Example.Migrator.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.4" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.16" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.1" />
   </ItemGroup>

--- a/samples/FluentMigrator.Example.Migrator/FluentMigrator.Example.Migrator.csproj
+++ b/samples/FluentMigrator.Example.Migrator/FluentMigrator.Example.Migrator.csproj
@@ -18,9 +18,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.16" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.1" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\FluentMigrator.Runner\FluentMigrator.Runner.csproj" />

--- a/samples/FluentMigrator.Example.Migrator/Program.cs
+++ b/samples/FluentMigrator.Example.Migrator/Program.cs
@@ -102,7 +102,7 @@ namespace FluentMigrator.Example.Migrator
             {
                 return new DatabaseConfiguration()
                 {
-                    ProcessorId = "sqlite",
+                    ProcessorId = ProcessorId.SQLite,
                     ConnectionString = connectionString.Value(),
                 };
             }

--- a/src/FluentMigrator.Console/FluentMigrator.Console.csproj
+++ b/src/FluentMigrator.Console/FluentMigrator.Console.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Npgsql" Version="3.2.7" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="5.12.1" />
     <PackageReference Include="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.4" />
     <PackageReference Include="Oracle.ManagedDataAccess" Version="12.2.1100" />
     <PackageReference Include="MySql.Data" Version="8.0.11" />
   </ItemGroup>

--- a/src/FluentMigrator.Console/FluentMigrator.Console.csproj
+++ b/src/FluentMigrator.Console/FluentMigrator.Console.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Npgsql" Version="3.2.7" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="5.12.1" />
     <PackageReference Include="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.4" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.16" />
     <PackageReference Include="Oracle.ManagedDataAccess" Version="12.2.1100" />
     <PackageReference Include="MySql.Data" Version="8.0.11" />
   </ItemGroup>

--- a/src/FluentMigrator.Console/FluentMigrator.Console.csproj
+++ b/src/FluentMigrator.Console/FluentMigrator.Console.csproj
@@ -22,9 +22,10 @@
     <PackageReference Include="Npgsql" Version="3.2.7" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="5.12.1" />
     <PackageReference Include="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.16" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.4" />
     <PackageReference Include="Oracle.ManagedDataAccess" Version="12.2.1100" />
     <PackageReference Include="MySql.Data" Version="8.0.11" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.7" />
   </ItemGroup>
   <ItemGroup Condition=" '$(Platform)' == 'x86' ">
     <PackageReference Include="Oracle.DataAccess.x86.4" Version="4.112.3" />

--- a/src/FluentMigrator.DotNet.Cli/FluentMigrator.DotNet.Cli.csproj
+++ b/src/FluentMigrator.DotNet.Cli/FluentMigrator.DotNet.Cli.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="5.12.1" />
     <PackageReference Include="FSharp.Core" Version="4.6.2" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.1" />

--- a/src/FluentMigrator.DotNet.Cli/FluentMigrator.DotNet.Cli.csproj
+++ b/src/FluentMigrator.DotNet.Cli/FluentMigrator.DotNet.Cli.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="5.12.1" />
     <PackageReference Include="FSharp.Core" Version="4.6.2" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.4" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.16" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.1" />

--- a/src/FluentMigrator.DotNet.Cli/FluentMigrator.DotNet.Cli.csproj
+++ b/src/FluentMigrator.DotNet.Cli/FluentMigrator.DotNet.Cli.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="5.12.1" />
     <PackageReference Include="FSharp.Core" Version="4.6.2" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.16" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.1" />
@@ -20,6 +20,7 @@
     <PackageReference Include="MySql.Data" Version="8.0.11" />
     <PackageReference Include="Npgsql" Version="3.2.7" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.60" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Runner\FluentMigrator.Runner.csproj" />

--- a/src/FluentMigrator.Runner.Db2/FluentMigrator.Runner.Db2.csproj
+++ b/src/FluentMigrator.Runner.Db2/FluentMigrator.Runner.Db2.csproj
@@ -13,5 +13,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
+    <ProjectReference Include="..\FluentMigrator\FluentMigrator.csproj" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.Db2/Processors/Db2/Db2Processor.cs
+++ b/src/FluentMigrator.Runner.Db2/Processors/Db2/Db2Processor.cs
@@ -54,7 +54,7 @@ namespace FluentMigrator.Runner.Processors.DB2
             Quoter = quoter;
         }
 
-        public override string DatabaseType => "DB2";
+        public override string DatabaseType => ProcessorId.DB2;
 
         public override IList<string> DatabaseTypeAliases { get; } = new List<string> { "IBM DB2" };
 

--- a/src/FluentMigrator.Runner.Firebird/FluentMigrator.Runner.Firebird.csproj
+++ b/src/FluentMigrator.Runner.Firebird/FluentMigrator.Runner.Firebird.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
+    <ProjectReference Include="..\FluentMigrator\FluentMigrator.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.1" />

--- a/src/FluentMigrator.Runner.Firebird/Processors/Firebird/FirebirdProcessor.cs
+++ b/src/FluentMigrator.Runner.Firebird/Processors/Firebird/FirebirdProcessor.cs
@@ -82,7 +82,7 @@ namespace FluentMigrator.Runner.Processors.Firebird
             ClearDDLFollowers();
         }
 
-        public override string DatabaseType => "Firebird";
+        public override string DatabaseType => ProcessorId.Firebird;
 
         public override IList<string> DatabaseTypeAliases { get; } = new List<string>();
 

--- a/src/FluentMigrator.Runner.Hana/FluentMigrator.Runner.Hana.csproj
+++ b/src/FluentMigrator.Runner.Hana/FluentMigrator.Runner.Hana.csproj
@@ -13,5 +13,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
+    <ProjectReference Include="..\FluentMigrator\FluentMigrator.csproj" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.Hana/Processors/Hana/HanaProcessor.cs
+++ b/src/FluentMigrator.Runner.Hana/Processors/Hana/HanaProcessor.cs
@@ -35,7 +35,7 @@ namespace FluentMigrator.Runner.Processors.Hana
         {
         }
 
-        public override string DatabaseType => "Hana";
+        public override string DatabaseType => ProcessorId.Hana;
 
         public override IList<string> DatabaseTypeAliases { get; } = new List<string>();
 

--- a/src/FluentMigrator.Runner.Jet/FluentMigrator.Runner.Jet.csproj
+++ b/src/FluentMigrator.Runner.Jet/FluentMigrator.Runner.Jet.csproj
@@ -13,5 +13,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
+    <ProjectReference Include="..\FluentMigrator\FluentMigrator.csproj" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.Jet/Processors/Jet/JetProcessor.cs
+++ b/src/FluentMigrator.Runner.Jet/Processors/Jet/JetProcessor.cs
@@ -81,7 +81,7 @@ namespace FluentMigrator.Runner.Processors.Jet
         [Obsolete]
         public override string ConnectionString { get; }
 
-        public override string DatabaseType { get; } = "Jet";
+        public override string DatabaseType { get; } = ProcessorId.Jet;
 
         public override IList<string> DatabaseTypeAliases { get; } = new List<string>();
 

--- a/src/FluentMigrator.Runner.MySql/FluentMigrator.Runner.MySql.csproj
+++ b/src/FluentMigrator.Runner.MySql/FluentMigrator.Runner.MySql.csproj
@@ -13,5 +13,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
+    <ProjectReference Include="..\FluentMigrator\FluentMigrator.csproj" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.MySql/Processors/MySql/MySql4Processor.cs
+++ b/src/FluentMigrator.Runner.MySql/Processors/MySql/MySql4Processor.cs
@@ -44,12 +44,13 @@ namespace FluentMigrator.Runner.Processors.MySql
         }
 
         /// <inheritdoc />
-        public override string DatabaseType => "MySql4";
+        public override string DatabaseType => ProcessorId.MySql4;
 
         /// <inheritdoc />
         public override IList<string> DatabaseTypeAliases { get; } = new List<string>()
         {
-            "MySQL",
+            ProcessorId.MariaDB,
+            ProcessorId.MySql,
             "MySQL 4"
         };
     }

--- a/src/FluentMigrator.Runner.MySql/Processors/MySql/MySql5Processor.cs
+++ b/src/FluentMigrator.Runner.MySql/Processors/MySql/MySql5Processor.cs
@@ -44,13 +44,13 @@ namespace FluentMigrator.Runner.Processors.MySql
         }
 
         /// <inheritdoc />
-        public override string DatabaseType => "MySql5";
+        public override string DatabaseType => ProcessorId.MySql5;
 
         /// <inheritdoc />
         public override IList<string> DatabaseTypeAliases { get; } = new List<string>()
         {
-            "MariaDB",
-            "MySQL",
+            ProcessorId.MariaDB,
+            ProcessorId.MySql,
             "MySQL 5"
         };
     }

--- a/src/FluentMigrator.Runner.MySql/Processors/MySql/MySqlProcessor.cs
+++ b/src/FluentMigrator.Runner.MySql/Processors/MySql/MySqlProcessor.cs
@@ -36,9 +36,9 @@ namespace FluentMigrator.Runner.Processors.MySql
     {
         private readonly MySqlQuoter _quoter = new MySqlQuoter();
 
-        public override string DatabaseType => "MySql";
+        public override string DatabaseType => ProcessorId.MySql;
 
-        public override IList<string> DatabaseTypeAliases { get; } = new List<string> { "MariaDB" };
+        public override IList<string> DatabaseTypeAliases { get; } = new List<string> { ProcessorId.MariaDB };
 
         [Obsolete]
         public MySqlProcessor(IDbConnection connection, IMigrationGenerator generator, IAnnouncer announcer, IMigrationProcessorOptions options, IDbFactory factory)

--- a/src/FluentMigrator.Runner.Oracle/FluentMigrator.Runner.Oracle.csproj
+++ b/src/FluentMigrator.Runner.Oracle/FluentMigrator.Runner.Oracle.csproj
@@ -14,5 +14,6 @@
   <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Extensions.Oracle\FluentMigrator.Extensions.Oracle.csproj" />
     <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
+    <ProjectReference Include="..\FluentMigrator\FluentMigrator.csproj" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.Oracle/Processors/Oracle/Oracle12CProcessor.cs
+++ b/src/FluentMigrator.Runner.Oracle/Processors/Oracle/Oracle12CProcessor.cs
@@ -54,10 +54,10 @@ namespace FluentMigrator.Runner.Processors.Oracle
         }
 
         /// <inheritdoc />
-        public override string DatabaseType => "Oracle12c";
+        public override string DatabaseType => ProcessorId.Oracle12c;
 
         /// <inheritdoc />
         public override IList<string> DatabaseTypeAliases { get; } = new List<string>()
-            { "Oracle 12c", "Oracle" };
+            { ProcessorId.Oracle, "Oracle 12c" };
     }
 }

--- a/src/FluentMigrator.Runner.Oracle/Processors/Oracle/OracleManagedProcessor.cs
+++ b/src/FluentMigrator.Runner.Oracle/Processors/Oracle/OracleManagedProcessor.cs
@@ -32,7 +32,7 @@ namespace FluentMigrator.Runner.Processors.Oracle
             [NotNull] ILogger<OracleManagedProcessor> logger,
             [NotNull] IOptionsSnapshot<ProcessorOptions> options,
             [NotNull] IConnectionStringAccessor connectionStringAccessor)
-            : base("OracleManaged", factory, generator, logger, options, connectionStringAccessor)
+            : base(ProcessorId.OracleManaged, factory, generator, logger, options, connectionStringAccessor)
         {
         }
     }

--- a/src/FluentMigrator.Runner.Oracle/Processors/Oracle/OracleProcessor.cs
+++ b/src/FluentMigrator.Runner.Oracle/Processors/Oracle/OracleProcessor.cs
@@ -39,7 +39,7 @@ namespace FluentMigrator.Runner.Processors.Oracle
             IAnnouncer announcer,
             IMigrationProcessorOptions options,
             IDbFactory factory)
-            : base("Oracle", connection, generator, announcer, options, factory)
+            : base(ProcessorId.Oracle, connection, generator, announcer, options, factory)
         {
         }
 
@@ -49,7 +49,7 @@ namespace FluentMigrator.Runner.Processors.Oracle
             [NotNull] ILogger<OracleProcessor> logger,
             [NotNull] IOptionsSnapshot<ProcessorOptions> options,
             [NotNull] IConnectionStringAccessor connectionStringAccessor)
-            : base("Oracle", factory, generator, logger, options, connectionStringAccessor)
+            : base(ProcessorId.Oracle, factory, generator, logger, options, connectionStringAccessor)
         {
         }
     }

--- a/src/FluentMigrator.Runner.Oracle/Processors/Oracle/OracleProcessorBase.cs
+++ b/src/FluentMigrator.Runner.Oracle/Processors/Oracle/OracleProcessorBase.cs
@@ -62,7 +62,7 @@ namespace FluentMigrator.Runner.Processors.Oracle
 
         public override string DatabaseType { get; }
 
-        public override IList<string> DatabaseTypeAliases { get; } = new List<string>() { "Oracle" };
+        public override IList<string> DatabaseTypeAliases { get; } = new List<string>() { ProcessorId.Oracle };
 
         public IQuoter Quoter => ((OracleGenerator) Generator).Quoter;
 

--- a/src/FluentMigrator.Runner.Postgres/FluentMigrator.Runner.Postgres.csproj
+++ b/src/FluentMigrator.Runner.Postgres/FluentMigrator.Runner.Postgres.csproj
@@ -14,5 +14,6 @@
   <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Extensions.Postgres\FluentMigrator.Extensions.Postgres.csproj" />
     <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
+    <ProjectReference Include="..\FluentMigrator\FluentMigrator.csproj" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.Postgres/Processors/Postgres/Postgres10_0Processor.cs
+++ b/src/FluentMigrator.Runner.Postgres/Processors/Postgres/Postgres10_0Processor.cs
@@ -39,9 +39,9 @@ namespace FluentMigrator.Runner.Processors.Postgres
         {
         }
 
-        public override string DatabaseType => "PostgreSQL10_0";
+        public override string DatabaseType => ProcessorId.PostgreSQL10_0;
 
-        public override IList<string> DatabaseTypeAliases { get; } = new List<string> { "PostgreSQL" };
+        public override IList<string> DatabaseTypeAliases { get; } = new List<string> { ProcessorId.PostgreSQL };
 
     }
 }

--- a/src/FluentMigrator.Runner.Postgres/Processors/Postgres/Postgres11_0Processor.cs
+++ b/src/FluentMigrator.Runner.Postgres/Processors/Postgres/Postgres11_0Processor.cs
@@ -39,9 +39,9 @@ namespace FluentMigrator.Runner.Processors.Postgres
         {
         }
 
-        public override string DatabaseType => "PostgreSQL11_0";
+        public override string DatabaseType => ProcessorId.PostgreSQL11_0;
 
-        public override IList<string> DatabaseTypeAliases { get; } = new List<string> { "PostgreSQL" };
+        public override IList<string> DatabaseTypeAliases { get; } = new List<string> { ProcessorId.PostgreSQL };
 
     }
 }

--- a/src/FluentMigrator.Runner.Postgres/Processors/Postgres/PostgresProcessor.cs
+++ b/src/FluentMigrator.Runner.Postgres/Processors/Postgres/PostgresProcessor.cs
@@ -36,9 +36,9 @@ namespace FluentMigrator.Runner.Processors.Postgres
     {
         private readonly PostgresQuoter _quoter;
 
-        public override string DatabaseType => "Postgres";
+        public override string DatabaseType => ProcessorId.Postgres;
 
-        public override IList<string> DatabaseTypeAliases { get; } = new List<string> { "PostgreSQL" };
+        public override IList<string> DatabaseTypeAliases { get; } = new List<string> { ProcessorId.PostgreSQL };
 
         [Obsolete]
         public PostgresProcessor(IDbConnection connection, IMigrationGenerator generator, IAnnouncer announcer, IMigrationProcessorOptions options, IDbFactory factory,

--- a/src/FluentMigrator.Runner.Redshift/FluentMigrator.Runner.Redshift.csproj
+++ b/src/FluentMigrator.Runner.Redshift/FluentMigrator.Runner.Redshift.csproj
@@ -13,5 +13,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
+    <ProjectReference Include="..\FluentMigrator\FluentMigrator.csproj" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.Redshift/Processors/Redshift/RedshiftProcessor.cs
+++ b/src/FluentMigrator.Runner.Redshift/Processors/Redshift/RedshiftProcessor.cs
@@ -37,7 +37,7 @@ namespace FluentMigrator.Runner.Processors.Redshift
     {
         private readonly RedshiftQuoter _quoter = new RedshiftQuoter();
 
-        public override string DatabaseType => "Redshift";
+        public override string DatabaseType => ProcessorId.Redshift;
 
         public override IList<string> DatabaseTypeAliases { get; } = new List<string>();
 

--- a/src/FluentMigrator.Runner.SQLite/FluentMigrator.Runner.SQLite.csproj
+++ b/src/FluentMigrator.Runner.SQLite/FluentMigrator.Runner.SQLite.csproj
@@ -13,5 +13,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
+    <ProjectReference Include="..\FluentMigrator\FluentMigrator.csproj" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteColumn.cs
+++ b/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteColumn.cs
@@ -86,7 +86,7 @@ namespace FluentMigrator.Runner.Generators.SQLite
         /// <inheritdoc />
         public override bool ShouldPrimaryKeysBeAddedSeparately(IEnumerable<ColumnDefinition> primaryKeyColumns)
         {
-            //If there are no identity column then we can add as a separate constrint
+            // If there are no identity column then we can add as a separate constraint
             var pkColDefs = primaryKeyColumns.ToList();
             return !pkColDefs.Any(x => x.IsIdentity) && pkColDefs.Any(x => x.IsPrimaryKey);
         }

--- a/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteColumn.cs
+++ b/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteColumn.cs
@@ -52,7 +52,7 @@ namespace FluentMigrator.Runner.Generators.SQLite
         {
             var fk2 = (ForeignKeyDefinition)foreignKey.Clone();
 
-            // SQLite FK's most be within the same schema as the FK itself
+            // SQLite FK's must be within the same schema as the FK itself
             // so we'll remove the schema from the FK definition
             fk2.PrimaryTableSchema = string.Empty;
 
@@ -68,7 +68,7 @@ namespace FluentMigrator.Runner.Generators.SQLite
                 // see: http://www.sqlite.org/syntaxdiagrams.html#column-constraint syntax details
                 if (!column.IsPrimaryKey && (!column.Type.HasValue || GetTypeMap(column.Type.Value, null, null) != "INTEGER"))
                 {
-                    throw new ArgumentException("SQLite only supports identity on a single integer, primary key coulmn");
+                    throw new ArgumentException("SQLite only supports identity on a single integer, primary key column");
                 }
 
                 return "AUTOINCREMENT";

--- a/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteColumn.cs
+++ b/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteColumn.cs
@@ -13,6 +13,8 @@ namespace FluentMigrator.Runner.Generators.SQLite
         public SQLiteColumn()
             : base(new SQLiteTypeMap(), new SQLiteQuoter())
         {
+            // Add UNIQUE before IDENTITY and after PRIMARY KEY
+            ClauseOrder.Insert(ClauseOrder.Count - 2, FormatUniqueConstraint);
         }
 
         /// <inheritdoc />
@@ -22,8 +24,15 @@ namespace FluentMigrator.Runner.Generators.SQLite
             var foreignKeyColumns = colDefs.Where(x => x.IsForeignKey && x.ForeignKey != null);
             var foreignKeyClauses = foreignKeyColumns
                 .Select(x => ", " + FormatForeignKey(x.ForeignKey, GenerateForeignKeyName));
+
             // Append foreign key definitions after all column definitions and the primary key definition
             return base.Generate(colDefs, tableName) + string.Concat(foreignKeyClauses);
+        }
+
+        protected virtual string FormatUniqueConstraint(ColumnDefinition column)
+        {
+            // Define unique constraints on columns in addition to creating a unique index
+            return column.IsUnique ? "UNIQUE" : string.Empty;
         }
 
         /// <inheritdoc />

--- a/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteColumn.cs
+++ b/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteColumn.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Linq;
 using FluentMigrator.Model;
 using FluentMigrator.Runner.Generators.Base;
@@ -44,7 +43,7 @@ namespace FluentMigrator.Runner.Generators.SQLite
                 // see: http://www.sqlite.org/syntaxdiagrams.html#column-constraint syntax details
                 if (!column.IsPrimaryKey && (!column.Type.HasValue || GetTypeMap(column.Type.Value, null, null) != "INTEGER"))
                 {
-                    throw new ArgumentException("SQLite only supports identity on a single integer, primary key coulmns");
+                    throw new ArgumentException("SQLite only supports identity on a single integer, primary key coulmn");
                 }
 
                 return "AUTOINCREMENT";
@@ -54,17 +53,17 @@ namespace FluentMigrator.Runner.Generators.SQLite
         }
 
         /// <inheritdoc />
+        protected override string FormatPrimaryKey(ColumnDefinition column)
+        {
+            return column.IsPrimaryKey ? "PRIMARY KEY" : string.Empty;
+        }
+
+        /// <inheritdoc />
         public override bool ShouldPrimaryKeysBeAddedSeparately(IEnumerable<ColumnDefinition> primaryKeyColumns)
         {
             //If there are no identity column then we can add as a separate constrint
             var pkColDefs = primaryKeyColumns.ToList();
             return !pkColDefs.Any(x => x.IsIdentity) && pkColDefs.Any(x => x.IsPrimaryKey);
-        }
-
-        /// <inheritdoc />
-        protected override string FormatPrimaryKey(ColumnDefinition column)
-        {
-            return column.IsPrimaryKey ? "PRIMARY KEY" : string.Empty;
         }
     }
 }

--- a/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteColumn.cs
+++ b/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteColumn.cs
@@ -68,7 +68,7 @@ namespace FluentMigrator.Runner.Generators.SQLite
                 // see: http://www.sqlite.org/syntaxdiagrams.html#column-constraint syntax details
                 if (!column.IsPrimaryKey && (!column.Type.HasValue || GetTypeMap(column.Type.Value, null, null) != "INTEGER"))
                 {
-                    throw new ArgumentException("SQLite only supports identity on a single integer, primary key column");
+                    throw new ArgumentException($"Cannot create identity constraint on column {column.Name}. SQLite only supports identity on a single integer, primary key column.");
                 }
 
                 return "AUTOINCREMENT";

--- a/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteColumn.cs
+++ b/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteColumn.cs
@@ -28,6 +28,11 @@ namespace FluentMigrator.Runner.Generators.SQLite
             return base.Generate(colDefs, tableName) + string.Concat(foreignKeyClauses);
         }
 
+        /// <summary>
+        /// Formats the unique SQL fragment
+        /// </summary>
+        /// <param name="column">The column definition</param>
+        /// <returns>The formatted unique SQL fragment</returns>
         protected virtual string FormatUniqueConstraint(ColumnDefinition column)
         {
             // Define unique constraints on columns in addition to creating a unique index

--- a/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteGenerator.cs
+++ b/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteGenerator.cs
@@ -35,18 +35,21 @@ namespace FluentMigrator.Runner.Generators.SQLite
     {
         public SQLiteGenerator()
             : this(new SQLiteQuoter())
-        { }
+        {
+        }
 
         public SQLiteGenerator(
             [NotNull] SQLiteQuoter quoter)
             : this(quoter, new OptionsWrapper<GeneratorOptions>(new GeneratorOptions()))
-        { }
+        {
+        }
 
         public SQLiteGenerator(
             [NotNull] SQLiteQuoter quoter,
             [NotNull] IOptions<GeneratorOptions> generatorOptions)
             : base(new SQLiteColumn(), quoter, new EmptyDescriptionGenerator(), generatorOptions)
-        { }
+        {
+        }
 
         public override string RenameTable { get { return "ALTER TABLE {0} RENAME TO {1}"; } }
         public override string RenameColumn { get { return "ALTER TABLE {0} RENAME COLUMN {1} TO {2}"; } }

--- a/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteGenerator.cs
+++ b/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteGenerator.cs
@@ -49,6 +49,7 @@ namespace FluentMigrator.Runner.Generators.SQLite
             [NotNull] IOptions<GeneratorOptions> generatorOptions)
             : base(new SQLiteColumn(), quoter, new EmptyDescriptionGenerator(), generatorOptions)
         {
+            CompatibilityMode = generatorOptions.Value.CompatibilityMode ?? CompatibilityMode.STRICT;
         }
 
         public override string RenameTable { get { return "ALTER TABLE {0} RENAME TO {1}"; } }
@@ -61,11 +62,6 @@ namespace FluentMigrator.Runner.Generators.SQLite
 
         public override string Generate(RenameColumnExpression expression)
         {
-            if (CompatibilityMode == CompatibilityMode.STRICT)
-            {
-                return CompatibilityMode.HandleCompatibilty("SQLite does not support renaming of columns");
-            }
-
             return string.Format(
                 RenameColumn,
                 Quoter.QuoteTableName(expression.TableName, expression.SchemaName),

--- a/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteQuoter.cs
+++ b/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteQuoter.cs
@@ -20,7 +20,21 @@ namespace FluentMigrator.Runner.Generators.SQLite
 
         public override string QuoteSchemaName(string schemaName)
         {
-            return string.Empty;
+            // SQLite doesn't support Schemas in the same sense as traditional SQL Server does,
+            // instead it allows multiple databases to be attached to the current DB connection
+            // and those attached DB's have an `alias` that can be used as a prefix similar to schemas.
+            // As this is nearest paradigm in FM, we'll allow schemas to be defined and generate the
+            // relevant SQL, however we don't currently have an approach for attaching databases
+            // so we'll have to currently assume that the implementor does this.
+            // See: https://www.sqlite.org/lang_attach.html  and https://www.sqlite.org/lang_naming.html
+            return base.QuoteSchemaName(schemaName);
+        }
+
+        public override string QuoteIndexName(string indexName, string schemaName)
+        {
+            return CreateSchemaPrefixedQuotedIdentifier(
+                QuoteSchemaName(schemaName),
+                IsQuoted(indexName) ? indexName : Quote(indexName));
         }
 
         protected override string FormatByteArray(byte[] value)

--- a/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteQuoter.cs
+++ b/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteQuoter.cs
@@ -20,7 +20,7 @@ namespace FluentMigrator.Runner.Generators.SQLite
 
         public override string QuoteSchemaName(string schemaName)
         {
-            // SQLite doesn't support Schemas in the same sense as traditional SQL Server does,
+            // SQLite doesn't support Schemas in the same sense as other SQL databases (e.g. SQL Server) does,
             // instead it allows multiple databases to be attached to the current DB connection
             // and those attached DB's have an `alias` that can be used as a prefix similar to schemas.
             // As this is nearest paradigm in FM, we'll allow schemas to be defined and generate the

--- a/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteDbFactory.cs
+++ b/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteDbFactory.cs
@@ -25,9 +25,9 @@ namespace FluentMigrator.Runner.Processors.SQLite
     {
         private static readonly TestEntry[] _testEntries =
         {
+            new TestEntry("Microsoft.Data.Sqlite", "Microsoft.Data.Sqlite.SqliteFactory"),
             new TestEntry("System.Data.SQLite", "System.Data.SQLite.SQLiteFactory"),
             new TestEntry("Mono.Data.Sqlite, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756", "Mono.Data.Sqlite.SqliteFactory"),
-            new TestEntry("Microsoft.Data.Sqlite", "Microsoft.Data.Sqlite.SqliteFactory"),
         };
 
         [Obsolete]

--- a/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteProcessor.cs
+++ b/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteProcessor.cs
@@ -103,7 +103,10 @@ namespace FluentMigrator.Runner.Processors.SQLite
 
         public override bool ConstraintExists(string schemaName, string tableName, string constraintName)
         {
-            return false;
+            return Exists("select count(*) from {2}sqlite_master where name={0} and tbl_name={1} and type='index' and sql LIKE 'CREATE UNIQUE INDEX %'",
+                   _quoter.QuoteValue(constraintName),
+                   _quoter.QuoteValue(tableName),
+                   !string.IsNullOrWhiteSpace(schemaName) ? _quoter.QuoteValue(schemaName) + "." : string.Empty);
         }
 
         public override bool IndexExists(string schemaName, string tableName, string indexName)

--- a/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteProcessor.cs
+++ b/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteProcessor.cs
@@ -47,10 +47,7 @@ namespace FluentMigrator.Runner.Processors.SQLite
         [NotNull]
         private readonly SQLiteQuoter _quoter;
 
-        public override string DatabaseType
-        {
-            get { return "SQLite"; }
-        }
+        public override string DatabaseType => ProcessorId.SQLite;
 
         public override IList<string> DatabaseTypeAliases { get; } = new List<string>();
 

--- a/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteProcessor.cs
+++ b/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteProcessor.cs
@@ -88,12 +88,17 @@ namespace FluentMigrator.Runner.Processors.SQLite
 
         public override bool TableExists(string schemaName, string tableName)
         {
-            return Exists("select count(*) from sqlite_master where name={0} and type='table'", _quoter.QuoteValue(tableName));
+            return Exists("select count(*) from {1}sqlite_master where name={0} and type='table'",
+                _quoter.QuoteValue(tableName),
+                !string.IsNullOrWhiteSpace(schemaName) ? _quoter.QuoteValue(schemaName) + "." : string.Empty);
         }
 
         public override bool ColumnExists(string schemaName, string tableName, string columnName)
         {
-            return Exists("select count(*) from sqlite_master AS t, pragma_table_info(t.name) AS c where t.type = 'table' AND t.name = {0} AND c.name = {1}", _quoter.QuoteValue(tableName), _quoter.QuoteValue(columnName));
+            return Exists("select count(*) from {2}sqlite_master AS t, {2}pragma_table_info(t.name) AS c where t.type = 'table' AND t.name = {0} AND c.name = {1}",
+                _quoter.QuoteValue(tableName),
+                _quoter.QuoteValue(columnName),
+                !string.IsNullOrWhiteSpace(schemaName) ? _quoter.QuoteValue(schemaName) + "." : string.Empty);
         }
 
         public override bool ConstraintExists(string schemaName, string tableName, string constraintName)
@@ -103,7 +108,10 @@ namespace FluentMigrator.Runner.Processors.SQLite
 
         public override bool IndexExists(string schemaName, string tableName, string indexName)
         {
-            return Exists("select count(*) from sqlite_master where name={0} and tbl_name={1} and type='index'", _quoter.QuoteValue(indexName), _quoter.QuoteValue(tableName));
+            return Exists("select count(*) from {2}sqlite_master where name={0} and tbl_name={1} and type='index'",
+                _quoter.QuoteValue(indexName),
+                _quoter.QuoteValue(tableName),
+                !string.IsNullOrWhiteSpace(schemaName) ? _quoter.QuoteValue(schemaName) + "." : string.Empty);
         }
 
         public override bool SequenceExists(string schemaName, string sequenceName)
@@ -138,7 +146,7 @@ namespace FluentMigrator.Runner.Processors.SQLite
 
         public override DataSet ReadTableData(string schemaName, string tableName)
         {
-            return Read("select * from {0}", _quoter.QuoteTableName(tableName));
+            return Read("select * from {0}", _quoter.QuoteTableName(tableName, schemaName));
         }
 
         public override bool DefaultValueExists(string schemaName, string tableName, string columnName, object defaultValue)

--- a/src/FluentMigrator.Runner.SqlAnywhere/FluentMigrator.Runner.SqlAnywhere.csproj
+++ b/src/FluentMigrator.Runner.SqlAnywhere/FluentMigrator.Runner.SqlAnywhere.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Extensions.SqlAnywhere\FluentMigrator.Extensions.SqlAnywhere.csproj" />
     <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
+    <ProjectReference Include="..\FluentMigrator\FluentMigrator.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Generators\" />

--- a/src/FluentMigrator.Runner.SqlAnywhere/Processors/SqlAnywhere/SqlAnywhere16Processor.cs
+++ b/src/FluentMigrator.Runner.SqlAnywhere/Processors/SqlAnywhere/SqlAnywhere16Processor.cs
@@ -40,7 +40,7 @@ namespace FluentMigrator.Runner.Processors.SqlAnywhere
             [NotNull] IConnectionStringAccessor connectionStringAccessor,
             [NotNull] IServiceProvider serviceProvider)
             : base(
-                "SqlAnywhere16",
+                ProcessorId.SqlAnywhere16,
                 () => factory.Factory,
                 generator,
                 logger,

--- a/src/FluentMigrator.Runner.SqlAnywhere/Processors/SqlAnywhere/SqlAnywhereProcessor.cs
+++ b/src/FluentMigrator.Runner.SqlAnywhere/Processors/SqlAnywhere/SqlAnywhereProcessor.cs
@@ -58,7 +58,7 @@ namespace FluentMigrator.Runner.Processors.SqlAnywhere
 
         public override string DatabaseType { get; }
 
-        public override IList<string> DatabaseTypeAliases { get; } = new List<string> { "SqlAnywhere" };
+        public override IList<string> DatabaseTypeAliases { get; } = new List<string> { ProcessorId.SqlAnywhere };
 
         [Obsolete]
         public SqlAnywhereProcessor(string databaseType, IDbConnection connection, IMigrationGenerator generator, IAnnouncer announcer, IMigrationProcessorOptions options, IDbFactory factory)

--- a/src/FluentMigrator.Runner.SqlServer/FluentMigrator.Runner.SqlServer.csproj
+++ b/src/FluentMigrator.Runner.SqlServer/FluentMigrator.Runner.SqlServer.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Extensions.SqlServer\FluentMigrator.Extensions.SqlServer.csproj" />
     <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
+    <ProjectReference Include="..\FluentMigrator\FluentMigrator.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient">

--- a/src/FluentMigrator.Runner.SqlServer/Processors/SqlServer/SqlServer2000Processor.cs
+++ b/src/FluentMigrator.Runner.SqlServer/Processors/SqlServer/SqlServer2000Processor.cs
@@ -92,9 +92,9 @@ namespace FluentMigrator.Runner.Processors.SqlServer
             _serviceProvider = serviceProvider;
         }
 
-        public override string DatabaseType => "SqlServer2000";
+        public override string DatabaseType => ProcessorId.SqlServer2000;
 
-        public override IList<string> DatabaseTypeAliases { get; } = new List<string>() { "SqlServer" };
+        public override IList<string> DatabaseTypeAliases { get; } = new List<string>() { ProcessorId.SqlServer };
 
         public override void BeginTransaction()
         {

--- a/src/FluentMigrator.Runner.SqlServer/Processors/SqlServer/SqlServer2005Processor.cs
+++ b/src/FluentMigrator.Runner.SqlServer/Processors/SqlServer/SqlServer2005Processor.cs
@@ -36,7 +36,7 @@ namespace FluentMigrator.Runner.Processors.SqlServer
             [NotNull] IOptionsSnapshot<ProcessorOptions> options,
             [NotNull] IConnectionStringAccessor connectionStringAccessor,
             [NotNull] IServiceProvider serviceProvider)
-            : base(new[] { "SqlServer2005", "SqlServer" }, generator, quoter, logger, options, connectionStringAccessor, serviceProvider)
+            : base(new[] { ProcessorId.SqlServer2005, ProcessorId.SqlServer }, generator, quoter, logger, options, connectionStringAccessor, serviceProvider)
         {
         }
     }

--- a/src/FluentMigrator.Runner.SqlServer/Processors/SqlServer/SqlServer2008Processor.cs
+++ b/src/FluentMigrator.Runner.SqlServer/Processors/SqlServer/SqlServer2008Processor.cs
@@ -36,7 +36,7 @@ namespace FluentMigrator.Runner.Processors.SqlServer
             [NotNull] IOptionsSnapshot<ProcessorOptions> options,
             [NotNull] IConnectionStringAccessor connectionStringAccessor,
             [NotNull] IServiceProvider serviceProvider)
-            : base(new[] { "SqlServer2008", "SqlServer" }, generator, quoter, logger, options, connectionStringAccessor, serviceProvider)
+            : base(new[] { ProcessorId.SqlServer2008, ProcessorId.SqlServer }, generator, quoter, logger, options, connectionStringAccessor, serviceProvider)
         {
         }
     }

--- a/src/FluentMigrator.Runner.SqlServer/Processors/SqlServer/SqlServer2012Processor.cs
+++ b/src/FluentMigrator.Runner.SqlServer/Processors/SqlServer/SqlServer2012Processor.cs
@@ -36,7 +36,7 @@ namespace FluentMigrator.Runner.Processors.SqlServer
             [NotNull] IOptionsSnapshot<ProcessorOptions> options,
             [NotNull] IConnectionStringAccessor connectionStringAccessor,
             [NotNull] IServiceProvider serviceProvider)
-            : base(new[] { "SqlServer2012", "SqlServer" }, generator, quoter, logger, options, connectionStringAccessor, serviceProvider)
+            : base(new[] { ProcessorId.SqlServer2012, ProcessorId.SqlServer }, generator, quoter, logger, options, connectionStringAccessor, serviceProvider)
         {
         }
     }

--- a/src/FluentMigrator.Runner.SqlServer/Processors/SqlServer/SqlServer2014Processor.cs
+++ b/src/FluentMigrator.Runner.SqlServer/Processors/SqlServer/SqlServer2014Processor.cs
@@ -36,7 +36,7 @@ namespace FluentMigrator.Runner.Processors.SqlServer
             [NotNull] IOptionsSnapshot<ProcessorOptions> options,
             [NotNull] IConnectionStringAccessor connectionStringAccessor,
             [NotNull] IServiceProvider serviceProvider)
-            : base(new[] { "SqlServer2014", "SqlServer" }, generator, quoter, logger, options, connectionStringAccessor, serviceProvider)
+            : base(new[] { ProcessorId.SqlServer2014, ProcessorId.SqlServer }, generator, quoter, logger, options, connectionStringAccessor, serviceProvider)
         {
         }
     }

--- a/src/FluentMigrator.Runner.SqlServer/Processors/SqlServer/SqlServer2016Processor.cs
+++ b/src/FluentMigrator.Runner.SqlServer/Processors/SqlServer/SqlServer2016Processor.cs
@@ -59,7 +59,7 @@ namespace FluentMigrator.Runner.Processors.SqlServer
             [NotNull] IConnectionStringAccessor connectionStringAccessor,
             [NotNull] IServiceProvider serviceProvider)
             : base(
-                new[] { "SqlServer2016", "SqlServer" },
+                new[] { ProcessorId.SqlServer2016, ProcessorId.SqlServer },
                 factory,
                 generator,
                 quoter,

--- a/src/FluentMigrator.Runner.SqlServerCe/FluentMigrator.Runner.SqlServerCe.csproj
+++ b/src/FluentMigrator.Runner.SqlServerCe/FluentMigrator.Runner.SqlServerCe.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Runner.SqlServer\FluentMigrator.Runner.SqlServer.csproj" />
+    <ProjectReference Include="..\FluentMigrator\FluentMigrator.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Security.Permissions" Version="4.7.0" />

--- a/src/FluentMigrator.Runner.SqlServerCe/Processors/SqlServer/SqlServerCeProcessor.cs
+++ b/src/FluentMigrator.Runner.SqlServerCe/Processors/SqlServer/SqlServerCeProcessor.cs
@@ -40,9 +40,9 @@ namespace FluentMigrator.Runner.Processors.SqlServer
         [CanBeNull]
         private readonly IServiceProvider _serviceProvider;
 
-        public override string DatabaseType => "SqlServerCe";
+        public override string DatabaseType => ProcessorId.SqlServerCe;
 
-        public override IList<string> DatabaseTypeAliases { get; } = new List<string> { "SqlServer" };
+        public override IList<string> DatabaseTypeAliases { get; } = new List<string> { ProcessorId.SqlServer };
 
         [Obsolete]
         public SqlServerCeProcessor(IDbConnection connection, IMigrationGenerator generator, IAnnouncer announcer, IMigrationProcessorOptions options, IDbFactory factory)

--- a/src/FluentMigrator/ProcessorId.cs
+++ b/src/FluentMigrator/ProcessorId.cs
@@ -1,0 +1,34 @@
+namespace FluentMigrator
+{
+    public static class ProcessorId
+    {
+        public const string DB2 = nameof(DB2);
+        public const string Db2ISeries = nameof(Db2ISeries);
+        public const string Firebird = nameof(Firebird);
+        public const string Hana = nameof(Hana);
+        public const string Jet = nameof(Jet); 
+        public const string MariaDB = nameof(MariaDB);
+        public const string MySql = nameof(MySql); 
+        public const string MySql4 = nameof(MySql4);
+        public const string MySql5 = nameof(MySql5);
+        public const string Oracle = nameof(Oracle);
+        public const string OracleManaged = nameof(OracleManaged);
+        public const string Oracle12c = nameof(Oracle12c);
+        public const string Postgres = nameof(Postgres);
+        public const string PostgreSQL = nameof(PostgreSQL);
+        public const string PostgreSQL10_0 = nameof(PostgreSQL10_0);
+        public const string PostgreSQL11_0 = nameof(PostgreSQL11_0);
+        public const string Redshift = nameof(Redshift);
+        public const string SqlAnywhere = nameof(SqlAnywhere);
+        public const string SqlAnywhere16 = nameof(SqlAnywhere16);
+        public const string SQLite = nameof(SQLite);
+        public const string SqlServer = nameof(SqlServer);
+        public const string SqlServer2000 = nameof(SqlServer2000);
+        public const string SqlServer2005 = nameof(SqlServer2005);
+        public const string SqlServer2008 = nameof(SqlServer2008);
+        public const string SqlServer2012 = nameof(SqlServer2012);
+        public const string SqlServer2014 = nameof(SqlServer2014);
+        public const string SqlServer2016 = nameof(SqlServer2016);
+        public const string SqlServerCe = nameof(SqlServerCe);
+    }
+}

--- a/test/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/test/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Autofac" Version="5.1.2" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.4.0" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="5.12.1" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.4" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.16" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.1" />

--- a/test/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/test/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Autofac" Version="5.1.2" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.4.0" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="5.12.1" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.16" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.1" />
@@ -31,6 +31,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Sap.Data.SQLAnywhere" Version="17.0.7.3399" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\FluentMigrator.Console\FluentMigrator.Console.csproj" />

--- a/test/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/test/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Autofac" Version="5.1.2" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.4.0" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="5.12.1" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.16" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.1" />

--- a/test/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/test/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Autofac" Version="5.1.2" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.4.0" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="5.12.1" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.16" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.1" />

--- a/test/FluentMigrator.Tests/Integration/IntegrationTestBase.cs
+++ b/test/FluentMigrator.Tests/Integration/IntegrationTestBase.cs
@@ -178,8 +178,6 @@ namespace FluentMigrator.Tests.Integration
             if (!serverOptions.IsEnabled)
                 Assert.Ignore($"The configuration for {processorType.Name} is not enabled.");
 
-            serverOptions = serverOptions.ReplaceConnectionStringDataDirectory(_tempDataDirectory);
-
             var services = ServiceCollectionExtensions.CreateServices()
                 .ConfigureRunner(
                     r => r

--- a/test/FluentMigrator.Tests/Integration/MigrationRunnerTests.cs
+++ b/test/FluentMigrator.Tests/Integration/MigrationRunnerTests.cs
@@ -650,7 +650,6 @@ namespace FluentMigrator.Tests.Integration
                         processor.TableExists(null, "Users").ShouldBeFalse();
                     },
                     false,
-                    typeof(SQLiteProcessor),
                     typeof(SqlAnywhere16Processor));
             }
             finally
@@ -884,10 +883,6 @@ namespace FluentMigrator.Tests.Integration
 
             try
             {
-                // Excluded SqliteProcessor as it errors on DB cleanup (RollbackToVersion)
-                // which I believe is because we are using it in in-memory mode and so
-                // the exception causes it to reset
-
                 ExecuteWithSupportedProcessors(
                     services => services.WithMigrationsIn(migrationsNamespace).Configure<RunnerOptions>(opt => opt.Tags = new[] { "TenantA" }),
                     (serviceProvider, processor) =>
@@ -901,7 +896,7 @@ namespace FluentMigrator.Tests.Integration
                         processor.TableExists(null, "TenantAandBTable").ShouldBeTrue();
                     },
                     false,
-                    typeof(SQLiteProcessor), typeof(SqlAnywhere16Processor));
+                    typeof(SqlAnywhere16Processor));
 
                 ExecuteWithSupportedProcessors(
                     services => services.WithMigrationsIn(migrationsNamespace).Configure<RunnerOptions>(opt => opt.Tags = new[] { "TenantB" }),
@@ -916,7 +911,7 @@ namespace FluentMigrator.Tests.Integration
                         processor.TableExists(null, "TenantAandBTable").ShouldBeFalse();
                     },
                     false,
-                    typeof(SQLiteProcessor), typeof(SqlAnywhere16Processor));
+                    typeof(SqlAnywhere16Processor));
             }
             finally
             {
@@ -928,7 +923,7 @@ namespace FluentMigrator.Tests.Integration
                         runner.RollbackToVersion(0, false);
                     },
                     false,
-                    typeof(SQLiteProcessor), typeof(SqlAnywhere16Processor));
+                    typeof(SqlAnywhere16Processor));
             }
         }
 
@@ -1041,8 +1036,7 @@ namespace FluentMigrator.Tests.Integration
         [Category("SqlServer2016")]
         public void ValidateVersionOrderShouldDoNothingIfUnappliedMigrationVersionIsGreaterThanLatestAppliedMigration()
         {
-            // Using SqlServer instead of SQLite as versions not deleted from VersionInfo table when using Sqlite.
-            var excludedProcessors = new[] { typeof(SQLiteProcessor), typeof(MySqlProcessor), typeof(PostgresProcessor), typeof(SqlAnywhere16Processor) };
+            var excludedProcessors = new[] { typeof(MySqlProcessor), typeof(PostgresProcessor), typeof(SqlAnywhere16Processor) };
 
             var namespacePass2 = typeof(Migrations.Interleaved.Pass2.User).Namespace;
             var namespacePass3 = typeof(Migrations.Interleaved.Pass3.User).Namespace;
@@ -1098,8 +1092,7 @@ namespace FluentMigrator.Tests.Integration
         [Category("SqlServer2016")]
         public void ValidateVersionOrderShouldThrowExceptionIfUnappliedMigrationVersionIsLessThanLatestAppliedMigration()
         {
-            // Using SqlServer instead of SQLite as versions not deleted from VersionInfo table when using Sqlite.
-            var excludedProcessors = new[] { typeof(MySqlProcessor), typeof(SQLiteProcessor), typeof(SqlAnywhere16Processor) };
+            var excludedProcessors = new[] { typeof(MySqlProcessor), typeof(SqlAnywhere16Processor) };
 
             var namespacePass2 = typeof(Migrations.Interleaved.Pass2.User).Namespace;
             var namespacePass3 = typeof(Migrations.Interleaved.Pass3.User).Namespace;

--- a/test/FluentMigrator.Tests/Integration/MigrationRunnerTests.cs
+++ b/test/FluentMigrator.Tests/Integration/MigrationRunnerTests.cs
@@ -1850,7 +1850,7 @@ namespace FluentMigrator.Tests.Integration
     {
         public override void Up()
         {
-            // NB: SQLite only supports FK's defined in the create statement so
+            // SQLite only supports FK's defined in the create statement so
             // we ensure this is the only approach used so that SQLite can
             // successfully tested. At time of implementing, the FK constraint
             // wasn't explicitly used by any tests and so should affect anything.
@@ -1977,7 +1977,7 @@ namespace FluentMigrator.Tests.Integration
     {
         public override void Up()
         {
-            // NB: SQLite only supports FK's defined in the create statement so
+            // SQLite only supports FK's defined in the create statement so
             // we ensure this is the only approach used so that SQLite can
             // successfully tested. At time of implementing, the FK constraint
             // wasn't explicitly used by any tests and so should affect anything.

--- a/test/FluentMigrator.Tests/Integration/MigrationRunnerTests.cs
+++ b/test/FluentMigrator.Tests/Integration/MigrationRunnerTests.cs
@@ -1944,12 +1944,12 @@ namespace FluentMigrator.Tests.Integration
         {
             // SQLite doesn't support creating schemas so for non SQLite DB's we'll create
             // the schema, but for SQLite we'll attach a temp DB with the schema alias
-            var createSchemaExpr = IfDatabase(t => t != "SQLite").Create.Schema("TestSchema");
+            var createSchemaExpr = IfDatabase(t => t != ProcessorId.SQLite).Create.Schema("TestSchema");
 
-            IfDatabase(t => t.StartsWith("SqlAnywhere"))
+            IfDatabase(t => t.StartsWith(ProcessorId.SqlAnywhere))
                 .Delegate(() => createSchemaExpr.Password("TestSchemaPassword"));
 
-            IfDatabase("SQLite").Execute.Sql("ATTACH DATABASE '' AS \"TestSchema\"");
+            IfDatabase(ProcessorId.SQLite).Execute.Sql("ATTACH DATABASE '' AS \"TestSchema\"");
 
             Create.Table("Users")
                 .InSchema("TestSchema")
@@ -1965,11 +1965,11 @@ namespace FluentMigrator.Tests.Integration
         {
             Delete.Index("IX_Users_GroupId").OnTable("Users").InSchema("TestSchema").OnColumn("GroupId");
             Delete.Table("Users").InSchema("TestSchema");
-            IfDatabase(t => t != "SQLite").Delete.Schema("TestSchema");
+            IfDatabase(t => t != ProcessorId.SQLite).Delete.Schema("TestSchema");
 
             // Can't actually detatch SQLite DB here as migrations run in a transaction
             // and you can't detach a database whilst in a transaction
-            // IfDatabase("SQLite").Execute.Sql("DETACH DATABASE \"TestSchema\"");
+            // IfDatabase(ProcessorId.SQLite).Execute.Sql("DETACH DATABASE \"TestSchema\"");
         }
     }
 
@@ -2043,21 +2043,21 @@ namespace FluentMigrator.Tests.Integration
         {
             // SQLite doesn't support creating schemas so for non SQLite DB's we'll create
             // the schema, but for SQLite we'll attach a temp DB with the schema alias
-            var createSchemaExpr = IfDatabase(t => t != "SQLite").Create.Schema("TestSchema");
+            var createSchemaExpr = IfDatabase(t => t != ProcessorId.SQLite).Create.Schema("TestSchema");
 
-            IfDatabase(t => t.StartsWith("SqlAnywhere"))
+            IfDatabase(t => t.StartsWith(ProcessorId.SqlAnywhere))
                 .Delegate(() => createSchemaExpr.Password("TestSchemaPassword"));
 
-            IfDatabase("SQLite").Execute.Sql("ATTACH DATABASE '' AS \"TestSchema\"");
+            IfDatabase(ProcessorId.SQLite).Execute.Sql("ATTACH DATABASE '' AS \"TestSchema\"");
         }
 
         public override void Down()
         {
-            IfDatabase(t => t != "SQLite").Delete.Schema("TestSchema");
+            IfDatabase(t => t != ProcessorId.SQLite).Delete.Schema("TestSchema");
 
             // Can't actually detatch SQLite DB here as migrations run in a transaction
             // and you can't detach a database whilst in a transaction
-            // IfDatabase("SQLite").Execute.Sql("DETACH DATABASE \"TestSchema\"");
+            // IfDatabase(ProcessorId.SQLite).Execute.Sql("DETACH DATABASE \"TestSchema\"");
         }
     }
 

--- a/test/FluentMigrator.Tests/Integration/MigrationRunnerTests.cs
+++ b/test/FluentMigrator.Tests/Integration/MigrationRunnerTests.cs
@@ -623,10 +623,6 @@ namespace FluentMigrator.Tests.Integration
         {
             try
             {
-                // Can't currently test SQLite as we are using in-memory mode
-                // which I believe gets reset on each scope and so assertions
-                // outside scopes fail
-
                 ExecuteWithSupportedProcessors(
                     services => services.WithMigrationsIn(RootNamespace),
                     (serviceProvider, processor) =>

--- a/test/FluentMigrator.Tests/Integration/Migrations/TestMigration.cs
+++ b/test/FluentMigrator.Tests/Integration/Migrations/TestMigration.cs
@@ -25,7 +25,7 @@ namespace FluentMigrator.Tests.Integration.Migrations
     {
         public override void Up()
         {
-            // NB: SQLite only supports FK's defined in the create statement so
+            // SQLite only supports FK's defined in the create statement so
             // we ensure this is the only approach used so that SQLite can
             // successfully tested. At time of implementing, the FK constraint
             // wasn't explicitly used by any tests and so should affect anything.

--- a/test/FluentMigrator.Tests/Integration/Migrations/TestMigration.cs
+++ b/test/FluentMigrator.Tests/Integration/Migrations/TestMigration.cs
@@ -25,9 +25,14 @@ namespace FluentMigrator.Tests.Integration.Migrations
     {
         public override void Up()
         {
+            // NB: SQLite only supports FK's defined in the create statement so
+            // we ensure this is the only approach used so that SQLite can
+            // successfully tested. At time of implementing, the FK constraint
+            // wasn't explicitly used by any tests and so should affect anything.
+
             Create.Table("Users")
                 .WithColumn("UserId").AsInt32().Identity().PrimaryKey()
-                .WithColumn("GroupId").AsInt32().NotNullable()
+                .WithColumn("GroupId").AsInt32().NotNullable().ForeignKey("Groups", "GroupId")
                 .WithColumn("UserName").AsString(32).NotNullable()
                 .WithColumn("Password").AsString(32).NotNullable();
 
@@ -36,12 +41,6 @@ namespace FluentMigrator.Tests.Integration.Migrations
                 .WithColumn("Name").AsString(32).NotNullable();
 
             Create.Column("Foo").OnTable("Users").AsInt16().Indexed().WithDefaultValue(1);
-
-            //commenting out the FK so it passes the sqlite tests
-            Create.ForeignKey()
-                .FromTable("Users").ForeignColumn("GroupId")
-                .ToTable("Groups").PrimaryColumn("GroupId");
-            //Create.ForeignKey("FK_Foo").FromTable("Users").ForeignColumn("GroupId").ToTable("Groups").PrimaryColumn("GroupId");
 
             Create.Table("Foo")
                 .WithColumn("Fizz").AsString(32);

--- a/test/FluentMigrator.Tests/Integration/Migrations/TestSetExistingRowValuesMigration.cs
+++ b/test/FluentMigrator.Tests/Integration/Migrations/TestSetExistingRowValuesMigration.cs
@@ -7,13 +7,16 @@ namespace FluentMigrator.Tests.Integration.Migrations
    {
       public override void Up()
       {
-         IfDatabase(t => t != "SQLite").Alter.Table("Bar")
+         // SQLite doesn't support altering tables so we can't set the LastLoginDate
+         // to be nullable and then change it to nullable once populated so we allow
+         // this for non-SQLite setups but for SQLite we just set the column as nullable
+         IfDatabase(t => t != ProcessorId.SQLite).Alter.Table("Bar")
              .AddColumn("LastLoginDate")
              .AsDateTime()
              .NotNullable()
              .SetExistingRowsTo(DateTime.Today);
 
-        IfDatabase("SQLite").Alter.Table("Bar")
+        IfDatabase(ProcessorId.SQLite).Alter.Table("Bar")
              .AddColumn("LastLoginDate")
              .AsDateTime()
              .Nullable()

--- a/test/FluentMigrator.Tests/Integration/Migrations/TestSetExistingRowValuesMigration.cs
+++ b/test/FluentMigrator.Tests/Integration/Migrations/TestSetExistingRowValuesMigration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace FluentMigrator.Tests.Integration.Migrations
 {
@@ -7,12 +7,18 @@ namespace FluentMigrator.Tests.Integration.Migrations
    {
       public override void Up()
       {
-         Alter.Table("Bar")
+         IfDatabase(t => t != "SQLite").Alter.Table("Bar")
              .AddColumn("LastLoginDate")
              .AsDateTime()
              .NotNullable()
              .SetExistingRowsTo(DateTime.Today);
-      }
+
+        IfDatabase("SQLite").Alter.Table("Bar")
+             .AddColumn("LastLoginDate")
+             .AsDateTime()
+             .Nullable()
+             .SetExistingRowsTo(DateTime.Today);
+        }
 
       public override void Down()
       {

--- a/test/FluentMigrator.Tests/Integration/Migrations/TestUpdateAllRowsMigration.cs
+++ b/test/FluentMigrator.Tests/Integration/Migrations/TestUpdateAllRowsMigration.cs
@@ -16,7 +16,7 @@ namespace FluentMigrator.Tests.Integration.Migrations
                 .Set(new { SomeDate = DateTime.Today })
                 .AllRows();
 
-            IfDatabase(t => t != "SQLite").Alter.Table("Bar")
+            IfDatabase(t => t != ProcessorId.SQLite).Alter.Table("Bar")
                 .AlterColumn("SomeDate")
                 .AsDateTime()
                 .NotNullable();

--- a/test/FluentMigrator.Tests/Integration/Migrations/TestUpdateAllRowsMigration.cs
+++ b/test/FluentMigrator.Tests/Integration/Migrations/TestUpdateAllRowsMigration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace FluentMigrator.Tests.Integration.Migrations
 {
@@ -16,7 +16,7 @@ namespace FluentMigrator.Tests.Integration.Migrations
                 .Set(new { SomeDate = DateTime.Today })
                 .AllRows();
 
-            Alter.Table("Bar")
+            IfDatabase(t => t != "SQLite").Alter.Table("Bar")
                 .AlterColumn("SomeDate")
                 .AsDateTime()
                 .NotNullable();

--- a/test/FluentMigrator.Tests/Integration/ObsoleteIntegrationTestBase.cs
+++ b/test/FluentMigrator.Tests/Integration/ObsoleteIntegrationTestBase.cs
@@ -60,8 +60,6 @@ namespace FluentMigrator.Tests.Integration
 
         private string _tempDataDirectory;
 
-        private static string _sqliteDbPath = null;
-
         protected ObsoleteIntegrationTestBase()
         {
             _processors = new List<(Type, Func<IntegrationTestOptions.DatabaseServerOptions>, ExecuteTestDelegate)>
@@ -100,18 +98,6 @@ namespace FluentMigrator.Tests.Integration
             {
                 Directory.Delete(_tempDataDirectory, true);
             }
-        }
-
-        [SetUp]
-        public void SetUpSqlite()
-        {
-            _sqliteDbPath = Path.Combine(_tempDataDirectory, Guid.NewGuid().ToString("N") + ".db");
-        }
-
-        [TearDown]
-        public void TearDownSqlite()
-        {
-            _sqliteDbPath = null;
         }
 
         protected bool IsAnyServerEnabled(params Type[] exceptProcessors)
@@ -172,8 +158,6 @@ namespace FluentMigrator.Tests.Integration
 
                 if (!isMatch(processorType))
                     continue;
-
-                opt.ReplaceConnectionStringDataDirectory(_tempDataDirectory);
 
                 executed = true;
                 executeFunc(test, tryRollback, opt);
@@ -266,7 +250,7 @@ namespace FluentMigrator.Tests.Integration
             using (var connection = factory.Factory.CreateConnection())
             {
                 Debug.Assert(connection != null, nameof(connection) + " != null");
-                connection.ConnectionString = $"Data Source={ _sqliteDbPath };Pooling=false;";
+                connection.ConnectionString = serverOptions.ConnectionString;
                 connection.Open();
 
                 using (var processor = new SQLiteProcessor(connection, new SQLiteGenerator(), announcer, new ProcessorOptions(), factory, new SQLiteQuoter()))

--- a/test/FluentMigrator.Tests/Integration/ObsoleteIntegrationTestBase.cs
+++ b/test/FluentMigrator.Tests/Integration/ObsoleteIntegrationTestBase.cs
@@ -173,6 +173,8 @@ namespace FluentMigrator.Tests.Integration
                 if (!isMatch(processorType))
                     continue;
 
+                opt.ReplaceConnectionStringDataDirectory(_tempDataDirectory);
+
                 executed = true;
                 executeFunc(test, tryRollback, opt);
             }

--- a/test/FluentMigrator.Tests/Integration/ObsoleteMigrationRunnerTests.cs
+++ b/test/FluentMigrator.Tests/Integration/ObsoleteMigrationRunnerTests.cs
@@ -242,9 +242,7 @@ namespace FluentMigrator.Tests.Integration
                     processor.ConstraintExists(null, "Users", "UC_Users_GroupId").ShouldBeFalse();
                     processor.ConstraintExists(null, "Users", "UC_Users_AccountId").ShouldBeFalse();
                     processor.TableExists(null, "Users").ShouldBeFalse();
-                },
-                false,
-                typeof(SQLiteProcessor));
+                });
         }
 
         [Test]
@@ -341,7 +339,9 @@ namespace FluentMigrator.Tests.Integration
 
                     runner.Down(new TestCreateSchema());
                     //processor.CommitTransaction();
-                }, false, new[] { typeof(SQLiteProcessor), typeof(FirebirdProcessor) });
+                },
+                false,
+                typeof(FirebirdProcessor));
         }
 
         [Test]
@@ -451,7 +451,7 @@ namespace FluentMigrator.Tests.Integration
 
                     runner.Down(new TestCreateAndDropTableMigration());
                     processor.ColumnExists(null, "TestTable2", "Name").ShouldBeFalse();
-                }, true, typeof(SQLiteProcessor));
+                });
         }
 
         [Test]
@@ -487,7 +487,9 @@ namespace FluentMigrator.Tests.Integration
                     processor.ColumnExists("TestSchema", "TestTable2", "Name").ShouldBeFalse();
 
                     runner.Down(new TestCreateSchema());
-                }, true, typeof(SQLiteProcessor), typeof(FirebirdProcessor));
+                },
+                true,
+                typeof(FirebirdProcessor));
         }
 
         [Test]
@@ -633,7 +635,7 @@ namespace FluentMigrator.Tests.Integration
                     testRunner.MigrateDown(0, false);
                     testRunner.VersionLoader.VersionInfo.HasAppliedMigration(1).ShouldBeFalse();
                     processor.TableExists(null, "Users").ShouldBeFalse();
-                }, false, typeof(SQLiteProcessor));
+                }, false);
             }
             finally
             {
@@ -1285,7 +1287,9 @@ namespace FluentMigrator.Tests.Integration
 
                     runner.Down(new TestCreateAndDropTableMigration());
 
-                }, true, typeof(SQLiteProcessor), typeof(SqlAnywhereProcessor));
+                },
+                true,
+                typeof(SqlAnywhereProcessor));
         }
 
         [Test]
@@ -1317,7 +1321,10 @@ namespace FluentMigrator.Tests.Integration
                     runner.Down(new TestCreateAndDropTableMigrationWithSchema());
 
                     runner.Down(new TestCreateSchema());
-                }, true, new[] { typeof(SQLiteProcessor), typeof(FirebirdProcessor), typeof(SqlAnywhereProcessor) });
+                },
+                true,
+                typeof(FirebirdProcessor),
+                typeof(SqlAnywhereProcessor));
         }
 
         [Test]
@@ -1344,7 +1351,7 @@ namespace FluentMigrator.Tests.Integration
 
                     runner.Down(new TestCreateAndDropTableMigration());
 
-                }, true, new[] { typeof(SQLiteProcessor) });
+                });
         }
 
         [Test]
@@ -1373,7 +1380,9 @@ namespace FluentMigrator.Tests.Integration
                     runner.Down(new TestCreateAndDropTableMigrationWithSchema());
 
                     runner.Down(new TestCreateSchema());
-                }, true, new[] { typeof(SQLiteProcessor), typeof(FirebirdProcessor) });
+                },
+                true,
+                typeof(FirebirdProcessor));
         }
 
         [Test]
@@ -1409,7 +1418,9 @@ namespace FluentMigrator.Tests.Integration
                     runner.Down(new TestCreateAndDropTableMigrationWithSchema());
 
                     runner.Down(new TestCreateSchema());
-                }, true, new[] { typeof(SQLiteProcessor), typeof(FirebirdProcessor) });
+                },
+                true,
+                typeof(FirebirdProcessor));
         }
 
         [Test]
@@ -1442,7 +1453,7 @@ namespace FluentMigrator.Tests.Integration
 
                     runner.Down(new TestCreateAndDropTableMigration());
 
-                }, true, new[] { typeof(SQLiteProcessor) });
+                });
         }
 
         [Test]
@@ -1477,7 +1488,9 @@ namespace FluentMigrator.Tests.Integration
                     runner.Down(new TestCreateAndDropTableMigrationWithSchema());
 
                     runner.Down(new TestCreateSchema());
-                }, true, new[] { typeof(SQLiteProcessor), typeof(FirebirdProcessor) });
+                },
+                true,
+                typeof(FirebirdProcessor));
         }
 
         [Test]
@@ -1510,7 +1523,7 @@ namespace FluentMigrator.Tests.Integration
                     runner.Down(new TestCreateAndDropTableMigrationWithSchema());
 
                     runner.Down(new TestCreateSchema());
-                }, true, new[] { typeof(SQLiteProcessor) });
+                });
         }
 
         [Test]
@@ -1539,7 +1552,9 @@ namespace FluentMigrator.Tests.Integration
 
                     runner.Down(new TestCreateAndDropTableMigration());
 
-                }, true, new[] { typeof(SQLiteProcessor), typeof(SqlAnywhereProcessor) });
+                },
+                true,
+                typeof(SqlAnywhereProcessor));
         }
 
         [Test]
@@ -1572,7 +1587,9 @@ namespace FluentMigrator.Tests.Integration
 
                     runner.Down(new TestCreateSchema());
 
-                }, true, new[] { typeof(SQLiteProcessor), typeof(SqlAnywhereProcessor) });
+                },
+                true,
+                typeof(SqlAnywhereProcessor));
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Integration/ObsoleteMigrationRunnerTests.cs
+++ b/test/FluentMigrator.Tests/Integration/ObsoleteMigrationRunnerTests.cs
@@ -868,7 +868,6 @@ namespace FluentMigrator.Tests.Integration
                 Namespace = migrationsNamespace,
             };
 
-            // Excluded SqliteProcessor as it errors on DB cleanup (RollbackToVersion).
             ExecuteWithSupportedProcessors(processor =>
             {
                 try
@@ -897,7 +896,7 @@ namespace FluentMigrator.Tests.Integration
 
                     new MigrationRunner(assembly, runnerContext, processor).RollbackToVersion(0, false);
                 }
-            }, true, typeof(SQLiteProcessor));
+            });
         }
 
         [Test]
@@ -1008,9 +1007,7 @@ namespace FluentMigrator.Tests.Integration
         [Category("SqlAnywhere16")]
         public void ValidateVersionOrderShouldDoNothingIfUnappliedMigrationVersionIsGreaterThanLatestAppliedMigration()
         {
-
-            // Using SqlServer instead of SQLite as versions not deleted from VersionInfo table when using Sqlite.
-            var excludedProcessors = new[] { typeof(SQLiteProcessor), typeof(MySqlProcessor), typeof(PostgresProcessor) };
+            var excludedProcessors = new[] { typeof(MySqlProcessor), typeof(PostgresProcessor) };
 
             var assembly = typeof(Migrations.Interleaved.Pass3.User).Assembly;
 
@@ -1054,8 +1051,7 @@ namespace FluentMigrator.Tests.Integration
         [Category("SqlAnywhere16")]
         public void ValidateVersionOrderShouldThrowExceptionIfUnappliedMigrationVersionIsLessThanLatestAppliedMigration()
         {
-            // Using SqlServer instead of SQLite as versions not deleted from VersionInfo table when using Sqlite.
-            var excludedProcessors = new[] { typeof(MySqlProcessor), typeof(SQLiteProcessor) };
+            var excludedProcessors = new[] { typeof(MySqlProcessor) };
 
             var assembly = typeof(Migrations.Interleaved.Pass3.User).Assembly;
 

--- a/test/FluentMigrator.Tests/Integration/Processors/SQLite/SQLiteProcessorTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/SQLite/SQLiteProcessorTests.cs
@@ -181,7 +181,7 @@ namespace FluentMigrator.Tests.Integration.Processors.SQLite
             var serivces = ServiceCollectionExtensions.CreateServices()
                 .ConfigureRunner(r => r.AddSQLite())
                 .AddScoped<IConnectionStringReader>(
-                    _ => new PassThroughConnectionStringReader(IntegrationTestOptions.SQLite.ConnectionString));
+                    _ => new PassThroughConnectionStringReader("Data Source=:memory:;Pooling=False;")); // Just use in-memory DB
 
             initAction?.Invoke(serivces);
 

--- a/test/FluentMigrator.Tests/IntegrationTestOptions.cs
+++ b/test/FluentMigrator.Tests/IntegrationTestOptions.cs
@@ -58,38 +58,38 @@ namespace FluentMigrator.Tests
 
         private static IReadOnlyDictionary<string, DatabaseServerOptions> DatabaseServers { get;}
 
-        public static DatabaseServerOptions SqlServer2005 => GetOptions("SqlServer2005");
+        public static DatabaseServerOptions SqlServer2005 => GetOptions(ProcessorId.SqlServer2005);
 
-        public static DatabaseServerOptions SqlServer2008 => GetOptions("SqlServer2008");
+        public static DatabaseServerOptions SqlServer2008 => GetOptions(ProcessorId.SqlServer2008);
 
-        public static DatabaseServerOptions SqlServer2012 => GetOptions("SqlServer2012");
+        public static DatabaseServerOptions SqlServer2012 => GetOptions(ProcessorId.SqlServer2012);
 
-        public static DatabaseServerOptions SqlServer2014 => GetOptions("SqlServer2014");
+        public static DatabaseServerOptions SqlServer2014 => GetOptions(ProcessorId.SqlServer2014);
 
-        public static DatabaseServerOptions SqlServer2016 => GetOptions("SqlServer2016");
+        public static DatabaseServerOptions SqlServer2016 => GetOptions(ProcessorId.SqlServer2016);
 
-        public static DatabaseServerOptions SqlServerCe => GetOptions("SqlServerCe");
+        public static DatabaseServerOptions SqlServerCe => GetOptions(ProcessorId.SqlServerCe);
 
-        public static DatabaseServerOptions SqlAnywhere16 => GetOptions("SqlAnywhere16").GetOptionsForPlatform();
+        public static DatabaseServerOptions SqlAnywhere16 => GetOptions(ProcessorId.SqlAnywhere16).GetOptionsForPlatform();
 
-        public static DatabaseServerOptions Jet => GetOptions("Jet");
+        public static DatabaseServerOptions Jet => GetOptions(ProcessorId.Jet);
 
         // ReSharper disable once InconsistentNaming
-        public static DatabaseServerOptions SQLite => GetOptions("SQLite");
+        public static DatabaseServerOptions SQLite => GetOptions(ProcessorId.SQLite);
 
-        public static DatabaseServerOptions MySql => GetOptions("MySql");
+        public static DatabaseServerOptions MySql => GetOptions(ProcessorId.MySql);
 
-        public static DatabaseServerOptions Postgres => GetOptions("Postgres");
+        public static DatabaseServerOptions Postgres => GetOptions(ProcessorId.Postgres);
 
-        public static DatabaseServerOptions Firebird => GetOptions("Firebird").GetOptionsForPlatform();
+        public static DatabaseServerOptions Firebird => GetOptions(ProcessorId.Firebird).GetOptionsForPlatform();
 
-        public static DatabaseServerOptions Oracle => GetOptions("Oracle");
+        public static DatabaseServerOptions Oracle => GetOptions(ProcessorId.Oracle);
 
-        public static DatabaseServerOptions Db2 => Environment.Is64BitProcess ? GetOptions("Db2") : DatabaseServerOptions.Empty;
+        public static DatabaseServerOptions Db2 => Environment.Is64BitProcess ? GetOptions(ProcessorId.DB2) : DatabaseServerOptions.Empty;
 
-        public static DatabaseServerOptions Db2ISeries => GetOptions("Db2ISeries");
+        public static DatabaseServerOptions Db2ISeries => GetOptions(ProcessorId.Db2ISeries);
 
-        public static DatabaseServerOptions Hana => Environment.Is64BitProcess ? GetOptions("Hana") : DatabaseServerOptions.Empty;
+        public static DatabaseServerOptions Hana => Environment.Is64BitProcess ? GetOptions(ProcessorId.Hana) : DatabaseServerOptions.Empty;
 
         public class DatabaseServerOptions
         {

--- a/test/FluentMigrator.Tests/IntegrationTestOptions.cs
+++ b/test/FluentMigrator.Tests/IntegrationTestOptions.cs
@@ -16,12 +16,15 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data.OleDb;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 
 using Microsoft.Extensions.Configuration;
+
+using static FluentMigrator.Tests.IntegrationTestOptions;
 
 namespace FluentMigrator.Tests
 {
@@ -138,6 +141,20 @@ namespace FluentMigrator.Tests
             if (DatabaseServers.TryGetValue(key, out var options))
                 return options;
             return DatabaseServerOptions.Empty;
+        }
+    }
+
+    public static class DatabaseServerOptionsExtensions
+    {
+        public static DatabaseServerOptions ReplaceConnectionStringDataDirectory(this DatabaseServerOptions dbOpts, string tempDir)
+        {
+            var newDbOpts = new DatabaseServerOptions
+            {
+                ConnectionString = dbOpts.ConnectionString.Replace("|DataDirectory|", tempDir),
+                IsEnabled = dbOpts.IsEnabled,
+            };
+
+            return newDbOpts;
         }
     }
 }

--- a/test/FluentMigrator.Tests/IntegrationTestOptions.cs
+++ b/test/FluentMigrator.Tests/IntegrationTestOptions.cs
@@ -78,7 +78,7 @@ namespace FluentMigrator.Tests
         public static DatabaseServerOptions Jet => GetOptions(ProcessorId.Jet);
 
         // ReSharper disable once InconsistentNaming
-        public static DatabaseServerOptions SQLite => GetOptions(ProcessorId.SQLite);
+        public static DatabaseServerOptions SQLite => GetOptions(ProcessorId.SQLite).ReplaceConnectionStringDataDirectory();
 
         public static DatabaseServerOptions MySql => GetOptions(ProcessorId.MySql);
 
@@ -98,6 +98,7 @@ namespace FluentMigrator.Tests
         {
             private ISet<string> _supportedPlatforms;
             private string _supportedPlatformsValue;
+            private string _originalConnectionString;
 
             public static DatabaseServerOptions Empty { get; } = new DatabaseServerOptions() { IsEnabled = false };
 
@@ -134,6 +135,17 @@ namespace FluentMigrator.Tests
                     return this;
                 return Empty;
             }
+
+            public DatabaseServerOptions ReplaceConnectionStringDataDirectory()
+            {
+                if (string.IsNullOrWhiteSpace(_originalConnectionString))
+                    _originalConnectionString = ConnectionString;
+
+                ConnectionString = _originalConnectionString
+                    .Replace("|DataDirectory|", AppDomain.CurrentDomain.GetData("DataDirectory")?.ToString());
+
+                return this;
+            }
         }
 
         private static DatabaseServerOptions GetOptions(string key)
@@ -141,20 +153,6 @@ namespace FluentMigrator.Tests
             if (DatabaseServers.TryGetValue(key, out var options))
                 return options;
             return DatabaseServerOptions.Empty;
-        }
-    }
-
-    public static class DatabaseServerOptionsExtensions
-    {
-        public static DatabaseServerOptions ReplaceConnectionStringDataDirectory(this DatabaseServerOptions dbOpts, string tempDir)
-        {
-            var newDbOpts = new DatabaseServerOptions
-            {
-                ConnectionString = dbOpts.ConnectionString.Replace("|DataDirectory|", tempDir),
-                IsEnabled = dbOpts.IsEnabled,
-            };
-
-            return newDbOpts;
         }
     }
 }

--- a/test/FluentMigrator.Tests/IssueTests/GH0904/Fixture.cs
+++ b/test/FluentMigrator.Tests/IssueTests/GH0904/Fixture.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 // Copyright (c) 2018, FluentMigrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,7 +43,7 @@ namespace FluentMigrator.Tests.IssueTests.GH0904
                 .ConfigureRunner(
                     rb => rb
                         .AddSQLite()
-                        .WithGlobalConnectionString($"Data Source={_sqliteDbFileName}")
+                        .WithGlobalConnectionString($"Data Source={_sqliteDbFileName};Pooling=False;") // Must disable pooling otherwise SQLite won't release lock on DB
                         .ScanIn(typeof(Fixture).Assembly).For.Migrations())
                 .Configure<TypeFilterOptions>(
                     opt =>

--- a/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteColumnTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteColumnTests.cs
@@ -46,7 +46,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("ALTER TABLE \"TestTable1\" ADD COLUMN \"TestColumn1\" MyDomainType");
+            result.ShouldBe("ALTER TABLE \"TestSchema\".\"TestTable1\" ADD COLUMN \"TestColumn1\" MyDomainType");
         }
 
         [Test]
@@ -85,7 +85,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("ALTER TABLE \"TestTable1\" ADD COLUMN \"TestColumn1\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT");
+            result.ShouldBe("ALTER TABLE \"TestSchema\".\"TestTable1\" ADD COLUMN \"TestColumn1\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT");
         }
 
         [Test]
@@ -105,7 +105,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("ALTER TABLE \"TestTable1\" ADD COLUMN \"TestColumn1\" TEXT NOT NULL");
+            result.ShouldBe("ALTER TABLE \"TestSchema\".\"TestTable1\" ADD COLUMN \"TestColumn1\" TEXT NOT NULL");
         }
 
         [Test]
@@ -123,8 +123,8 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expressions = GeneratorTestHelper.GetCreateColumnWithSystemMethodExpression("TestSchema");
             var result = string.Join(Environment.NewLine, expressions.Select(x => (string)Generator.Generate((dynamic)x)));
             result.ShouldBe(
-                @"ALTER TABLE ""TestTable1"" ADD COLUMN ""TestColumn1"" TEXT" + Environment.NewLine +
-                @"UPDATE ""TestTable1"" SET ""TestColumn1"" = (datetime('now','localtime')) WHERE 1 = 1");
+                @"ALTER TABLE ""TestSchema"".""TestTable1"" ADD COLUMN ""TestColumn1"" TEXT" + Environment.NewLine +
+                @"UPDATE ""TestSchema"".""TestTable1"" SET ""TestColumn1"" = (datetime('now','localtime')) WHERE 1 = 1");
         }
 
         [Test]
@@ -144,7 +144,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("ALTER TABLE \"TestTable1\" ADD COLUMN \"TestColumn1\" TEXT NOT NULL");
+            result.ShouldBe("ALTER TABLE \"TestSchema\".\"TestTable1\" ADD COLUMN \"TestColumn1\" TEXT NOT NULL");
         }
 
         [Test]
@@ -163,7 +163,8 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+
+            result.ShouldBe("ALTER TABLE \"TestSchema\".\"TestTable1\" DROP COLUMN \"TestColumn1\"");
         }
 
         [Test]
@@ -172,7 +173,8 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetDeleteColumnExpression();
 
             var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+
+            result.ShouldBe("ALTER TABLE \"TestTable1\" DROP COLUMN \"TestColumn1\"");
         }
 
         [Test]
@@ -182,7 +184,8 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+
+            result.ShouldBe("ALTER TABLE \"TestSchema\".\"TestTable1\" DROP COLUMN \"TestColumn1\"; ALTER TABLE \"TestSchema\".\"TestTable1\" DROP COLUMN \"TestColumn2\"");
         }
 
         [Test]
@@ -191,7 +194,8 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetDeleteColumnExpression(new [] { "TestColumn1", "TestColumn2" });
 
             var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+
+            result.ShouldBe("ALTER TABLE \"TestTable1\" DROP COLUMN \"TestColumn1\"; ALTER TABLE \"TestTable1\" DROP COLUMN \"TestColumn2\"");
         }
 
         [Test]
@@ -201,7 +205,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe($"ALTER TABLE {quoter.QuoteTableName("TestTable1")} "
+            result.ShouldBe($"ALTER TABLE {quoter.QuoteTableName("TestSchema")}.{quoter.QuoteTableName("TestTable1")} "
               + $"RENAME COLUMN {quoter.QuoteColumnName("TestColumn1")} TO {quoter.QuoteColumnName("TestColumn2")}");
         }
 

--- a/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteColumnTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteColumnTests.cs
@@ -163,7 +163,6 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-
             result.ShouldBe("ALTER TABLE \"TestSchema\".\"TestTable1\" DROP COLUMN \"TestColumn1\"");
         }
 
@@ -173,7 +172,6 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetDeleteColumnExpression();
 
             var result = Generator.Generate(expression);
-
             result.ShouldBe("ALTER TABLE \"TestTable1\" DROP COLUMN \"TestColumn1\"");
         }
 
@@ -184,7 +182,6 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-
             result.ShouldBe("ALTER TABLE \"TestSchema\".\"TestTable1\" DROP COLUMN \"TestColumn1\"; ALTER TABLE \"TestSchema\".\"TestTable1\" DROP COLUMN \"TestColumn2\"");
         }
 
@@ -194,7 +191,6 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetDeleteColumnExpression(new [] { "TestColumn1", "TestColumn2" });
 
             var result = Generator.Generate(expression);
-
             result.ShouldBe("ALTER TABLE \"TestTable1\" DROP COLUMN \"TestColumn1\"; ALTER TABLE \"TestTable1\" DROP COLUMN \"TestColumn2\"");
         }
 
@@ -216,6 +212,27 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
 
             var result = Generator.Generate(expression);
             result.ShouldBe($"ALTER TABLE {quoter.QuoteTableName("TestTable1")} RENAME COLUMN {quoter.QuoteColumnName("TestColumn1")} TO {quoter.QuoteColumnName("TestColumn2")}");
+        }
+
+        [Test]
+        public virtual void CanCreateUniqueColumnWithDefaultSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateColumnExpression();
+            expression.Column.IsUnique = true;
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE \"TestTable1\" ADD COLUMN \"TestColumn1\" TEXT NOT NULL UNIQUE");
+        }
+
+        [Test]
+        public virtual void CanCreateUniqueColumnWithCustomSchema()
+        {
+            var expression = GeneratorTestHelper.GetCreateColumnExpression();
+            expression.Column.IsUnique = true;
+            expression.SchemaName = "TestSchema";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE \"TestSchema\".\"TestTable1\" ADD COLUMN \"TestColumn1\" TEXT NOT NULL UNIQUE");
         }
     }
 }

--- a/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteColumnTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteColumnTests.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Linq;
 
+using FluentMigrator.Exceptions;
 using FluentMigrator.Runner.Generators.SQLite;
 using NUnit.Framework;
 
@@ -64,8 +65,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetAlterColumnExpression();
             expression.SchemaName = "TestSchema";
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -73,8 +73,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetAlterColumnExpression();
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteConstraintsTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteConstraintsTests.cs
@@ -17,6 +17,8 @@
 #endregion
 
 using System.Data;
+
+using FluentMigrator.Exceptions;
 using FluentMigrator.Runner.Generators.SQLite;
 using NUnit.Framework;
 
@@ -42,8 +44,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetCreateForeignKeyExpression();
             expression.ForeignKey.ForeignTableSchema = "TestSchema";
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -51,8 +52,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetCreateForeignKeyExpression();
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -61,8 +61,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetCreateForeignKeyExpression();
             expression.ForeignKey.ForeignTableSchema = "TestSchema";
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -72,8 +71,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.ForeignKey.ForeignTableSchema = "TestSchema";
             expression.ForeignKey.PrimaryTableSchema = "TestSchema";
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -81,8 +79,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetCreateMultiColumnForeignKeyExpression();
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -91,8 +88,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetCreateMultiColumnForeignKeyExpression();
             expression.ForeignKey.ForeignTableSchema = "TestSchema";
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -101,8 +97,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetCreateMultiColumnPrimaryKeyExpression();
             expression.Constraint.SchemaName = "TestSchema";
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -110,8 +105,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetCreateMultiColumnPrimaryKeyExpression();
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -140,8 +134,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.ForeignKey.ForeignTableSchema = "TestSchema";
             expression.ForeignKey.PrimaryTableSchema = "TestSchema";
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -149,8 +142,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetCreateNamedForeignKeyExpression();
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -159,8 +151,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetCreateNamedForeignKeyExpression();
             expression.ForeignKey.ForeignTableSchema = "TestSchema";
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -170,8 +161,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.ForeignKey.OnDelete = Rule.Cascade;
             expression.ForeignKey.OnUpdate = Rule.SetDefault;
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [TestCase(Rule.SetDefault, "SET DEFAULT"), TestCase(Rule.SetNull, "SET NULL"), TestCase(Rule.Cascade, "CASCADE")]
@@ -180,8 +170,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetCreateNamedForeignKeyExpression();
             expression.ForeignKey.OnDelete = rule;
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [TestCase(Rule.SetDefault, "SET DEFAULT"), TestCase(Rule.SetNull, "SET NULL"), TestCase(Rule.Cascade, "CASCADE")]
@@ -190,8 +179,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetCreateNamedForeignKeyExpression();
             expression.ForeignKey.OnUpdate = rule;
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -201,8 +189,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.ForeignKey.ForeignTableSchema = "TestSchema";
             expression.ForeignKey.PrimaryTableSchema = "TestSchema";
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -210,8 +197,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetCreateNamedMultiColumnForeignKeyExpression();
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -220,8 +206,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetCreateNamedMultiColumnForeignKeyExpression();
             expression.ForeignKey.ForeignTableSchema = "TestSchema";
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -230,8 +215,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetCreateNamedMultiColumnPrimaryKeyExpression();
             expression.Constraint.SchemaName = "TestSchema";
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -239,8 +223,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetCreateNamedMultiColumnPrimaryKeyExpression();
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -268,8 +251,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetCreateNamedPrimaryKeyExpression();
             expression.Constraint.SchemaName = "TestSchema";
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -277,8 +259,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetCreateNamedPrimaryKeyExpression();
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -306,8 +287,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetCreatePrimaryKeyExpression();
             expression.Constraint.SchemaName = "TestSchema";
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -315,8 +295,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetCreatePrimaryKeyExpression();
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -344,8 +323,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetDeleteForeignKeyExpression();
             expression.ForeignKey.ForeignTableSchema = "TestSchema";
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -353,8 +331,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetDeleteForeignKeyExpression();
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -363,8 +340,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetDeletePrimaryKeyExpression();
             expression.Constraint.SchemaName = "TestSchema";
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -372,8 +348,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetDeletePrimaryKeyExpression();
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteConstraintsTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteConstraintsTests.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 //
 // Copyright (c) 2018, Fluent Migrator Project
 //
@@ -121,7 +121,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.Constraint.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            result.ShouldBe("CREATE UNIQUE INDEX \"TestSchema\".\"IX_TestTable1_TestColumn1_TestColumn2\" ON \"TestTable1\" (\"TestColumn1\" ASC, \"TestColumn2\" ASC)");
         }
 
         [Test]
@@ -130,7 +130,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetCreateMultiColumnUniqueConstraintExpression();
 
             var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            result.ShouldBe("CREATE UNIQUE INDEX \"IX_TestTable1_TestColumn1_TestColumn2\" ON \"TestTable1\" (\"TestColumn1\" ASC, \"TestColumn2\" ASC)");
         }
 
         [Test]
@@ -250,7 +250,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.Constraint.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            result.ShouldBe("CREATE UNIQUE INDEX \"TestSchema\".\"TESTUNIQUECONSTRAINT\" ON \"TestTable1\" (\"TestColumn1\" ASC, \"TestColumn2\" ASC)");
         }
 
         [Test]
@@ -259,7 +259,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetCreateNamedMultiColumnUniqueConstraintExpression();
 
             var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            result.ShouldBe("CREATE UNIQUE INDEX \"TESTUNIQUECONSTRAINT\" ON \"TestTable1\" (\"TestColumn1\" ASC, \"TestColumn2\" ASC)");
         }
 
         [Test]
@@ -288,7 +288,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.Constraint.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            result.ShouldBe("CREATE UNIQUE INDEX \"TestSchema\".\"TESTUNIQUECONSTRAINT\" ON \"TestTable1\" (\"TestColumn1\" ASC)");
         }
 
         [Test]
@@ -297,7 +297,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetCreateNamedUniqueConstraintExpression();
 
             var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            result.ShouldBe("CREATE UNIQUE INDEX \"TESTUNIQUECONSTRAINT\" ON \"TestTable1\" (\"TestColumn1\" ASC)");
         }
 
         [Test]
@@ -326,7 +326,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.Constraint.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            result.ShouldBe("CREATE UNIQUE INDEX \"TestSchema\".\"IX_TestTable1_TestColumn1\" ON \"TestTable1\" (\"TestColumn1\" ASC)");
         }
 
         [Test]
@@ -335,7 +335,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetCreateUniqueConstraintExpression();
 
             var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            result.ShouldBe("CREATE UNIQUE INDEX \"IX_TestTable1_TestColumn1\" ON \"TestTable1\" (\"TestColumn1\" ASC)");
         }
 
         [Test]
@@ -383,7 +383,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.Constraint.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            result.ShouldBe("DROP INDEX \"TestSchema\".\"TESTUNIQUECONSTRAINT\"");
         }
 
         [Test]
@@ -392,7 +392,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetDeleteUniqueConstraintExpression();
 
             var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            result.ShouldBe("DROP INDEX \"TESTUNIQUECONSTRAINT\"");
         }
     }
 }

--- a/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteConstraintsTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteConstraintsTests.cs
@@ -115,7 +115,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.Constraint.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE UNIQUE INDEX \"TestSchema\".\"IX_TestTable1_TestColumn1_TestColumn2\" ON \"TestTable1\" (\"TestColumn1\" ASC, \"TestColumn2\" ASC)");
+            result.ShouldBe("CREATE UNIQUE INDEX \"TestSchema\".\"UC_TestTable1_TestColumn1_TestColumn2\" ON \"TestTable1\" (\"TestColumn1\" ASC, \"TestColumn2\" ASC)");
         }
 
         [Test]
@@ -124,7 +124,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetCreateMultiColumnUniqueConstraintExpression();
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE UNIQUE INDEX \"IX_TestTable1_TestColumn1_TestColumn2\" ON \"TestTable1\" (\"TestColumn1\" ASC, \"TestColumn2\" ASC)");
+            result.ShouldBe("CREATE UNIQUE INDEX \"UC_TestTable1_TestColumn1_TestColumn2\" ON \"TestTable1\" (\"TestColumn1\" ASC, \"TestColumn2\" ASC)");
         }
 
         [Test]
@@ -305,7 +305,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.Constraint.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE UNIQUE INDEX \"TestSchema\".\"IX_TestTable1_TestColumn1\" ON \"TestTable1\" (\"TestColumn1\" ASC)");
+            result.ShouldBe("CREATE UNIQUE INDEX \"TestSchema\".\"UC_TestTable1_TestColumn1\" ON \"TestTable1\" (\"TestColumn1\" ASC)");
         }
 
         [Test]
@@ -314,7 +314,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetCreateUniqueConstraintExpression();
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE UNIQUE INDEX \"IX_TestTable1_TestColumn1\" ON \"TestTable1\" (\"TestColumn1\" ASC)");
+            result.ShouldBe("CREATE UNIQUE INDEX \"UC_TestTable1_TestColumn1\" ON \"TestTable1\" (\"TestColumn1\" ASC)");
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteDataTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteDataTests.cs
@@ -43,7 +43,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("DELETE FROM \"TestTable1\" WHERE 1 = 1");
+            result.ShouldBe("DELETE FROM \"TestSchema\".\"TestTable1\" WHERE 1 = 1");
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("DELETE FROM \"TestTable1\" WHERE \"Name\" = 'Just''in' AND \"Website\" IS NULL; DELETE FROM \"TestTable1\" WHERE \"Website\" = 'github.com'");
+            result.ShouldBe("DELETE FROM \"TestSchema\".\"TestTable1\" WHERE \"Name\" = 'Just''in' AND \"Website\" IS NULL; DELETE FROM \"TestSchema\".\"TestTable1\" WHERE \"Website\" = 'github.com'");
         }
 
         [Test]
@@ -81,7 +81,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("DELETE FROM \"TestTable1\" WHERE \"Name\" = 'Just''in' AND \"Website\" IS NULL");
+            result.ShouldBe("DELETE FROM \"TestSchema\".\"TestTable1\" WHERE \"Name\" = 'Just''in' AND \"Website\" IS NULL");
         }
 
         [Test]
@@ -107,8 +107,8 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var expression = GeneratorTestHelper.GetInsertDataExpression();
             expression.SchemaName = "TestSchema";
 
-            var expected = "INSERT INTO \"TestTable1\" (\"Id\", \"Name\", \"Website\") VALUES (1, 'Just''in', 'codethinked.com');";
-            expected += " INSERT INTO \"TestTable1\" (\"Id\", \"Name\", \"Website\") VALUES (2, 'Na\\te', 'kohari.org')";
+            var expected = "INSERT INTO \"TestSchema\".\"TestTable1\" (\"Id\", \"Name\", \"Website\") VALUES (1, 'Just''in', 'codethinked.com');";
+            expected += " INSERT INTO \"TestSchema\".\"TestTable1\" (\"Id\", \"Name\", \"Website\") VALUES (2, 'Na\\te', 'kohari.org')";
 
             var result = Generator.Generate(expression);
             result.ShouldBe(expected);
@@ -133,7 +133,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe(string.Format("INSERT INTO \"TestTable1\" (\"guid\") VALUES ('{0}')", GeneratorTestHelper.TestGuid.ToString()));
+            result.ShouldBe(string.Format("INSERT INTO \"TestSchema\".\"TestTable1\" (\"guid\") VALUES ('{0}')", GeneratorTestHelper.TestGuid.ToString()));
         }
 
         [Test]
@@ -152,7 +152,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("UPDATE \"TestTable1\" SET \"Name\" = 'Just''in', \"Age\" = 25 WHERE 1 = 1");
+            result.ShouldBe("UPDATE \"TestSchema\".\"TestTable1\" SET \"Name\" = 'Just''in', \"Age\" = 25 WHERE 1 = 1");
         }
 
         [Test]
@@ -171,7 +171,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("UPDATE \"TestTable1\" SET \"Name\" = 'Just''in', \"Age\" = 25 WHERE \"Id\" = 9 AND \"Homepage\" IS NULL");
+            result.ShouldBe("UPDATE \"TestSchema\".\"TestTable1\" SET \"Name\" = 'Just''in', \"Age\" = 25 WHERE \"Id\" = 9 AND \"Homepage\" IS NULL");
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteGeneratorTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteGeneratorTests.cs
@@ -44,16 +44,17 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         }
 
         [Test]
-        public void CanAlterColumnInStrictMode()
+        public void CanNotAlterColumnInStrictMode()
         {
-            var expression = GeneratorTestHelper.GetRenameColumnExpression();
+            var expression = GeneratorTestHelper.GetAlterColumnExpression();
+
             Generator.CompatibilityMode = CompatibilityMode.STRICT;
 
             Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
-        public void CanAlterSchemaInStrictMode()
+        public void CanNotAlterSchemaInStrictMode()
         {
             Generator.CompatibilityMode = CompatibilityMode.STRICT;
 
@@ -61,7 +62,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         }
 
         [Test]
-        public void CanCreateForeignKeyInStrictMode()
+        public void CanNotCreateForeignKeyInStrictMode()
         {
             Generator.CompatibilityMode = CompatibilityMode.STRICT;
 
@@ -69,7 +70,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         }
 
         [Test]
-        public void CanCreateMulitColumnForeignKeyInStrictMode()
+        public void CanNotCreateMulitColumnForeignKeyInStrictMode()
         {
             Generator.CompatibilityMode = CompatibilityMode.STRICT;
 
@@ -77,7 +78,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         }
 
         [Test]
-        public void CanCreateSchemaInStrictMode()
+        public void CanNotCreateSchemaInStrictMode()
         {
             Generator.CompatibilityMode = CompatibilityMode.STRICT;
 
@@ -98,7 +99,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         }
 
         [Test]
-        public void CanDropForeignKeyInStrictMode()
+        public void CanNotDropForeignKeyInStrictMode()
         {
             var expression = GeneratorTestHelper.GetDeleteForeignKeyExpression();
             Generator.CompatibilityMode = CompatibilityMode.STRICT;
@@ -107,7 +108,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         }
 
         [Test]
-        public void CanDropSchemaInStrictMode()
+        public void CanNotDropSchemaInStrictMode()
         {
             Generator.CompatibilityMode = CompatibilityMode.STRICT;
 
@@ -145,12 +146,15 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var result = Generator.Generate(expression);
             result.ShouldBe("CREATE TABLE \"TestTable1\" (\"DateTimeCol\" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)");
         }
+
         [Test]
         public void CanRenameColumnInStrictMode()
         {
+            var expression = GeneratorTestHelper.GetRenameColumnExpression();
             Generator.CompatibilityMode = CompatibilityMode.STRICT;
 
-            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(GeneratorTestHelper.GetRenameColumnExpression()));
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE \"TestTable1\" RENAME COLUMN \"TestColumn1\" TO \"TestColumn2\"");
         }
     }
 }

--- a/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteIndexTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteIndexTests.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 //
 // Copyright (c) 2018, Fluent Migrator Project
 //
@@ -42,7 +42,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.Index.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE INDEX \"TestIndex\" ON \"TestTable1\" (\"TestColumn1\" ASC)");
+            result.ShouldBe("CREATE INDEX \"TestSchema\".\"TestIndex\" ON \"TestTable1\" (\"TestColumn1\" ASC)");
         }
 
         [Test]
@@ -61,7 +61,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.Index.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE INDEX \"TestIndex\" ON \"TestTable1\" (\"TestColumn1\" ASC, \"TestColumn2\" DESC)");
+            result.ShouldBe("CREATE INDEX \"TestSchema\".\"TestIndex\" ON \"TestTable1\" (\"TestColumn1\" ASC, \"TestColumn2\" DESC)");
         }
 
         [Test]
@@ -80,7 +80,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.Index.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE UNIQUE INDEX \"TestIndex\" ON \"TestTable1\" (\"TestColumn1\" ASC, \"TestColumn2\" DESC)");
+            result.ShouldBe("CREATE UNIQUE INDEX \"TestSchema\".\"TestIndex\" ON \"TestTable1\" (\"TestColumn1\" ASC, \"TestColumn2\" DESC)");
         }
 
         [Test]
@@ -99,7 +99,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.Index.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE UNIQUE INDEX \"TestIndex\" ON \"TestTable1\" (\"TestColumn1\" ASC)");
+            result.ShouldBe("CREATE UNIQUE INDEX \"TestSchema\".\"TestIndex\" ON \"TestTable1\" (\"TestColumn1\" ASC)");
         }
 
         [Test]
@@ -118,7 +118,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.Index.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("DROP INDEX \"TestIndex\"");
+            result.ShouldBe("DROP INDEX \"TestSchema\".\"TestIndex\"");
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteSchemaTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteSchemaTests.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 //
 // Copyright (c) 2018, Fluent Migrator Project
 //
@@ -16,6 +16,7 @@
 //
 #endregion
 
+using FluentMigrator.Exceptions;
 using FluentMigrator.Runner.Generators.SQLite;
 using NUnit.Framework;
 
@@ -40,8 +41,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetAlterSchemaExpression();
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -49,8 +49,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetCreateSchemaExpression();
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
 
         [Test]
@@ -58,8 +57,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         {
             var expression = GeneratorTestHelper.GetDeleteSchemaExpression();
 
-            var result = Generator.Generate(expression);
-            result.ShouldBe(string.Empty);
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
         }
     }
 }

--- a/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteTableTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteTableTests.cs
@@ -53,7 +53,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE TABLE \"TestTable1\" (\"TestColumn1\" TEXT NOT NULL, \"TestColumn2\" timestamp NOT NULL, PRIMARY KEY (\"TestColumn1\"))");
+            result.ShouldBe("CREATE TABLE \"TestSchema\".\"TestTable1\" (\"TestColumn1\" TEXT NOT NULL, \"TestColumn2\" timestamp NOT NULL, PRIMARY KEY (\"TestColumn1\"))");
         }
 
         [Test]
@@ -75,7 +75,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE TABLE \"TestTable1\" (\"TestColumn1\" TEXT NOT NULL, \"TestColumn2\" INTEGER NOT NULL)");
+            result.ShouldBe("CREATE TABLE \"TestSchema\".\"TestTable1\" (\"TestColumn1\" TEXT NOT NULL, \"TestColumn2\" INTEGER NOT NULL)");
         }
 
         [Test]
@@ -96,7 +96,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE TABLE \"TestTable1\" (\"TestColumn1\" TEXT NOT NULL DEFAULT NULL, \"TestColumn2\" INTEGER NOT NULL DEFAULT 0)");
+            result.ShouldBe("CREATE TABLE \"TestSchema\".\"TestTable1\" (\"TestColumn1\" TEXT NOT NULL DEFAULT NULL, \"TestColumn2\" INTEGER NOT NULL DEFAULT 0)");
         }
 
         [Test]
@@ -117,7 +117,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE TABLE \"TestTable1\" (\"TestColumn1\" TEXT NOT NULL DEFAULT 'Default', \"TestColumn2\" INTEGER NOT NULL DEFAULT 0)");
+            result.ShouldBe("CREATE TABLE \"TestSchema\".\"TestTable1\" (\"TestColumn1\" TEXT NOT NULL DEFAULT 'Default', \"TestColumn2\" INTEGER NOT NULL DEFAULT 0)");
         }
 
         [Test]
@@ -138,7 +138,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE TABLE \"TestTable1\" (\"TestColumn1\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, \"TestColumn2\" INTEGER NOT NULL)");
+            result.ShouldBe("CREATE TABLE \"TestSchema\".\"TestTable1\" (\"TestColumn1\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, \"TestColumn2\" INTEGER NOT NULL)");
         }
 
         [Test]
@@ -159,7 +159,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE TABLE \"TestTable1\" (\"TestColumn1\" TEXT NOT NULL, \"TestColumn2\" INTEGER NOT NULL, PRIMARY KEY (\"TestColumn1\", \"TestColumn2\"))");
+            result.ShouldBe("CREATE TABLE \"TestSchema\".\"TestTable1\" (\"TestColumn1\" TEXT NOT NULL, \"TestColumn2\" INTEGER NOT NULL, PRIMARY KEY (\"TestColumn1\", \"TestColumn2\"))");
         }
 
         [Test]
@@ -178,7 +178,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE TABLE \"TestTable1\" (\"TestColumn1\" TEXT NOT NULL, \"TestColumn2\" INTEGER NOT NULL, CONSTRAINT \"TestKey\" PRIMARY KEY (\"TestColumn1\", \"TestColumn2\"))");
+            result.ShouldBe("CREATE TABLE \"TestSchema\".\"TestTable1\" (\"TestColumn1\" TEXT NOT NULL, \"TestColumn2\" INTEGER NOT NULL, CONSTRAINT \"TestKey\" PRIMARY KEY (\"TestColumn1\", \"TestColumn2\"))");
         }
 
         [Test]
@@ -197,7 +197,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE TABLE \"TestTable1\" (\"TestColumn1\" TEXT NOT NULL, \"TestColumn2\" INTEGER NOT NULL, CONSTRAINT \"TestKey\" PRIMARY KEY (\"TestColumn1\"))");
+            result.ShouldBe("CREATE TABLE \"TestSchema\".\"TestTable1\" (\"TestColumn1\" TEXT NOT NULL, \"TestColumn2\" INTEGER NOT NULL, CONSTRAINT \"TestKey\" PRIMARY KEY (\"TestColumn1\"))");
         }
 
         [Test]
@@ -216,7 +216,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE TABLE \"TestTable1\" (\"TestColumn1\" TEXT, \"TestColumn2\" INTEGER NOT NULL)");
+            result.ShouldBe("CREATE TABLE \"TestSchema\".\"TestTable1\" (\"TestColumn1\" TEXT, \"TestColumn2\" INTEGER NOT NULL)");
         }
 
         [Test]
@@ -235,7 +235,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE TABLE \"TestTable1\" (\"TestColumn1\" TEXT NOT NULL, \"TestColumn2\" INTEGER NOT NULL, PRIMARY KEY (\"TestColumn1\"))");
+            result.ShouldBe("CREATE TABLE \"TestSchema\".\"TestTable1\" (\"TestColumn1\" TEXT NOT NULL, \"TestColumn2\" INTEGER NOT NULL, PRIMARY KEY (\"TestColumn1\"))");
         }
 
         [Test]
@@ -290,7 +290,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("DROP TABLE \"TestTable1\"");
+            result.ShouldBe("DROP TABLE \"TestSchema\".\"TestTable1\"");
         }
 
         [Test]
@@ -309,7 +309,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("ALTER TABLE \"TestTable1\" RENAME TO \"TestTable2\"");
+            result.ShouldBe("ALTER TABLE \"TestSchema\".\"TestTable1\" RENAME TO \"TestTable2\"");
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Runners/MigratorConsoleTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Runners/MigratorConsoleTests.cs
@@ -31,7 +31,7 @@ namespace FluentMigrator.Tests.Unit.Runners
     [TestFixture]
     public class MigratorConsoleTests
     {
-        private const string Database = "SQLite";
+        private const string Database = ProcessorId.SQLite;
         private const string Connection = "Data Source=:memory:";
         private const string Target = "FluentMigrator.Tests.dll";
 

--- a/test/FluentMigrator.Tests/appsettings.json
+++ b/test/FluentMigrator.Tests/appsettings.json
@@ -29,7 +29,7 @@
             "IsEnabled": false
         },
         "SQLite": {
-            "ConnectionString": "Data Source=:memory:",
+            "ConnectionString": "Data Source=|DataDirectory|\\TestDatabase.db;Pooling=False;Mode=ReadWriteCreate;",
             "IsEnabled": true
         },
         "MySql": {


### PR DESCRIPTION
This PR is looking at implementing most of the supported features of SQLite that appear to be missing in the current implementation.

Progress:
* [x] Added Schema support
* [x] Added SQLite drop column support (Fixes #812)
* [x] Add UNIQUE constraint support (Fixes #1492 and #662)
* [x] Switched to CompatabilityMode.Strict by default so that any missing features will warn users and not just fail silently (Fixes #1485)

Notes:
* UNIQUE constraint support is added in two ways. Either when defining the table you can use `.Unique()` which does a true UNIQUE constraint on the column or when using the `Create.UniqueConstraint` we actually just create a UNIQUE index instead.
* ~~Couldn't upgrade Microsoft.Data.Sqlite to v6 due to error `Unable to load DLL 'e_sqlite3'` (some background here https://github.com/dotnet/efcore/issues/19396) so upgraded to latest v5 where the error isn't present~~ Have now managed to upgrade to v6 by installing `SQLitePCLRaw.bundle_e_sqlite3` too.