### PR TITLE
Use PackageLicenseExpression

### DIFF
--- a/Global.props
+++ b/Global.props
@@ -9,7 +9,7 @@
     <Company>FluentMigrator Project</Company>
     <Authors>Sean Chambers;Josh Coffman;Tom Marien;Mark Junker</Authors>
     <PackageProjectUrl>https://github.com/fluentmigrator/fluentmigrator/wiki</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/fluentmigrator/fluentmigrator/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReleaseNotes>Use of standard dependency injection, configuration and logging libraries.
 Simplification of in-process runner configuration and instantiation.
 dotnet-fm is now a global .NET Core 2.1 tool.


### PR DESCRIPTION
Related: https://github.com/microsoft/MSBuildSdks/issues/312

<https://learn.microsoft.com/en-us/nuget/reference/nuspec#license> recommends using an SPDX identifier instead of a license file inside nuget packages, if an OSI approvied license is used.

My use case: I (semi-)automate checking license compliance of tools I use at work. If the license expression is used, this becomes much easier.

Other advantage: License is shown in nuget gallery, as it is e.g. [here](https://www.nuget.org/packages/SixLabors.ImageSharp/)