### PR TITLE
Properly dispose of ServiceProvider upon completed migrations

### DIFF
--- a/src/FluentMigrator.DotNet.Cli/Commands/BaseCommand.cs
+++ b/src/FluentMigrator.DotNet.Cli/Commands/BaseCommand.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.DotNet.Cli/Commands/BaseCommand.cs
+++ b/src/FluentMigrator.DotNet.Cli/Commands/BaseCommand.cs
@@ -26,7 +26,7 @@ namespace FluentMigrator.DotNet.Cli.Commands
     {
         protected int ExecuteMigrations(MigratorOptions options, IConsole console)
         {
-            var serviceProvider = Setup.BuildServiceProvider(options, console);
+            using var serviceProvider = Setup.BuildServiceProvider(options, console);
             var executor = serviceProvider.GetRequiredService<TaskExecutor>();
             executor.Execute();
             return 0;

--- a/src/FluentMigrator.DotNet.Cli/Commands/ConnectionCommand.cs
+++ b/src/FluentMigrator.DotNet.Cli/Commands/ConnectionCommand.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.DotNet.Cli/Commands/ListCommand.cs
+++ b/src/FluentMigrator.DotNet.Cli/Commands/ListCommand.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.DotNet.Cli/Commands/ListMigrations.cs
+++ b/src/FluentMigrator.DotNet.Cli/Commands/ListMigrations.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.DotNet.Cli/Commands/ListProcessors.cs
+++ b/src/FluentMigrator.DotNet.Cli/Commands/ListProcessors.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.DotNet.Cli/Commands/Migrate.cs
+++ b/src/FluentMigrator.DotNet.Cli/Commands/Migrate.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.DotNet.Cli/Commands/MigrateDown.cs
+++ b/src/FluentMigrator.DotNet.Cli/Commands/MigrateDown.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.DotNet.Cli/Commands/MigrateUp.cs
+++ b/src/FluentMigrator.DotNet.Cli/Commands/MigrateUp.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.DotNet.Cli/Commands/MigrationCommand.cs
+++ b/src/FluentMigrator.DotNet.Cli/Commands/MigrationCommand.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.DotNet.Cli/Commands/Rollback.cs
+++ b/src/FluentMigrator.DotNet.Cli/Commands/Rollback.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.DotNet.Cli/Commands/RollbackAll.cs
+++ b/src/FluentMigrator.DotNet.Cli/Commands/RollbackAll.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.DotNet.Cli/Commands/RollbackBy.cs
+++ b/src/FluentMigrator.DotNet.Cli/Commands/RollbackBy.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.DotNet.Cli/Commands/RollbackTo.cs
+++ b/src/FluentMigrator.DotNet.Cli/Commands/RollbackTo.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.DotNet.Cli/Commands/Root.cs
+++ b/src/FluentMigrator.DotNet.Cli/Commands/Root.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.DotNet.Cli/Commands/Validate.cs
+++ b/src/FluentMigrator.DotNet.Cli/Commands/Validate.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.DotNet.Cli/Commands/ValidateVersionOrder.cs
+++ b/src/FluentMigrator.DotNet.Cli/Commands/ValidateVersionOrder.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.DotNet.Cli/Setup.cs
+++ b/src/FluentMigrator.DotNet.Cli/Setup.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.DotNet.Cli/Setup.cs
+++ b/src/FluentMigrator.DotNet.Cli/Setup.cs
@@ -34,14 +34,14 @@ namespace FluentMigrator.DotNet.Cli
 {
     public static class Setup
     {
-        public static IServiceProvider BuildServiceProvider(MigratorOptions options, IConsole console)
+        public static ServiceProvider BuildServiceProvider(MigratorOptions options, IConsole console)
         {
             var serviceCollection = new ServiceCollection();
             var serviceProvider = ConfigureServices(serviceCollection, options, console);
             return serviceProvider;
         }
 
-        private static IServiceProvider ConfigureServices(IServiceCollection services, MigratorOptions options, IConsole console)
+        private static ServiceProvider ConfigureServices(IServiceCollection services, MigratorOptions options, IConsole console)
         {
             var conventionSet = new DefaultConventionSet(defaultSchemaName: options.SchemaName, options.WorkingDirectory);
 

--- a/src/FluentMigrator.DotNet.Cli/TransactionMode.cs
+++ b/src/FluentMigrator.DotNet.Cli/TransactionMode.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.Extensions.SqlServer/Builders/Create/Index/CreateIndexExpressionNonKeyBuilder.cs
+++ b/src/FluentMigrator.Extensions.SqlServer/Builders/Create/Index/CreateIndexExpressionNonKeyBuilder.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.Extensions.SqlServer/Builders/Create/Index/ICreateIndexNonKeyColumnSyntax.cs
+++ b/src/FluentMigrator.Extensions.SqlServer/Builders/Create/Index/ICreateIndexNonKeyColumnSyntax.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.Runner.Core/Generators/Base/ColumnBase.cs
+++ b/src/FluentMigrator.Runner.Core/Generators/Base/ColumnBase.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.Runner.Core/IMigrationRunner.cs
+++ b/src/FluentMigrator.Runner.Core/IMigrationRunner.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.Runner.Snowflake/Generators/Snowflake/SnowflakeColumn.cs
+++ b/src/FluentMigrator.Runner.Snowflake/Generators/Snowflake/SnowflakeColumn.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.Runner.Snowflake/Generators/Snowflake/SnowflakeDescriptionGenerator.cs
+++ b/src/FluentMigrator.Runner.Snowflake/Generators/Snowflake/SnowflakeDescriptionGenerator.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.Runner.Snowflake/Generators/Snowflake/SnowflakeGenerator.cs
+++ b/src/FluentMigrator.Runner.Snowflake/Generators/Snowflake/SnowflakeGenerator.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2000Column.cs
+++ b/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2000Column.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2005Column.cs
+++ b/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2005Column.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2008Column.cs
+++ b/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2008Column.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/FluentMigrator.Tests/Integration/Processors/Firebird/FirebirdLibraryProber.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Firebird/FirebirdLibraryProber.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/FluentMigrator.Tests/Integration/Processors/Firebird/TemporaryDatabase.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Firebird/TemporaryDatabase.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Sean Chambers and the FluentMigrator Project
+// Copyright (c) 2007-2024, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Also includes is a couple of remaining license attribution fixes that was missed the other day.

IServiceProvider doesn't include IDisposable so it was necessary to expose ServiceProvider instead to BaseCommand. I don't think this impacts anything as this instance isn't exposed outside of BaseCommand. Open to any other suggestions. Thanks!

Fixes #1638 