### PR TITLE
Updated refrences to MySql.Data to 8.1.0 from 8.0.28

### DIFF
--- a/src/FluentMigrator.Console/FluentMigrator.Console.csproj
+++ b/src/FluentMigrator.Console/FluentMigrator.Console.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.4" />
     <PackageReference Include="Oracle.ManagedDataAccess" Version="12.2.1100" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.7" />
-    <PackageReference Include="MySql.Data" Version="8.0.28" />
+    <PackageReference Include="MySql.Data" Version="8.1.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(Platform)' == 'x86' ">
     <PackageReference Include="Oracle.DataAccess.x86.4" Version="4.112.3" />

--- a/src/FluentMigrator.DotNet.Cli/FluentMigrator.DotNet.Cli.csproj
+++ b/src/FluentMigrator.DotNet.Cli/FluentMigrator.DotNet.Cli.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.1" />
-    <PackageReference Include="MySql.Data" Version="8.0.28" />
+    <PackageReference Include="MySql.Data" Version="8.1.0" />
     <PackageReference Include="Npgsql" Version="3.2.7" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.60" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.7" />

--- a/test/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/test/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="MySql.Data" Version="8.0.28" />
+    <PackageReference Include="MySql.Data" Version="8.1.0" />
     <PackageReference Include="Npgsql" Version="3.2.7" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit.Console" Version="3.16.3" />


### PR DESCRIPTION
Running into a security issue with https://github.com/advisories/GHSA-77rm-9x9h-xj3g. 

Updating the MySql Reference corrects the issue by updating the version of Google.Protobuf used. 