### PR TITLE
Add JetBrains.Annotations.MeansImplicitUse to MigrationAttribute

### DIFF
--- a/src/FluentMigrator.Abstractions/MigrationAttribute.cs
+++ b/src/FluentMigrator.Abstractions/MigrationAttribute.cs
@@ -20,12 +20,15 @@
 
 using System;
 
+using JetBrains.Annotations;
+
 namespace FluentMigrator
 {
     /// <summary>
     /// Attribute for a migration
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    [MeansImplicitUse]
     public class MigrationAttribute : Attribute
     {
         /// <summary>


### PR DESCRIPTION
Add MeansImplicitUseAttribute to MigrationAttribute to tell ReSharper/Rider that types marked by "Migration" are used implicitly and usage warning should not be shown