### PR TITLE
feat: add dotnet 7.0 support for cli tool

### DIFF
--- a/src/FluentMigrator.DotNet.Cli/FluentMigrator.DotNet.Cli.csproj
+++ b/src/FluentMigrator.DotNet.Cli/FluentMigrator.DotNet.Cli.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <ToolCommandName>dotnet-fm</ToolCommandName>
     <PackAsTool>true</PackAsTool>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
Add support for dotnet 7.0 in FluentMigrator.DotNet.Cli by adding net7.0 as target framework.