### PR TITLE
Add support to .NET 6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,14 @@
 <Project>
- <PropertyGroup>
-   <Deterministic>true</Deterministic>
- </PropertyGroup>
+    <PropertyGroup>
+        <Deterministic>true</Deterministic>
+        <RepositoryUrl>https://github.com/fluentmigrator/fluentmigrator/</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,12 +1,53 @@
 <Project>
+    <Import Project="DotNetSdkMono.props"/>
     <PropertyGroup>
-        <AppTargetFrameworks>net48;netstandard2.0;net6.0</AppTargetFrameworks>
+        <LibTargetFrameworks>net48;netstandard2.0;net6.0</LibTargetFrameworks>
+        <VersionPrefix>4.0.0</VersionPrefix>
+        <LangVersion>latest</LangVersion>
+        <Product>FluentMigrator</Product>
+
+        <Copyright>Sean Chambers and the FluentMigrator project 2008-2022</Copyright>
+        <Company>FluentMigrator Project</Company>
+        <Authors>Sean Chambers;Josh Coffman;Tom Marien;Mark Junker</Authors>
+        <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
+
         <Deterministic>true</Deterministic>
+
+        <MinClientVersion>3.5</MinClientVersion>
+
+        <NoWarn>$(NoWarn);CS3001;CS3002;CS3003;CS3005;NU5105;NU1701</NoWarn>
+
+        <IsPackable>false</IsPackable>
+
+        <PackageReleaseNotes>Use of standard dependency injection, configuration and logging libraries.
+            Simplification of in-process runner configuration and instantiation.
+            dotnet-fm is now a global .NET 2.1 tool.
+            Minimum .NET Framework version is 4.6.2, see https://aka.ms/msbuild/developerpacks for more information.
+
+            Details: https://github.com/fluentmigrator/fluentmigrator/releases
+        </PackageReleaseNotes>
+
+        <PackageProjectUrl>https://github.com/fluentmigrator/fluentmigrator</PackageProjectUrl>
         <RepositoryUrl>https://github.com/fluentmigrator/fluentmigrator/</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <LangVersion>latest</LangVersion>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>logo.png</PackageIcon>
+
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+
+        <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+
+        <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+
+        <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(TargetFramework)'=='net48'">
+        <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,12 +1,29 @@
 <Project>
     <PropertyGroup>
+        <AppTargetFrameworks>net48;netstandard2.0;net6.0</AppTargetFrameworks>
         <Deterministic>true</Deterministic>
         <RepositoryUrl>https://github.com/fluentmigrator/fluentmigrator/</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
+        <LangVersion>latest</LangVersion>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageIcon>logo.png</PackageIcon>
     </PropertyGroup>
 
     <ItemGroup>
+        <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+        <None Include="..\..\docs\logo.png" Pack="true" PackagePath="\"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="JetBrains.Annotations" Version="11.1.0" PrivateAssets="All"/>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(OS)' == 'Unix'">
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/FluentMigrator.sln
+++ b/FluentMigrator.sln
@@ -86,6 +86,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{B3796E78
 		GitVersion.yml = GitVersion.yml
 		nuget-upload.sh = nuget-upload.sh
 		nuget.config = nuget.config
+		Global.props = Global.props
 	EndProjectSection
 EndProject
 Global

--- a/FluentMigrator.sln
+++ b/FluentMigrator.sln
@@ -86,7 +86,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{B3796E78
 		GitVersion.yml = GitVersion.yml
 		nuget-upload.sh = nuget-upload.sh
 		nuget.config = nuget.config
-		Global.props = Global.props
 	EndProjectSection
 EndProject
 Global

--- a/FluentMigrator.sln
+++ b/FluentMigrator.sln
@@ -7,9 +7,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		CHANGELOG.md = CHANGELOG.md
-		Directory.Buiild.props = Directory.Buiild.props
 		nuget.config = nuget.config
 		README.md = README.md
+		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FluentMigrator.Runner", "src\FluentMigrator.Runner\FluentMigrator.Runner.csproj", "{0433595D-963A-49BE-BF05-9F293D88C7B2}"

--- a/Global.props
+++ b/Global.props
@@ -17,9 +17,6 @@ Minimum .NET Framework version is 4.6.2, see https://aka.ms/msbuild/developerpac
 
 Details: https://github.com/fluentmigrator/fluentmigrator/releases
     </PackageReleaseNotes>
-    <PackageIconUrl>https://github.com/fluentmigrator/fluentmigrator/raw/develop/docs/logo.png</PackageIconUrl>
-    <RepositoryUrl>https://github.com/fluentmigrator/fluentmigrator.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
     <MinClientVersion>3.5</MinClientVersion>
     <IsPackable>false</IsPackable>
     <!-- Enable the CS300x warnings when the obsoleted code gets removed -->
@@ -30,12 +27,7 @@ Details: https://github.com/fluentmigrator/fluentmigrator/releases
     <Compile Include="$(MSBuildThisFileDirectory)src/GlobalAssemblyInfo.cs" Link="Properties\GlobalAssemblyInfo.cs" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="11.1.0" PrivateAssets="All" />
-  </ItemGroup>
-
   <PropertyGroup Condition="'$(TargetFramework)'=='net48'">
     <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
   </PropertyGroup>
-
 </Project>

--- a/Global.props
+++ b/Global.props
@@ -1,33 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <Import Project="DotNetSdkMono.props" />
-  <PropertyGroup>
-    <LangVersion>latest</LangVersion>
-    <VersionPrefix>4.0.0</VersionPrefix>
-    <Product>FluentMigrator</Product>
-    <Copyright>Sean Chambers and the FluentMigrator project 2008-2022</Copyright>
-    <Company>FluentMigrator Project</Company>
-    <Authors>Sean Chambers;Josh Coffman;Tom Marien;Mark Junker</Authors>
-    <PackageProjectUrl>https://github.com/fluentmigrator/fluentmigrator/wiki</PackageProjectUrl>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageReleaseNotes>Use of standard dependency injection, configuration and logging libraries.
-Simplification of in-process runner configuration and instantiation.
-dotnet-fm is now a global .NET Core 2.1 tool.
-Minimum .NET Framework version is 4.6.2, see https://aka.ms/msbuild/developerpacks for more information.
-
-Details: https://github.com/fluentmigrator/fluentmigrator/releases
-    </PackageReleaseNotes>
-    <MinClientVersion>3.5</MinClientVersion>
-    <IsPackable>false</IsPackable>
-    <!-- Enable the CS300x warnings when the obsoleted code gets removed -->
-    <NoWarn>$(NoWarn);CS3001;CS3002;CS3003;CS3005;NU5105;NU1701</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)src/GlobalAssemblyInfo.cs" Link="Properties\GlobalAssemblyInfo.cs" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'=='net48'">
-    <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
-  </PropertyGroup>
 </Project>

--- a/PackageLibrary.props
+++ b/PackageLibrary.props
@@ -6,15 +6,15 @@
   <PropertyGroup>
     <NoWarn Condition=" '$(Configuration)' != 'Release' ">$(NoWarn);1591</NoWarn>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-    <DebugType Condition=" '$(Configuration)' == 'Release' ">portable</DebugType> <!-- Required for EmbedSources -->
-    <DebugType Condition=" '$(Configuration)' == 'Debug' ">full</DebugType> <!-- Required for EmbedSources -->
+<!--    <DebugType Condition=" '$(Configuration)' == 'Release' ">portable</DebugType> &lt;!&ndash; Required for EmbedSources &ndash;&gt;-->
+<!--    <DebugType Condition=" '$(Configuration)' == 'Debug' ">full</DebugType> &lt;!&ndash; Required for EmbedSources &ndash;&gt;-->
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(Configuration)' == 'Release' ">
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />
-    <PackageReference Include="SourceLink.Embed.AllSourceFiles" Version="2.8.0" PrivateAssets="all" />
-    <PackageReference Include="SourceLink.Copy.PdbFiles" Version="2.8.0" PrivateAssets="All" />
-  </ItemGroup>
+<!--  <ItemGroup Condition=" '$(Configuration)' == 'Release' ">-->
+<!--    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />-->
+<!--    <PackageReference Include="SourceLink.Embed.AllSourceFiles" Version="2.8.0" PrivateAssets="all" />-->
+<!--    <PackageReference Include="SourceLink.Copy.PdbFiles" Version="2.8.0" PrivateAssets="All" />-->
+<!--  </ItemGroup>-->
 
 </Project>

--- a/azure-pipelines-pullrequests.yml
+++ b/azure-pipelines-pullrequests.yml
@@ -8,7 +8,7 @@ trigger: none
 pr:
   branches:
     include:
-    - '*'  # must quote since "*" is a YAML reserved character; we want a string
+      - '*'  # must quote since "*" is a YAML reserved character; we want a string
 
 pool:
   vmImage: 'windows-latest'
@@ -18,37 +18,77 @@ variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
 
-steps:
-- task: NuGetToolInstaller@1
+stages:
+  - stage: Build on Windows
+    jobs:
+      - job: 'Build on Windows'
+        pool:
+          vmImage: 'windows-latest'
+        steps:
+          - task: NuGetToolInstaller@1
 
-- task: UseGitVersion@5
-  displayName: 'UseGitVersion (preview)'
-  inputs:
-    versionSpec: '5.1.3'
-    includePrerelease: true
-    updateAssemblyInfo: false
-  env:
-      BUILD_BUILDNUMBER: $(GitVersion.NuGetVersionV2)
+          - task: UseDotNet@2
+            inputs:
+              version: '7.x'
 
-- task: NuGetCommand@2
-  inputs:
-    restoreSolution: '$(solution)'
+          - task: UseGitVersion@5
+            displayName: 'UseGitVersion (preview)'
+            inputs:
+              versionSpec: '5.12'
+              includePrerelease: true
+              updateAssemblyInfo: false
+            env:
+              BUILD_BUILDNUMBER: $(GitVersion.NuGetVersionV2)
 
-- task: VSBuild@1
-  inputs:
-    solution: '$(solution)'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    msbuildArgs: '/p:Version="$(build.buildNumber)"'
+          - task: NuGetCommand@2
+            inputs:
+              restoreSolution: '$(solution)'
 
-- task: VSTest@2
-  inputs:
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    diagnosticsEnabled: true
+          - task: VSBuild@1
+            inputs:
+              solution: '$(solution)'
+              platform: '$(buildPlatform)'
+            configuration: '$(buildConfiguration)'
+            msbuildArgs: '/p:Version="$(build.buildNumber)"'
 
-- task: PublishBuildArtifacts@1
-  inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-    ArtifactName: 'drop'
-    publishLocation: 'Container'
+          - task: VSTest@2
+            inputs:
+              platform: '$(buildPlatform)'
+              configuration: '$(buildConfiguration)'
+              diagnosticsEnabled: true
+
+  - stage: Build on Ubuntu
+    dependsOn: []
+    jobs:
+      - job: 'Build on Ubuntu'
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+          - task: UseDotNet@2
+            inputs:
+              version: '7.x'
+
+          - task: UseGitVersion@5
+            displayName: 'UseGitVersion (preview)'
+            inputs:
+              versionSpec: '5.12'
+              includePrerelease: true
+              updateAssemblyInfo: false
+            env:
+              BUILD_BUILDNUMBER: $(GitVersion.NuGetVersionV2)
+
+          - task: DotNetCoreCLI@2
+            inputs:
+              command: 'restore'
+
+          - task: DotNetCoreCLI@1
+            inputs:
+              command: 'build'
+              project: '$(solution)'
+              configuration: '$(buildConfiguration)'
+              buildProperties: 'Version="$(build.buildNumber)"'
+
+          - task: DotNetCoreCLI@2
+            inputs:
+              project: '$(solution)'
+              configuration: '$(buildConfiguration)'

--- a/azure-pipelines-pullrequests.yml
+++ b/azure-pipelines-pullrequests.yml
@@ -8,7 +8,7 @@ trigger: none
 pr:
   branches:
     include:
-      - '*'  # must quote since "*" is a YAML reserved character; we want a string
+    - '*'  # must quote since "*" is a YAML reserved character; we want a string
 
 pool:
   vmImage: 'windows-latest'
@@ -18,58 +18,37 @@ variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
 
-stages:
-  - stage: Build on Windows
-    jobs:
-      - job: 'Build on Windows'
-        pool:
-          vmImage: 'windows-latest'
-        steps:
-          - task: NuGetToolInstaller@1
+steps:
+- task: NuGetToolInstaller@1
 
-          - task: UseDotNet@2
-            inputs:
-              version: '7.x'
+- task: UseGitVersion@5
+  displayName: 'UseGitVersion (preview)'
+  inputs:
+    versionSpec: '5.12'
+    includePrerelease: true
+    updateAssemblyInfo: false
+  env:
+      BUILD_BUILDNUMBER: $(GitVersion.NuGetVersionV2)
 
-          - task: NuGetCommand@2
-            inputs:
-              restoreSolution: '$(solution)'
+- task: NuGetCommand@2
+  inputs:
+    restoreSolution: '$(solution)'
 
-          - task: VSBuild@1
-            inputs:
-              solution: '$(solution)'
-              platform: '$(buildPlatform)'
-            configuration: '$(buildConfiguration)'
+- task: VSBuild@1
+  inputs:
+    solution: '$(solution)'
+    platform: '$(buildPlatform)'
+    configuration: '$(buildConfiguration)'
+    msbuildArgs: '/p:Version="$(build.buildNumber)"'
 
-          - task: VSTest@2
-            inputs:
-              platform: '$(buildPlatform)'
-              configuration: '$(buildConfiguration)'
-              diagnosticsEnabled: true
+- task: VSTest@2
+  inputs:
+    platform: '$(buildPlatform)'
+    configuration: '$(buildConfiguration)'
+    diagnosticsEnabled: true
 
-  - stage: Build on Ubuntu
-    dependsOn: []
-    jobs:
-      - job: 'Build on Ubuntu'
-        pool:
-          vmImage: 'ubuntu-latest'
-        steps:
-          - task: UseDotNet@2
-            inputs:
-              version: '7.x'
-
-          - task: DotNetCoreCLI@2
-            inputs:
-              command: 'restore'
-
-          - task: DotNetCoreCLI@1
-            inputs:
-              command: 'build'
-              project: '$(solution)'
-              configuration: '$(buildConfiguration)'
-
-          - task: DotNetCoreCLI@2
-            inputs:
-              command: 'test'
-              project: '$(solution)'
-              configuration: '$(buildConfiguration)'
+- task: PublishBuildArtifacts@1
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+    ArtifactName: 'drop'
+    publishLocation: 'Container'

--- a/azure-pipelines-pullrequests.yml
+++ b/azure-pipelines-pullrequests.yml
@@ -31,15 +31,6 @@ stages:
             inputs:
               version: '7.x'
 
-          - task: UseGitVersion@5
-            displayName: 'UseGitVersion (preview)'
-            inputs:
-              versionSpec: '5.12'
-              includePrerelease: true
-              updateAssemblyInfo: false
-            env:
-              BUILD_BUILDNUMBER: $(GitVersion.NuGetVersionV2)
-
           - task: NuGetCommand@2
             inputs:
               restoreSolution: '$(solution)'
@@ -49,7 +40,6 @@ stages:
               solution: '$(solution)'
               platform: '$(buildPlatform)'
             configuration: '$(buildConfiguration)'
-            msbuildArgs: '/p:Version="$(build.buildNumber)"'
 
           - task: VSTest@2
             inputs:
@@ -68,15 +58,6 @@ stages:
             inputs:
               version: '7.x'
 
-          - task: UseGitVersion@5
-            displayName: 'UseGitVersion (preview)'
-            inputs:
-              versionSpec: '5.12'
-              includePrerelease: true
-              updateAssemblyInfo: false
-            env:
-              BUILD_BUILDNUMBER: $(GitVersion.NuGetVersionV2)
-
           - task: DotNetCoreCLI@2
             inputs:
               command: 'restore'
@@ -86,9 +67,9 @@ stages:
               command: 'build'
               project: '$(solution)'
               configuration: '$(buildConfiguration)'
-              buildProperties: 'Version="$(build.buildNumber)"'
 
           - task: DotNetCoreCLI@2
             inputs:
+              command: 'test'
               project: '$(solution)'
               configuration: '$(buildConfiguration)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,16 +6,16 @@
 trigger:
   branches:
     include:
-      - release/*
-      - develop
-      - master
+    - release/*
+    - develop
+    - master
   tags:
     include:
-      - v1.*
-      - v2.*
-      - v3.*
-      - v4.*
-      - v5.*
+    - v1.*
+    - v2.*
+    - v3.*
+    - v4.*
+    - v5.*
 
 pr: none
 
@@ -27,141 +27,84 @@ variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
 
-stages:
-  - stage: Build on Windows
-    jobs:
-      - job: 'Build on Windows'
-        pool:
-          vmImage: 'windows-latest'
-        steps:
-          - task: NuGetToolInstaller@1
+steps:
+- task: NuGetToolInstaller@1
 
-          - task: UseDotNet@2
-            inputs:
-              version: '7.x'
+- task: gitversion/setup@0
+  displayName: 'Install GitVersion (using GitTools 0.10.2.23031113 or later)'
+  inputs:
+    versionSpec: '5.12'
+    includePrerelease: true
 
-          - task: UseGitVersion@5
-            displayName: 'UseGitVersion (preview)'
-            inputs:
-              versionSpec: '5.12'
-              includePrerelease: true
-              updateAssemblyInfo: false
-            env:
-              BUILD_BUILDNUMBER: $(GitVersion.NuGetVersionV2)
+- task: gitversion/execute@0
+  displayName: 'Execute GitVersion (using GitTools 0.10.2.23031113 or later)'
+  inputs:
+    updateAssemblyInfo: false
+  env:
+      BUILD_BUILDNUMBER: $(GitVersion.NuGetVersionV2)
 
-          - task: gitversion/execute@0
-            displayName: 'Execute GitVersion (using GitTools 0.10.2.23031113 or later)'
-            inputs:
-              updateAssemblyInfo: false
-            env:
-              BUILD_BUILDNUMBER: $(GitVersion.NuGetVersionV2)
+- task: NuGetCommand@2
+  inputs:
+    restoreSolution: '$(solution)'
 
-          - task: NuGetCommand@2
-            inputs:
-              restoreSolution: '$(solution)'
+- task: VSBuild@1
+  inputs:
+    solution: '$(solution)'
+    platform: '$(buildPlatform)'
+    configuration: '$(buildConfiguration)'
+    msbuildArgs: '/p:Version="$(build.buildNumber)"'
 
-          - task: VSBuild@1
-            inputs:
-              solution: '$(solution)'
-              platform: '$(buildPlatform)'
-            configuration: '$(buildConfiguration)'
-            msbuildArgs: '/p:Version="$(build.buildNumber)"'
+- task: VSTest@2
+  inputs:
+    platform: '$(buildPlatform)'
+    configuration: '$(buildConfiguration)'
+    diagnosticsEnabled: true
 
-          - task: VSTest@2
-            inputs:
-              platform: '$(buildPlatform)'
-              configuration: '$(buildConfiguration)'
-              diagnosticsEnabled: true
+- task: CmdLine@2
+  inputs:
+    script: 'dotnet pack $(Build.SourcesDirectory)\FluentMigrator.sln --output $(Build.ArtifactStagingDirectory) --include-symbols -p:Configuration=$(buildConfiguration) -p:Version=$(build.buildNumber) --verbosity Detailed'
 
-          - task: DotNetCoreCLI@2
-            inputs:
-              command: 'publish'
-              publishWebProjects: false
-              projects: 'src/FluentMigrator.Console/FluentMigrator.Console.csproj'
-              configuration: '$(buildConfiguration)'
-              outputDir: '$(Build.ArtifactStagingDirectory)/publish/tools/net48/x86'
-              arguments: '-r win7-x86 -o "$(Build.ArtifactStagingDirectory)/publish/tools/net48/x86" -p:Platform=x86 -p:TargetFramework=net48 -p:Version=$(build.buildNumber)'
-              zipAfterPublish: false
-              modifyOutputPath: false
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'publish'
+    publishWebProjects: false
+    projects: 'src/FluentMigrator.Console/FluentMigrator.Console.csproj'
+    arguments: '-c $(buildConfiguration) -r win7-x86 -o "$(Build.ArtifactStagingDirectory)/publish/tools/net48/x86" -p:Platform=x86 -p:TargetFramework=net48 -p:Version=$(build.buildNumber)'
+    zipAfterPublish: false
+    modifyOutputPath: false
 
-          - task: DotNetCoreCLI@2
-            inputs:
-              command: 'publish'
-              publishWebProjects: false
-              projects: 'src/FluentMigrator.Console/FluentMigrator.Console.csproj'
-              configuration: '$(buildConfiguration)'
-              outputDir: '$(Build.ArtifactStagingDirectory)/publish/tools/net48/x86'
-              arguments: '-r win7-x64 -o "$(Build.ArtifactStagingDirectory)/publish/tools/net48/x64" -p:Platform=x86 -p:TargetFramework=net48 -p:Version=$(build.buildNumber)'
-              zipAfterPublish: false
-              modifyOutputPath: false
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'publish'
+    publishWebProjects: false
+    projects: 'src/FluentMigrator.Console/FluentMigrator.Console.csproj'
+    arguments: '-c $(buildConfiguration) -r win7-x64 -o "$(Build.ArtifactStagingDirectory)/publish/tools/net48/x64" -p:Platform=x64 -p:TargetFramework=net48 -p:Version=$(build.buildNumber)'
+    zipAfterPublish: false
+    modifyOutputPath: false
 
-          - script: nuget.exe pack $(Build.ArtifactStagingDirectory)/publish/FluentMigrator.Console.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory) -version $(build.buildNumber)
-            displayName: NuGet pack FluentMigrator.Console
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'publish'
+    publishWebProjects: false
+    projects: 'src/FluentMigrator.Console/FluentMigrator.Console.csproj'
+    arguments: '-c $(buildConfiguration) -r any -o "$(Build.ArtifactStagingDirectory)/publish/tools/net48/any" -p:Platform=AnyCpu -p:TargetFramework=net48 -p:Version=$(build.buildNumber)'
+    zipAfterPublish: false
+    modifyOutputPath: false
 
-          - publish: '$(Build.ArtifactStagingDirectory)'
-            displayName: 'Copying FluentMigrator.Console'
+- task: CopyFiles@2
+  inputs:
+    SourceFolder: 'publish'
+    Contents: '**'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)/publish'
 
-  - stage: Build on Ubuntu
-    jobs:
-      - job: 'Build on Ubuntu'
-        pool:
-          vmImage: 'ubuntu-latest'
-        steps:
-          - task: UseDotNet@2
-            inputs:
-              version: '7.x'
+- script: nuget.exe pack $(Build.ArtifactStagingDirectory)/publish/FluentMigrator.Console.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory) -version $(build.buildNumber)
+  displayName: NuGet pack FluentMigrator.Console
+  
+- script: nuget.exe pack $(Build.ArtifactStagingDirectory)/publish/FluentMigrator.Tools.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory) -version $(build.buildNumber)
+  displayName: NuGet pack FluentMigrator.Tools
 
-          - task: UseGitVersion@5
-            displayName: 'UseGitVersion (preview)'
-            inputs:
-              versionSpec: '5.12'
-              includePrerelease: true
-              updateAssemblyInfo: false
-            env:
-              BUILD_BUILDNUMBER: $(GitVersion.NuGetVersionV2)
-
-          - task: gitversion/execute@0
-            displayName: 'Execute GitVersion (using GitTools 0.10.2.23031113 or later)'
-            inputs:
-              updateAssemblyInfo: false
-            env:
-              BUILD_BUILDNUMBER: $(GitVersion.NuGetVersionV2)
-
-          - task: DotNetCoreCLI@2
-            inputs:
-              command: 'restore'
-
-          - task: DotNetCoreCLI@1
-            inputs:
-              command: 'build'
-              project: '$(solution)'
-              configuration: '$(buildConfiguration)'
-              versioningScheme: 'byEnvVar'
-
-          - task: DotNetCoreCLI@2
-            inputs:
-              command: 'test'
-              project: '$(solution)'
-              configuration: '$(buildConfiguration)'
-
-          - task: DotNetCoreCLI@2
-            inputs:
-              command: 'pack'
-              project: '$(solution)'
-              configuration: '$(buildConfiguration)'
-              outputDir: '$(Build.ArtifactStagingDirectory)'
-              includesymbols: true
-              includesource: true
-              versioningScheme: 'byEnvVar'
-
-          - task: CopyFiles@2
-            inputs:
-              SourceFolder: 'publish'
-              Contents: '**'
-              TargetFolder: '$(Build.ArtifactStagingDirectory)/publish'
-
-          - task: PublishBuildArtifacts@1
-            inputs:
-              PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-              ArtifactName: 'drop'
-              publishLocation: 'Container'
+- task: PublishBuildArtifacts@1
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+    ArtifactName: 'drop'
+    publishLocation: 'Container'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,16 +6,16 @@
 trigger:
   branches:
     include:
-    - release/*
-    - develop
-    - master
+      - release/*
+      - develop
+      - master
   tags:
     include:
-    - v1.*
-    - v2.*
-    - v3.*
-    - v4.*
-    - v5.*
+      - v1.*
+      - v2.*
+      - v3.*
+      - v4.*
+      - v5.*
 
 pr: none
 
@@ -27,84 +27,141 @@ variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
 
-steps:
-- task: NuGetToolInstaller@1
+stages:
+  - stage: Build on Windows
+    jobs:
+      - job: 'Build on Windows'
+        pool:
+          vmImage: 'windows-latest'
+        steps:
+          - task: NuGetToolInstaller@1
 
-- task: gitversion/setup@0
-  displayName: 'Install GitVersion (using GitTools 0.10.2.23031113 or later)'
-  inputs:
-    versionSpec: '5.12'
-    includePrerelease: true
+          - task: UseDotNet@2
+            inputs:
+              version: '7.x'
 
-- task: gitversion/execute@0
-  displayName: 'Execute GitVersion (using GitTools 0.10.2.23031113 or later)'
-  inputs:
-    updateAssemblyInfo: false
-  env:
-      BUILD_BUILDNUMBER: $(GitVersion.NuGetVersionV2)
+          - task: UseGitVersion@5
+            displayName: 'UseGitVersion (preview)'
+            inputs:
+              versionSpec: '5.12'
+              includePrerelease: true
+              updateAssemblyInfo: false
+            env:
+              BUILD_BUILDNUMBER: $(GitVersion.NuGetVersionV2)
 
-- task: NuGetCommand@2
-  inputs:
-    restoreSolution: '$(solution)'
+          - task: gitversion/execute@0
+            displayName: 'Execute GitVersion (using GitTools 0.10.2.23031113 or later)'
+            inputs:
+              updateAssemblyInfo: false
+            env:
+              BUILD_BUILDNUMBER: $(GitVersion.NuGetVersionV2)
 
-- task: VSBuild@1
-  inputs:
-    solution: '$(solution)'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    msbuildArgs: '/p:Version="$(build.buildNumber)"'
+          - task: NuGetCommand@2
+            inputs:
+              restoreSolution: '$(solution)'
 
-- task: VSTest@2
-  inputs:
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    diagnosticsEnabled: true
+          - task: VSBuild@1
+            inputs:
+              solution: '$(solution)'
+              platform: '$(buildPlatform)'
+            configuration: '$(buildConfiguration)'
+            msbuildArgs: '/p:Version="$(build.buildNumber)"'
 
-- task: CmdLine@2
-  inputs:
-    script: 'dotnet pack $(Build.SourcesDirectory)\FluentMigrator.sln --output $(Build.ArtifactStagingDirectory) --include-symbols -p:Configuration=$(buildConfiguration) -p:Version=$(build.buildNumber) --verbosity Detailed'
+          - task: VSTest@2
+            inputs:
+              platform: '$(buildPlatform)'
+              configuration: '$(buildConfiguration)'
+              diagnosticsEnabled: true
 
-- task: DotNetCoreCLI@2
-  inputs:
-    command: 'publish'
-    publishWebProjects: false
-    projects: 'src/FluentMigrator.Console/FluentMigrator.Console.csproj'
-    arguments: '-c $(buildConfiguration) -r win7-x86 -o "$(Build.ArtifactStagingDirectory)/publish/tools/net48/x86" -p:Platform=x86 -p:TargetFramework=net48 -p:Version=$(build.buildNumber)'
-    zipAfterPublish: false
-    modifyOutputPath: false
+          - task: DotNetCoreCLI@2
+            inputs:
+              command: 'publish'
+              publishWebProjects: false
+              projects: 'src/FluentMigrator.Console/FluentMigrator.Console.csproj'
+              configuration: '$(buildConfiguration)'
+              outputDir: '$(Build.ArtifactStagingDirectory)/publish/tools/net48/x86'
+              arguments: '-r win7-x86 -o "$(Build.ArtifactStagingDirectory)/publish/tools/net48/x86" -p:Platform=x86 -p:TargetFramework=net48 -p:Version=$(build.buildNumber)'
+              zipAfterPublish: false
+              modifyOutputPath: false
 
-- task: DotNetCoreCLI@2
-  inputs:
-    command: 'publish'
-    publishWebProjects: false
-    projects: 'src/FluentMigrator.Console/FluentMigrator.Console.csproj'
-    arguments: '-c $(buildConfiguration) -r win7-x64 -o "$(Build.ArtifactStagingDirectory)/publish/tools/net48/x64" -p:Platform=x64 -p:TargetFramework=net48 -p:Version=$(build.buildNumber)'
-    zipAfterPublish: false
-    modifyOutputPath: false
+          - task: DotNetCoreCLI@2
+            inputs:
+              command: 'publish'
+              publishWebProjects: false
+              projects: 'src/FluentMigrator.Console/FluentMigrator.Console.csproj'
+              configuration: '$(buildConfiguration)'
+              outputDir: '$(Build.ArtifactStagingDirectory)/publish/tools/net48/x86'
+              arguments: '-r win7-x64 -o "$(Build.ArtifactStagingDirectory)/publish/tools/net48/x64" -p:Platform=x86 -p:TargetFramework=net48 -p:Version=$(build.buildNumber)'
+              zipAfterPublish: false
+              modifyOutputPath: false
 
-- task: DotNetCoreCLI@2
-  inputs:
-    command: 'publish'
-    publishWebProjects: false
-    projects: 'src/FluentMigrator.Console/FluentMigrator.Console.csproj'
-    arguments: '-c $(buildConfiguration) -r any -o "$(Build.ArtifactStagingDirectory)/publish/tools/net48/any" -p:Platform=AnyCpu -p:TargetFramework=net48 -p:Version=$(build.buildNumber)'
-    zipAfterPublish: false
-    modifyOutputPath: false
+          - script: nuget.exe pack $(Build.ArtifactStagingDirectory)/publish/FluentMigrator.Console.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory) -version $(build.buildNumber)
+            displayName: NuGet pack FluentMigrator.Console
 
-- task: CopyFiles@2
-  inputs:
-    SourceFolder: 'publish'
-    Contents: '**'
-    TargetFolder: '$(Build.ArtifactStagingDirectory)/publish'
+          - publish: '$(Build.ArtifactStagingDirectory)'
+            displayName: 'Copying FluentMigrator.Console'
 
-- script: nuget.exe pack $(Build.ArtifactStagingDirectory)/publish/FluentMigrator.Console.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory) -version $(build.buildNumber)
-  displayName: NuGet pack FluentMigrator.Console
-  
-- script: nuget.exe pack $(Build.ArtifactStagingDirectory)/publish/FluentMigrator.Tools.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory) -version $(build.buildNumber)
-  displayName: NuGet pack FluentMigrator.Tools
+  - stage: Build on Ubuntu
+    jobs:
+      - job: 'Build on Ubuntu'
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+          - task: UseDotNet@2
+            inputs:
+              version: '7.x'
 
-- task: PublishBuildArtifacts@1
-  inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-    ArtifactName: 'drop'
-    publishLocation: 'Container'
+          - task: UseGitVersion@5
+            displayName: 'UseGitVersion (preview)'
+            inputs:
+              versionSpec: '5.12'
+              includePrerelease: true
+              updateAssemblyInfo: false
+            env:
+              BUILD_BUILDNUMBER: $(GitVersion.NuGetVersionV2)
+
+          - task: gitversion/execute@0
+            displayName: 'Execute GitVersion (using GitTools 0.10.2.23031113 or later)'
+            inputs:
+              updateAssemblyInfo: false
+            env:
+              BUILD_BUILDNUMBER: $(GitVersion.NuGetVersionV2)
+
+          - task: DotNetCoreCLI@2
+            inputs:
+              command: 'restore'
+
+          - task: DotNetCoreCLI@1
+            inputs:
+              command: 'build'
+              project: '$(solution)'
+              configuration: '$(buildConfiguration)'
+              versioningScheme: 'byEnvVar'
+
+          - task: DotNetCoreCLI@2
+            inputs:
+              command: 'test'
+              project: '$(solution)'
+              configuration: '$(buildConfiguration)'
+
+          - task: DotNetCoreCLI@2
+            inputs:
+              command: 'pack'
+              project: '$(solution)'
+              configuration: '$(buildConfiguration)'
+              outputDir: '$(Build.ArtifactStagingDirectory)'
+              includesymbols: true
+              includesource: true
+              versioningScheme: 'byEnvVar'
+
+          - task: CopyFiles@2
+            inputs:
+              SourceFolder: 'publish'
+              Contents: '**'
+              TargetFolder: '$(Build.ArtifactStagingDirectory)/publish'
+
+          - task: PublishBuildArtifacts@1
+            inputs:
+              PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+              ArtifactName: 'drop'
+              publishLocation: 'Container'

--- a/src/FluentMigrator.Abstractions/FluentMigrator.Abstractions.csproj
+++ b/src/FluentMigrator.Abstractions/FluentMigrator.Abstractions.csproj
@@ -7,7 +7,7 @@
     <SuppressPseudoWarning Condition="'$(Configuration)' == 'Debug'">true</SuppressPseudoWarning>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>FluentMigrator</RootNamespace>
     <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>

--- a/src/FluentMigrator.Abstractions/FluentMigrator.Abstractions.csproj
+++ b/src/FluentMigrator.Abstractions/FluentMigrator.Abstractions.csproj
@@ -7,9 +7,8 @@
     <SuppressPseudoWarning Condition="'$(Configuration)' == 'Debug'">true</SuppressPseudoWarning>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <RootNamespace>FluentMigrator</RootNamespace>
-    <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\FluentMigrator.snk</AssemblyOriginatorKeyFile>

--- a/src/FluentMigrator.Extensions.Oracle/FluentMigrator.Extensions.Oracle.csproj
+++ b/src/FluentMigrator.Extensions.Oracle/FluentMigrator.Extensions.Oracle.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <RootNamespace>FluentMigrator</RootNamespace>
-    <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\FluentMigrator.snk</AssemblyOriginatorKeyFile>

--- a/src/FluentMigrator.Extensions.Oracle/FluentMigrator.Extensions.Oracle.csproj
+++ b/src/FluentMigrator.Extensions.Oracle/FluentMigrator.Extensions.Oracle.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>FluentMigrator</RootNamespace>
     <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>

--- a/src/FluentMigrator.Extensions.Postgres/FluentMigrator.Extensions.Postgres.csproj
+++ b/src/FluentMigrator.Extensions.Postgres/FluentMigrator.Extensions.Postgres.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>FluentMigrator</RootNamespace>
     <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>

--- a/src/FluentMigrator.Extensions.Postgres/FluentMigrator.Extensions.Postgres.csproj
+++ b/src/FluentMigrator.Extensions.Postgres/FluentMigrator.Extensions.Postgres.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <RootNamespace>FluentMigrator</RootNamespace>
-    <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\FluentMigrator.snk</AssemblyOriginatorKeyFile>

--- a/src/FluentMigrator.Extensions.SqlServer/FluentMigrator.Extensions.SqlServer.csproj
+++ b/src/FluentMigrator.Extensions.SqlServer/FluentMigrator.Extensions.SqlServer.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <RootNamespace>FluentMigrator</RootNamespace>
-    <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\FluentMigrator.snk</AssemblyOriginatorKeyFile>

--- a/src/FluentMigrator.Extensions.SqlServer/FluentMigrator.Extensions.SqlServer.csproj
+++ b/src/FluentMigrator.Extensions.SqlServer/FluentMigrator.Extensions.SqlServer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>FluentMigrator</RootNamespace>
     <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>

--- a/src/FluentMigrator.MSBuild/FluentMigrator.MSBuild.csproj
+++ b/src/FluentMigrator.MSBuild/FluentMigrator.MSBuild.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
     <Description>MSBuild runner for FluentMigrator</Description>
   </PropertyGroup>
   <Import Project="$(MSBuildThisFileDirectory)../../PackageTool.props" />
@@ -21,7 +21,7 @@
       <Version>14.3.0</Version>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="Microsoft.Build.Utilities.Core">
       <Version>17.7.2</Version>
     </PackageReference>

--- a/src/FluentMigrator.MSBuild/FluentMigrator.MSBuild.csproj
+++ b/src/FluentMigrator.MSBuild/FluentMigrator.MSBuild.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <Description>MSBuild runner for FluentMigrator</Description>
   </PropertyGroup>
   <Import Project="$(MSBuildThisFileDirectory)../../PackageTool.props" />

--- a/src/FluentMigrator.Runner.Core/FluentMigrator.Runner.Core.csproj
+++ b/src/FluentMigrator.Runner.Core/FluentMigrator.Runner.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
     <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\FluentMigrator.snk</AssemblyOriginatorKeyFile>

--- a/src/FluentMigrator.Runner.Core/FluentMigrator.Runner.Core.csproj
+++ b/src/FluentMigrator.Runner.Core/FluentMigrator.Runner.Core.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
-    <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\FluentMigrator.snk</AssemblyOriginatorKeyFile>
     <RootNamespace>FluentMigrator.Runner</RootNamespace>

--- a/src/FluentMigrator.Runner.Core/Initialization/DefaultConnectionStringProvider.cs
+++ b/src/FluentMigrator.Runner.Core/Initialization/DefaultConnectionStringProvider.cs
@@ -21,8 +21,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
-using JetBrains.Annotations;
-
 #if NETFRAMEWORK
 using FluentMigrator.Runner.Initialization.NetFramework;
 using Microsoft.Extensions.Options;
@@ -33,8 +31,8 @@ namespace FluentMigrator.Runner.Initialization
     [Obsolete]
     public class DefaultConnectionStringProvider : IConnectionStringProvider
     {
-        [CanBeNull]
-        [ItemNotNull]
+        [JetBrains.Annotations.CanBeNull]
+        [JetBrains.Annotations.ItemCanBeNull]
         private readonly IReadOnlyCollection<IConnectionStringReader> _accessors;
 
         private readonly object _syncRoot = new object();
@@ -45,7 +43,13 @@ namespace FluentMigrator.Runner.Initialization
         {
         }
 
-        public DefaultConnectionStringProvider([NotNull, ItemNotNull] IEnumerable<IConnectionStringReader> accessors)
+        public DefaultConnectionStringProvider([
+            JetBrains.Annotations.NotNull,
+            JetBrains.Annotations.ItemNotNull
+            #if NET6
+            , System.Diagnostics.CodeAnalysis.NotNull
+            #endif
+        ] IEnumerable<IConnectionStringReader> accessors)
         {
             _accessors = accessors.ToList();
         }

--- a/src/FluentMigrator.Runner.Db2/FluentMigrator.Runner.Db2.csproj
+++ b/src/FluentMigrator.Runner.Db2/FluentMigrator.Runner.Db2.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>FluentMigrator.Runner</RootNamespace>
     <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>

--- a/src/FluentMigrator.Runner.Db2/FluentMigrator.Runner.Db2.csproj
+++ b/src/FluentMigrator.Runner.Db2/FluentMigrator.Runner.Db2.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <RootNamespace>FluentMigrator.Runner</RootNamespace>
-    <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\FluentMigrator.snk</AssemblyOriginatorKeyFile>

--- a/src/FluentMigrator.Runner.Firebird/FluentMigrator.Runner.Firebird.csproj
+++ b/src/FluentMigrator.Runner.Firebird/FluentMigrator.Runner.Firebird.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>FluentMigrator.Runner</RootNamespace>
     <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>

--- a/src/FluentMigrator.Runner.Firebird/FluentMigrator.Runner.Firebird.csproj
+++ b/src/FluentMigrator.Runner.Firebird/FluentMigrator.Runner.Firebird.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <RootNamespace>FluentMigrator.Runner</RootNamespace>
     <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>

--- a/src/FluentMigrator.Runner.Hana/FluentMigrator.Runner.Hana.csproj
+++ b/src/FluentMigrator.Runner.Hana/FluentMigrator.Runner.Hana.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>FluentMigrator.Runner</RootNamespace>
     <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>

--- a/src/FluentMigrator.Runner.Hana/FluentMigrator.Runner.Hana.csproj
+++ b/src/FluentMigrator.Runner.Hana/FluentMigrator.Runner.Hana.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <RootNamespace>FluentMigrator.Runner</RootNamespace>
-    <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\FluentMigrator.snk</AssemblyOriginatorKeyFile>

--- a/src/FluentMigrator.Runner.Hana/Processors/Hana/HanaDbFactory.cs
+++ b/src/FluentMigrator.Runner.Hana/Processors/Hana/HanaDbFactory.cs
@@ -39,6 +39,7 @@ namespace FluentMigrator.Runner.Processors.Hana
         {
             yield return new TestEntry("Sap.Data.Hana", "Sap.Data.Hana.HanaFactory");
             yield return new TestEntry("Sap.Data.Hana.v4.5", "Sap.Data.Hana.HanaFactory");
+            yield return new TestEntry("Sap.Data.Hana.Core.v2.1", "Sap.Data.Hana.HanaFactory");
         }
     }
 }

--- a/src/FluentMigrator.Runner.Jet/FluentMigrator.Runner.Jet.csproj
+++ b/src/FluentMigrator.Runner.Jet/FluentMigrator.Runner.Jet.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>net48</TargetFrameworks>
     <RootNamespace>FluentMigrator.Runner</RootNamespace>
-    <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\FluentMigrator.snk</AssemblyOriginatorKeyFile>

--- a/src/FluentMigrator.Runner.MySql/FluentMigrator.Runner.MySql.csproj
+++ b/src/FluentMigrator.Runner.MySql/FluentMigrator.Runner.MySql.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>FluentMigrator.Runner</RootNamespace>
     <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>

--- a/src/FluentMigrator.Runner.MySql/FluentMigrator.Runner.MySql.csproj
+++ b/src/FluentMigrator.Runner.MySql/FluentMigrator.Runner.MySql.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <RootNamespace>FluentMigrator.Runner</RootNamespace>
-    <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\FluentMigrator.snk</AssemblyOriginatorKeyFile>

--- a/src/FluentMigrator.Runner.Oracle/FluentMigrator.Runner.Oracle.csproj
+++ b/src/FluentMigrator.Runner.Oracle/FluentMigrator.Runner.Oracle.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>FluentMigrator.Runner</RootNamespace>
     <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>

--- a/src/FluentMigrator.Runner.Oracle/FluentMigrator.Runner.Oracle.csproj
+++ b/src/FluentMigrator.Runner.Oracle/FluentMigrator.Runner.Oracle.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <RootNamespace>FluentMigrator.Runner</RootNamespace>
-    <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\FluentMigrator.snk</AssemblyOriginatorKeyFile>

--- a/src/FluentMigrator.Runner.Postgres/FluentMigrator.Runner.Postgres.csproj
+++ b/src/FluentMigrator.Runner.Postgres/FluentMigrator.Runner.Postgres.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>FluentMigrator.Runner</RootNamespace>
     <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>

--- a/src/FluentMigrator.Runner.Postgres/FluentMigrator.Runner.Postgres.csproj
+++ b/src/FluentMigrator.Runner.Postgres/FluentMigrator.Runner.Postgres.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <RootNamespace>FluentMigrator.Runner</RootNamespace>
-    <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\FluentMigrator.snk</AssemblyOriginatorKeyFile>

--- a/src/FluentMigrator.Runner.Redshift/FluentMigrator.Runner.Redshift.csproj
+++ b/src/FluentMigrator.Runner.Redshift/FluentMigrator.Runner.Redshift.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>FluentMigrator.Runner</RootNamespace>
     <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>

--- a/src/FluentMigrator.Runner.Redshift/FluentMigrator.Runner.Redshift.csproj
+++ b/src/FluentMigrator.Runner.Redshift/FluentMigrator.Runner.Redshift.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <RootNamespace>FluentMigrator.Runner</RootNamespace>
-    <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\FluentMigrator.snk</AssemblyOriginatorKeyFile>

--- a/src/FluentMigrator.Runner.SQLite/FluentMigrator.Runner.SQLite.csproj
+++ b/src/FluentMigrator.Runner.SQLite/FluentMigrator.Runner.SQLite.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>FluentMigrator.Runner</RootNamespace>
     <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>

--- a/src/FluentMigrator.Runner.SQLite/FluentMigrator.Runner.SQLite.csproj
+++ b/src/FluentMigrator.Runner.SQLite/FluentMigrator.Runner.SQLite.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <RootNamespace>FluentMigrator.Runner</RootNamespace>
-    <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\FluentMigrator.snk</AssemblyOriginatorKeyFile>

--- a/src/FluentMigrator.Runner.SqlServer/FluentMigrator.Runner.SqlServer.csproj
+++ b/src/FluentMigrator.Runner.SqlServer/FluentMigrator.Runner.SqlServer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>FluentMigrator.Runner</RootNamespace>
     <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>

--- a/src/FluentMigrator.Runner.SqlServer/FluentMigrator.Runner.SqlServer.csproj
+++ b/src/FluentMigrator.Runner.SqlServer/FluentMigrator.Runner.SqlServer.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <RootNamespace>FluentMigrator.Runner</RootNamespace>
-    <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\FluentMigrator.snk</AssemblyOriginatorKeyFile>

--- a/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
+++ b/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
     <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\FluentMigrator.snk</AssemblyOriginatorKeyFile>

--- a/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
+++ b/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
-    <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\FluentMigrator.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/FluentMigrator/FluentMigrator.csproj
+++ b/src/FluentMigrator/FluentMigrator.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <RootNamespace>FluentMigrator</RootNamespace>
-    <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\FluentMigrator.snk</AssemblyOriginatorKeyFile>

--- a/src/FluentMigrator/FluentMigrator.csproj
+++ b/src/FluentMigrator/FluentMigrator.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>FluentMigrator</RootNamespace>
     <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <PackageTags>fluent;migrator;fluentmigrator;migration;database</PackageTags>

--- a/test/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/test/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\FluentMigrator.snk</AssemblyOriginatorKeyFile>
     <UserSecretsId>FluentMigrator.Tests</UserSecretsId>
@@ -47,15 +47,13 @@
     <ProjectReference Include="..\..\src\FluentMigrator.Runner.SQLite\FluentMigrator.Runner.SQLite.csproj" />
     <ProjectReference Include="..\..\src\FluentMigrator.Runner.SqlServer\FluentMigrator.Runner.SqlServer.csproj" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
     <Reference Include="IBM.Data.DB2">
       <HintPath>..\..\lib\DB2\amd64\IBM.Data.DB2.dll</HintPath>
     </Reference>
     <Reference Include="Sap.Data.Hana.v4.5">
       <HintPath>..\..\lib\Hana\ado.net\v4.5\Sap.Data.Hana.v4.5.dll</HintPath>
     </Reference>
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="../../lib/DB2/clidriver/**/*.*">
       <Link>clidriver/%(RecursiveDir)%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -64,10 +62,17 @@
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>
-  <ItemGroup Condition=" '$(MSBuildRuntimeType)' == 'Core' or '$(OS)' != 'Windows_NT' ">
     <Compile Remove="Integration\Processors\Jet\**" />
     <Compile Remove="Helpers\JetTestTable.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' and '$(OS)' == 'Windows_NT' ">
+    <PackageReference Include="IBM.Data.DB2.Core" Version="3.1.0.600" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' and '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' ">
+    <PackageReference Include="IBM.Data.DB2.Core-lnx" Version="3.1.0.500" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' and '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' ">
+    <PackageReference Include="IBM.Data.DB2.Core-osx" Version="3.1.0.500" />
   </ItemGroup>
   <ItemGroup>
     <None Update="appsettings.json">

--- a/test/FluentMigrator.Tests/Helpers/HanaTestSequence.cs
+++ b/test/FluentMigrator.Tests/Helpers/HanaTestSequence.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 #endregion
 
+#if NETFRAMEWORK
 using System;
 using System.Data;
 
@@ -78,3 +79,4 @@ namespace FluentMigrator.Tests.Helpers
         }
     }
 }
+#endif

--- a/test/FluentMigrator.Tests/Helpers/HanaTestTable.cs
+++ b/test/FluentMigrator.Tests/Helpers/HanaTestTable.cs
@@ -1,3 +1,4 @@
+#if NETFRAMEWORK
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -126,3 +127,4 @@ namespace FluentMigrator.Tests.Helpers
         }
     }
 }
+#endif

--- a/test/FluentMigrator.Tests/Helpers/JetTestTable.cs
+++ b/test/FluentMigrator.Tests/Helpers/JetTestTable.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 #endregion
 
+#if NETFRAMEWORK
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -104,3 +105,4 @@ namespace FluentMigrator.Tests.Helpers
         }
     }
 }
+#endif

--- a/test/FluentMigrator.Tests/Integration/Processors/Db2/Db2ColumnTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Db2/Db2ColumnTests.cs
@@ -148,8 +148,14 @@ namespace FluentMigrator.Tests.Integration.Processors.Db2
 
         private static void EnsureReference()
         {
+
             // This is here to avoid the removal of the referenced assembly
+#if NETFRAMEWORK
             Debug.WriteLine(typeof(IBM.Data.DB2.DB2Factory));
+#else
+            Debug.Write(typeof(IBM.Data.DB2.Core.DB2Factory));
+#endif
+
         }
     }
 }

--- a/test/FluentMigrator.Tests/Integration/Processors/Db2/Db2ConstraintTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Db2/Db2ConstraintTests.cs
@@ -37,7 +37,14 @@ namespace FluentMigrator.Tests.Integration.Processors.Db2
     {
         static Db2ConstraintTests()
         {
-            try { EnsureReference(); } catch { /* ignore */ }
+            try
+            {
+                EnsureReference();
+            }
+            catch
+            {
+                /* ignore */
+            }
         }
 
         private ServiceProvider ServiceProvider { get; set; }
@@ -149,7 +156,11 @@ namespace FluentMigrator.Tests.Integration.Processors.Db2
         private static void EnsureReference()
         {
             // This is here to avoid the removal of the referenced assembly
+#if NETFRAMEWORK
             Debug.WriteLine(typeof(IBM.Data.DB2.DB2Factory));
+#else
+            Debug.Write(typeof(IBM.Data.DB2.Core.DB2Factory));
+#endif
         }
     }
 }

--- a/test/FluentMigrator.Tests/Integration/Processors/Db2/Db2IndexTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Db2/Db2IndexTests.cs
@@ -149,8 +149,14 @@ namespace FluentMigrator.Tests.Integration.Processors.Db2
 
         private static void EnsureReference()
         {
+
             // This is here to avoid the removal of the referenced assembly
+#if NETFRAMEWORK
             Debug.WriteLine(typeof(IBM.Data.DB2.DB2Factory));
+#else
+            Debug.Write(typeof(IBM.Data.DB2.Core.DB2Factory));
+#endif
+
         }
     }
 }

--- a/test/FluentMigrator.Tests/Integration/Processors/Db2/Db2ProcessorTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Db2/Db2ProcessorTests.cs
@@ -107,8 +107,14 @@ namespace FluentMigrator.Tests.Integration.Processors.Db2
 
         private static void EnsureReference()
         {
+
             // This is here to avoid the removal of the referenced assembly
+#if NETFRAMEWORK
             Debug.WriteLine(typeof(IBM.Data.DB2.DB2Factory));
+#else
+            Debug.Write(typeof(IBM.Data.DB2.Core.DB2Factory));
+#endif
+
         }
     }
 }

--- a/test/FluentMigrator.Tests/Integration/Processors/Db2/Db2SchemaTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Db2/Db2SchemaTests.cs
@@ -95,7 +95,12 @@ namespace FluentMigrator.Tests.Integration.Processors.Db2
         private static void EnsureReference()
         {
             // This is here to avoid the removal of the referenced assembly
+#if NETFRAMEWORK
             Debug.WriteLine(typeof(IBM.Data.DB2.DB2Factory));
+#else
+            Debug.Write(typeof(IBM.Data.DB2.Core.DB2Factory));
+#endif
+
         }
     }
 }

--- a/test/FluentMigrator.Tests/Integration/Processors/Db2/Db2TableTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Db2/Db2TableTests.cs
@@ -119,7 +119,12 @@ namespace FluentMigrator.Tests.Integration.Processors.Db2
         private static void EnsureReference()
         {
             // This is here to avoid the removal of the referenced assembly
+#if NETFRAMEWORK
             Debug.WriteLine(typeof(IBM.Data.DB2.DB2Factory));
+#else
+            Debug.Write(typeof(IBM.Data.DB2.Core.DB2Factory));
+#endif
+
         }
     }
 }

--- a/test/FluentMigrator.Tests/Integration/Processors/Db2ISeries/Db2ISeriesColumnTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Db2ISeries/Db2ISeriesColumnTests.cs
@@ -149,7 +149,11 @@ namespace FluentMigrator.Tests.Integration.Processors.Db2ISeries
         private static void EnsureReference()
         {
             // This is here to avoid the removal of the referenced assembly
+#if NETFRAMEWORK
             Debug.WriteLine(typeof(IBM.Data.DB2.DB2Factory));
+#else
+            Debug.Write(typeof(IBM.Data.DB2.Core.DB2Factory));
+#endif
         }
     }
 }

--- a/test/FluentMigrator.Tests/Integration/Processors/Db2ISeries/Db2ISeriesConstraintTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Db2ISeries/Db2ISeriesConstraintTests.cs
@@ -149,7 +149,12 @@ namespace FluentMigrator.Tests.Integration.Processors.Db2ISeries
         private static void EnsureReference()
         {
             // This is here to avoid the removal of the referenced assembly
+#if NETFRAMEWORK
             Debug.WriteLine(typeof(IBM.Data.DB2.DB2Factory));
+#else
+            Debug.Write(typeof(IBM.Data.DB2.Core.DB2Factory));
+#endif
+
         }
     }
 }

--- a/test/FluentMigrator.Tests/Integration/Processors/Db2ISeries/Db2ISeriesIndexTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Db2ISeries/Db2ISeriesIndexTests.cs
@@ -150,7 +150,12 @@ namespace FluentMigrator.Tests.Integration.Processors.Db2ISeries
         private static void EnsureReference()
         {
             // This is here to avoid the removal of the referenced assembly
+#if NETFRAMEWORK
             Debug.WriteLine(typeof(IBM.Data.DB2.DB2Factory));
+#else
+            Debug.Write(typeof(IBM.Data.DB2.Core.DB2Factory));
+#endif
+
         }
     }
 }

--- a/test/FluentMigrator.Tests/Integration/Processors/Db2ISeries/Db2ISeriesProcessorTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Db2ISeries/Db2ISeriesProcessorTests.cs
@@ -108,7 +108,12 @@ namespace FluentMigrator.Tests.Integration.Processors.Db2ISeries
         private static void EnsureReference()
         {
             // This is here to avoid the removal of the referenced assembly
+#if NETFRAMEWORK
             Debug.WriteLine(typeof(IBM.Data.DB2.DB2Factory));
+#else
+            Debug.Write(typeof(IBM.Data.DB2.Core.DB2Factory));
+#endif
+
         }
     }
 }

--- a/test/FluentMigrator.Tests/Integration/Processors/Db2ISeries/Db2ISeriesSchemaTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Db2ISeries/Db2ISeriesSchemaTests.cs
@@ -95,7 +95,12 @@ namespace FluentMigrator.Tests.Integration.Processors.Db2ISeries
         private static void EnsureReference()
         {
             // This is here to avoid the removal of the referenced assembly
+#if NETFRAMEWORK
             Debug.WriteLine(typeof(IBM.Data.DB2.DB2Factory));
+#else
+            Debug.Write(typeof(IBM.Data.DB2.Core.DB2Factory));
+#endif
+
         }
     }
 }

--- a/test/FluentMigrator.Tests/Integration/Processors/Db2ISeries/Db2ISeriesTableTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Db2ISeries/Db2ISeriesTableTests.cs
@@ -119,7 +119,12 @@ namespace FluentMigrator.Tests.Integration.Processors.Db2ISeries
         private static void EnsureReference()
         {
             // This is here to avoid the removal of the referenced assembly
+#if NETFRAMEWORK
             Debug.WriteLine(typeof(IBM.Data.DB2.DB2Factory));
+#else
+            Debug.Write(typeof(IBM.Data.DB2.Core.DB2Factory));
+#endif
+
         }
     }
 }

--- a/test/FluentMigrator.Tests/Integration/Processors/Hana/EndToEnd/HanaTestDropPrimaryKey.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Hana/EndToEnd/HanaTestDropPrimaryKey.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 #endregion
 
+#if NETFRAMEWORK
 using NUnit.Framework;
 
 namespace FluentMigrator.Tests.Integration.Processors.Hana.EndToEnd
@@ -78,3 +79,4 @@ namespace FluentMigrator.Tests.Integration.Processors.Hana.EndToEnd
         }
     }
 }
+#endif

--- a/test/FluentMigrator.Tests/Integration/Processors/Hana/EndToEnd/HanaTestEndToEnd.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Hana/EndToEnd/HanaTestEndToEnd.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 #endregion
 
+#if NETFRAMEWORK
 using System;
 
 using FluentMigrator.Runner;
@@ -90,3 +91,4 @@ namespace FluentMigrator.Tests.Integration.Processors.Hana.EndToEnd
         }
     }
 }
+#endif

--- a/test/FluentMigrator.Tests/Integration/Processors/Hana/HanaColumnTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Hana/HanaColumnTests.cs
@@ -16,6 +16,8 @@
 //
 #endregion
 
+#if NETFRAMEWORK
+
 using FluentMigrator.Runner;
 using FluentMigrator.Runner.Generators;
 using FluentMigrator.Runner.Generators.Hana;
@@ -130,3 +132,4 @@ namespace FluentMigrator.Tests.Integration.Processors.Hana
         }
     }
 }
+#endif

--- a/test/FluentMigrator.Tests/Integration/Processors/Hana/HanaConstraintTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Hana/HanaConstraintTests.cs
@@ -16,6 +16,7 @@
 //
 #endregion
 
+#if NETFRAMEWORK
 using FluentMigrator.Runner;
 using FluentMigrator.Runner.Initialization;
 using FluentMigrator.Runner.Processors.Hana;
@@ -143,3 +144,4 @@ namespace FluentMigrator.Tests.Integration.Processors.Hana
         }
     }
 }
+#endif

--- a/test/FluentMigrator.Tests/Integration/Processors/Hana/HanaIndexTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Hana/HanaIndexTests.cs
@@ -16,6 +16,7 @@
 //
 #endregion
 
+#if NETFRAMEWORK
 using FluentMigrator.Runner;
 using FluentMigrator.Runner.Generators;
 using FluentMigrator.Runner.Generators.Hana;
@@ -142,3 +143,4 @@ namespace FluentMigrator.Tests.Integration.Processors.Hana
         }
     }
 }
+#endif

--- a/test/FluentMigrator.Tests/Integration/Processors/Hana/HanaProcessorTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Hana/HanaProcessorTests.cs
@@ -16,6 +16,7 @@
 //
 #endregion
 
+#if NETFRAMEWORK
 using System.IO;
 
 using FluentMigrator.Expressions;
@@ -94,3 +95,4 @@ namespace FluentMigrator.Tests.Integration.Processors.Hana
         }
     }
 }
+#endif

--- a/test/FluentMigrator.Tests/Integration/Processors/Hana/HanaSchemaExtensionsTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Hana/HanaSchemaExtensionsTests.cs
@@ -16,6 +16,7 @@
 //
 #endregion
 
+#if NETFRAMEWORK
 using FluentMigrator.Runner;
 using FluentMigrator.Runner.Initialization;
 using FluentMigrator.Runner.Processors.Hana;
@@ -113,3 +114,4 @@ namespace FluentMigrator.Tests.Integration.Processors.Hana
         }
     }
 }
+#endif

--- a/test/FluentMigrator.Tests/Integration/Processors/Hana/HanaSchemaTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Hana/HanaSchemaTests.cs
@@ -16,6 +16,7 @@
 //
 #endregion
 
+#if NETFRAMEWORK
 using FluentMigrator.Runner;
 using FluentMigrator.Runner.Initialization;
 using FluentMigrator.Runner.Processors.Hana;
@@ -82,3 +83,4 @@ namespace FluentMigrator.Tests.Integration.Processors.Hana
         }
     }
 }
+#endif

--- a/test/FluentMigrator.Tests/Integration/Processors/Hana/HanaSequenceTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Hana/HanaSequenceTests.cs
@@ -16,6 +16,7 @@
 //
 #endregion
 
+#if NETFRAMEWORK
 using FluentMigrator.Runner;
 using FluentMigrator.Runner.Initialization;
 using FluentMigrator.Runner.Processors.Hana;
@@ -96,3 +97,4 @@ namespace FluentMigrator.Tests.Integration.Processors.Hana
         }
     }
 }
+#endif

--- a/test/FluentMigrator.Tests/Integration/Processors/Hana/HanaTableTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Hana/HanaTableTests.cs
@@ -16,6 +16,7 @@
 //
 #endregion
 
+#if NETFRAMEWORK
 using FluentMigrator.Runner;
 using FluentMigrator.Runner.Initialization;
 using FluentMigrator.Runner.Processors.Hana;
@@ -103,3 +104,4 @@ namespace FluentMigrator.Tests.Integration.Processors.Hana
         }
     }
 }
+#endif

--- a/test/FluentMigrator.Tests/Integration/Processors/Jet/JetIntegrationTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Jet/JetIntegrationTests.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 #endregion
 
+#if NETFRAMEWORK
+
 using System;
 using System.Data.OleDb;
 using System.IO;
@@ -127,3 +129,5 @@ namespace FluentMigrator.Tests.Integration.Processors.Jet
         }
     }
 }
+
+#endif

--- a/test/FluentMigrator.Tests/Integration/Processors/Jet/JetProcessorTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Jet/JetProcessorTests.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 #endregion
 
+#if NETFRAMEWORK
+
 using System.Data;
 
 using FluentMigrator.Tests.Helpers;
@@ -104,3 +106,4 @@ namespace FluentMigrator.Tests.Integration.Processors.Jet
         }
     }
 }
+#endif

--- a/test/FluentMigrator.Tests/Unit/Initialization/ConnectionStringManagerTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Initialization/ConnectionStringManagerTests.cs
@@ -1,3 +1,4 @@
+
 #region License
 //
 // Copyright (c) 2018, Fluent Migrator Project
@@ -16,6 +17,7 @@
 //
 #endregion
 
+#if NETFRAMEWORK
 using System;
 using System.Collections.Generic;
 using System.Configuration;
@@ -176,3 +178,4 @@ namespace FluentMigrator.Tests.Unit.Initialization
         }
     }
 }
+#endif

--- a/test/FluentMigrator.Tests/Unit/Initialization/NetConfigManagerTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Initialization/NetConfigManagerTests.cs
@@ -16,6 +16,8 @@
 //
 #endregion
 
+#if NETFRAMEWORK
+
 using System;
 using System.Configuration;
 using System.IO;
@@ -94,3 +96,4 @@ namespace FluentMigrator.Tests.Unit.Initialization
         }
     }
 }
+#endif


### PR DESCRIPTION
Adding support to .NET 6 for FluentMigrator

Important point:

- Moved some properties for `Global.props` to `Directory.Build.props`
- Moved from [SourceLink](https://github.com/ctaggart/SourceLink)to [Microsoft.SourceLink.GitHub](https://github.com/dotnet/sourcelink), the main reason is the project is part of .NET Foundation and rename as Microsoft.SourceLink.*
- Added support to build package for .NET Framework in non-Windows machine without need to install Mono (by adding [Microsoft.NETFramework.ReferenceAssemblies](https://www.nuget.org/packages/Microsoft.NETFramework.ReferenceAssemblies/)
- Added a new property called `LibTargetFrameworks` with all target framework, it'll make easier to add or remove support to  .NET version
- Added preprocessor directives in some FluentMigrator.Tests to not run some test in case it's not running on Windows, like JET & SAP HANA
- Added support to test DB2 on non-Windows machine(by adding [IBM.Data.DB2.Core-lnx](https://www.nuget.org/packages/IBM.Data.DB2.Core-lnx) & [IBM.Data.DB2.Core-osx](https://www.nuget.org/packages/IBM.Data.DB2.Core-osx) packages)

Some question
Do you know if anyone has access to SAP, to download SAP Hana Driver to .NET Core?
Should we wait for .NET 8?