### PR TITLE
Make Postgres 10 & 11 processors public

### DIFF
--- a/src/FluentMigrator.Runner.Postgres/Processors/Postgres/Postgres10_0Processor.cs
+++ b/src/FluentMigrator.Runner.Postgres/Processors/Postgres/Postgres10_0Processor.cs
@@ -31,7 +31,7 @@ namespace FluentMigrator.Runner.Processors.Postgres
         public Postgres10_0Processor(
             [NotNull] PostgresDbFactory factory,
             [NotNull] Postgres10_0Generator generator,
-            [NotNull] ILogger<PostgresProcessor> logger,
+            [NotNull] ILogger<Postgres10_0Processor> logger,
             [NotNull] IOptionsSnapshot<ProcessorOptions> options,
             [NotNull] IConnectionStringAccessor connectionStringAccessor,
             [NotNull] PostgresOptions pgOptions)

--- a/src/FluentMigrator.Runner.Postgres/Processors/Postgres/Postgres10_0Processor.cs
+++ b/src/FluentMigrator.Runner.Postgres/Processors/Postgres/Postgres10_0Processor.cs
@@ -26,7 +26,7 @@ using Microsoft.Extensions.Options;
 
 namespace FluentMigrator.Runner.Processors.Postgres
 {
-    class Postgres10_0Processor : PostgresProcessor
+    public class Postgres10_0Processor : PostgresProcessor
     {
         public Postgres10_0Processor(
             [NotNull] PostgresDbFactory factory,

--- a/src/FluentMigrator.Runner.Postgres/Processors/Postgres/Postgres11_0Processor.cs
+++ b/src/FluentMigrator.Runner.Postgres/Processors/Postgres/Postgres11_0Processor.cs
@@ -26,7 +26,7 @@ using Microsoft.Extensions.Options;
 
 namespace FluentMigrator.Runner.Processors.Postgres
 {
-    class Postgres11_0Processor : PostgresProcessor
+    public class Postgres11_0Processor : PostgresProcessor
     {
         public Postgres11_0Processor(
             [NotNull] PostgresDbFactory factory,

--- a/src/FluentMigrator.Runner.Postgres/Processors/Postgres/Postgres11_0Processor.cs
+++ b/src/FluentMigrator.Runner.Postgres/Processors/Postgres/Postgres11_0Processor.cs
@@ -31,7 +31,7 @@ namespace FluentMigrator.Runner.Processors.Postgres
         public Postgres11_0Processor(
             [NotNull] PostgresDbFactory factory,
             [NotNull] Postgres11_0Generator generator,
-            [NotNull] ILogger<PostgresProcessor> logger,
+            [NotNull] ILogger<Postgres11_0Processor> logger,
             [NotNull] IOptionsSnapshot<ProcessorOptions> options,
             [NotNull] IConnectionStringAccessor connectionStringAccessor,
             [NotNull] PostgresOptions pgOptions)


### PR DESCRIPTION
In my projects, I inherit from the sql processor and sql generator classes, so that I can extend the functionality of the sql generator based on the "AdditionalFeatures" of an expression. I use this currently to make it really easy to automatically populate some fields when doing inserts using FluentMigrator.
My current project uses Postgres 13 and so I wanted to inherit from the Postgres 11 processor and generator, but this is currently not possible because both the Postgres 11 and 10 processors are internal. I guess this is not intentional, so this is a pull request to make them public.