### PR TITLE
Replace crlf with Environment.Newline

### DIFF
--- a/src/FluentMigrator.Runner.Core/Generators/Generic/GenericDescriptionGenerator.cs
+++ b/src/FluentMigrator.Runner.Core/Generators/Generic/GenericDescriptionGenerator.cs
@@ -16,6 +16,7 @@
 //
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -64,7 +65,7 @@ namespace FluentMigrator.Runner.Generators.Generic
                     descriptionsList.AddRange(from description in column.AdditionalColumnDescriptions
                                               let newDescriptionStatement = description.Key + ":" + description.Value
                                               select newDescriptionStatement);
-                    statements.Add(GenerateColumnDescription("Description", expression.SchemaName, expression.TableName, column.Name, string.Join("\r\n", descriptionsList)));
+                    statements.Add(GenerateColumnDescription("Description", expression.SchemaName, expression.TableName, column.Name, string.Join(Environment.NewLine, descriptionsList)));
                 }
             }
 
@@ -102,7 +103,7 @@ namespace FluentMigrator.Runner.Generators.Generic
                 descriptionsList.AddRange(from description in expression.Column.AdditionalColumnDescriptions
                                           let newDescriptionStatement = description.Key + ":" + description.Value
                                           select newDescriptionStatement);
-                return GenerateColumnDescription("Description", expression.SchemaName, expression.TableName, expression.Column.Name, string.Join("\r\n", descriptionsList));
+                return GenerateColumnDescription("Description", expression.SchemaName, expression.TableName, expression.Column.Name, string.Join(Environment.NewLine, descriptionsList));
             }
         }
 
@@ -126,7 +127,7 @@ namespace FluentMigrator.Runner.Generators.Generic
                 descriptionsList.AddRange(from description in expression.Column.AdditionalColumnDescriptions
                                           let newDescriptionStatement = description.Key + ":" + description.Value
                                           select newDescriptionStatement);
-                return GenerateColumnDescription("Description", expression.SchemaName, expression.TableName, expression.Column.Name, string.Join("\r\n", descriptionsList));
+                return GenerateColumnDescription("Description", expression.SchemaName, expression.TableName, expression.Column.Name, string.Join(Environment.NewLine, descriptionsList));
             }
         }
     }

--- a/src/FluentMigrator.Runner.MySql/Generators/MySql/MySqlColumn.cs
+++ b/src/FluentMigrator.Runner.MySql/Generators/MySql/MySqlColumn.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using FluentMigrator.Model;
 using FluentMigrator.Runner.Generators.Base;
 using System.Linq;
+using System;
 
 namespace FluentMigrator.Runner.Generators.MySql
 {
@@ -50,7 +51,7 @@ namespace FluentMigrator.Runner.Generators.MySql
             };
             descriptionsList.AddRange(from descriptionItem in column.AdditionalColumnDescriptions
                                       select descriptionItem.Key + ":" + descriptionItem.Value);
-            return string.Format("COMMENT {0}", Quoter.QuoteValue(string.Join("\r\n", descriptionsList)));
+            return string.Format("COMMENT {0}", Quoter.QuoteValue(string.Join(Environment.NewLine, descriptionsList)));
         }
 
         /// <inheritdoc />

--- a/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteProcessor.cs
+++ b/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteProcessor.cs
@@ -244,7 +244,7 @@ namespace FluentMigrator.Runner.Processors.SQLite
                 }
                 catch (DbException ex)
                 {
-                    throw new Exception(ex.Message + "\r\nWhile Processing:\r\n\"" + command.CommandText + "\"", ex);
+                    throw new Exception(ex.Message + Environment.NewLine + "While Processing:" + Environment.NewLine + "\"" + command.CommandText + "\"", ex);
                 }
             }
         }
@@ -282,7 +282,7 @@ namespace FluentMigrator.Runner.Processors.SQLite
             }
             catch (DbException ex)
             {
-                throw new Exception(ex.Message + "\r\nWhile Processing:\r\n\"" + sqlBatch + "\"", ex);
+                throw new Exception(ex.Message + Environment.NewLine + "While Processing:" + Environment.NewLine + "\"" + sqlBatch + "\"", ex);
             }
         }
 

--- a/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2005DescriptionGenerator.cs
+++ b/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2005DescriptionGenerator.cs
@@ -16,6 +16,7 @@
 //
 #endregion
 
+using System;
 using System.Collections.Generic;
 
 using FluentMigrator.Expressions;
@@ -86,7 +87,7 @@ namespace FluentMigrator.Runner.Generators.SqlServer
                 descriptionsList.Add(newDescriptionStatementToAdd);
             }
 
-            var joined = string.Join(";\r\n", descriptionsList);
+            var joined = string.Join(";" + Environment.NewLine, descriptionsList);
 
             return joined;
         }

--- a/test/FluentMigrator.Tests/Unit/Generators/MySql4/MySql4ColumnTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/MySql4/MySql4ColumnTests.cs
@@ -256,7 +256,7 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql4
             var expression = GeneratorTestHelper.GetAlterColumnExpressionWithDescriptionWithAdditionalDescriptions();
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("ALTER TABLE `TestTable1` MODIFY COLUMN `TestColumn1` VARCHAR(20) NOT NULL COMMENT 'Description:TestColumn1Description\r\nAdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1'");
+            result.ShouldBe("ALTER TABLE `TestTable1` MODIFY COLUMN `TestColumn1` VARCHAR(20) NOT NULL COMMENT 'Description:TestColumn1Description" + Environment.NewLine + "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1'");
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/Oracle/OracleDataTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Oracle/OracleDataTests.cs
@@ -297,6 +297,7 @@ Mrow stare out cat door then go back inside, run outside as soon as door open or
         }
 
         [Test]
+        [Category("NotWorkingOnMono")]
         public void CanInsertDataWithLargeString()
         {
             var expression = GetLargeInsertExpression();
@@ -306,6 +307,7 @@ Mrow stare out cat door then go back inside, run outside as soon as door open or
         }
 
         [Test]
+        [Category("NotWorkingOnMono")]
         public void CanUpdateDataWithLargeString()
         {
             var expression = GetLargeUpdateExpression();

--- a/test/FluentMigrator.Tests/Unit/Generators/Oracle/OracleQuoterTest.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Oracle/OracleQuoterTest.cs
@@ -84,6 +84,7 @@ Mrow stare out cat door then go back inside, run outside as soon as door open or
         }
 
         [Test]
+        [Category("NotWorkingOnMono")]
         public void LargeNonUnicodeStringIsChunked()
         {
             var chunks = _quoter.QuoteValue(new NonUnicodeString(OracleDataTests.LargeString));
@@ -91,6 +92,7 @@ Mrow stare out cat door then go back inside, run outside as soon as door open or
         }
 
         [Test]
+        [Category("NotWorkingOnMono")]
         public void LargeStringIsChunked()
         {
             var chunks = _quoter.QuoteValue(OracleDataTests.LargeString);


### PR DESCRIPTION
Not all locations in FluentMigrator.Runner were properly using Environment.Newline. This was causing tests to fail on osx.

This also includes more Category annotations that can be ignored when running tests on Mono. These failures are likely due to unicode character encoding and Shouldly not able to properly compare strings

Fixes #1751 