### PR TITLE
#1737: Don't apply AUTOINCREMENT on non-identity PK

### DIFF
--- a/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteColumn.cs
+++ b/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteColumn.cs
@@ -71,7 +71,9 @@ namespace FluentMigrator.Runner.Generators.SQLite
                     throw new ArgumentException($"Cannot create identity constraint on column {column.Name}. SQLite only supports identity on a single integer, primary key column.");
                 }
 
-                return "AUTOINCREMENT";
+                if (column.IsPrimaryKey) {
+                    return "AUTOINCREMENT";
+                }
             }
 
             return string.Empty;

--- a/test/FluentMigrator.Tests/Integration/Processors/SQLite/SQLiteProcessorTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/SQLite/SQLiteProcessorTests.cs
@@ -129,6 +129,20 @@ namespace FluentMigrator.Tests.Integration.Processors.SQLite
         }
 
         [Test]
+        public void PrimaryKeyNonIdentityColumnsSupported()
+        {
+            var expression = new CreateTableExpression { TableName = _tableName };
+            expression.Columns.Add(new ColumnDefinition {Name = "Id", Type = DbType.Int32, IsPrimaryKey = false, IsIdentity = true, IsNullable = false });
+            expression.Columns.Add(new ColumnDefinition {Name = "Key1", Type = DbType.String, IsPrimaryKey = true, IsIdentity = false, IsNullable = false });
+            expression.Columns.Add(new ColumnDefinition {Name = "Key2", Type = DbType.String, IsPrimaryKey = true, IsIdentity = false, IsNullable = false });
+
+            Processor.Process(expression);
+            Processor.ColumnExists(null, _tableName, "Id").ShouldBeTrue();
+            Processor.ColumnExists(null, _tableName, "Key1").ShouldBeTrue();
+            Processor.ColumnExists(null, _tableName, "Key2").ShouldBeTrue();
+        }
+
+        [Test]
         public void AGuidCanBeInsertedAndReadAgain([Values] bool binaryGuid)
         {
             using (var serviceProvider = CreateProcessorServices(null, binaryGuid))


### PR DESCRIPTION
Fixes regression introduced where non-identity, primary key columns always attempt to create with "AUTOINCREMENT" which is only valid for integer identity columns. Fixes issue #1737