### PR TITLE
Update MySQL SystemMethods.CurrentUTCDateTime to Use Expression

### DIFF
--- a/src/FluentMigrator.Runner.MySql/Generators/MySql/MySqlQuoter.cs
+++ b/src/FluentMigrator.Runner.MySql/Generators/MySql/MySqlQuoter.cs
@@ -48,7 +48,7 @@ namespace FluentMigrator.Runner.Generators.MySql
                 case SystemMethods.CurrentDateTime:
                     return "CURRENT_TIMESTAMP";
                 case SystemMethods.CurrentUTCDateTime:
-                    return "UTC_TIMESTAMP";
+                    return "(UTC_TIMESTAMP)";
                 case SystemMethods.CurrentUser:
                     return "CURRENT_USER()";
             }

--- a/test/FluentMigrator.Tests/Unit/Generators/MySql4/MySql4GeneratorTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/MySql4/MySql4GeneratorTests.cs
@@ -16,6 +16,8 @@
 //
 #endregion
 
+using System.Data;
+
 using FluentMigrator.Exceptions;
 using FluentMigrator.Expressions;
 using FluentMigrator.Model;
@@ -72,6 +74,17 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql4
 
             var result = Generator.Generate(expression);
             result.ShouldBe("ALTER TABLE `NewTable` ADD COLUMN `NewColumn` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP");
+        }
+
+        [Test]
+        public void CanUseSystemMethodCurrentUTCDateTimeAsADefaultValueForAColumn()
+        {
+            const string tableName = "NewTable";
+            var columnDefinition = new ColumnDefinition { Name = "NewColumn", Size = 15, Type = null, CustomType = "TIMESTAMP", DefaultValue = SystemMethods.CurrentUTCDateTime };
+            var expression = new CreateColumnExpression { Column = columnDefinition, TableName = tableName };
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE `NewTable` ADD COLUMN `NewColumn` TIMESTAMP NOT NULL DEFAULT (UTC_TIMESTAMP)");
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/MySql4/MySql4QuoterTest.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/MySql4/MySql4QuoterTest.cs
@@ -42,6 +42,13 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql4
         }
 
         [Test]
+        public void CurrentUTCDateTimeIsFormattedParentheses()
+        {
+            _quoter.QuoteValue(SystemMethods.CurrentUTCDateTime)
+                .ShouldBe("(UTC_TIMESTAMP)");
+        }
+
+        [Test]
         public void TimeSpanIsFormattedQuotes()
         {
             _quoter.QuoteValue(new TimeSpan(1,2, 13, 65))


### PR DESCRIPTION
Should fix #1796.

Currently, when creating a MySQL column using the SystemMethods.CurrentUTCDateTime, a MySQL syntax error is thrown, as UTC_TIMESTAMP is not a literal constant.

Unit tests were added, but integration tests were not. I could not find any integration tests for SystemMethods defaults, though I can add some for the DBMS I am familiar with, if desired. (MySQL, SQL Server, and possibly PostgreSQL, but I am not familiar enough with Hana, DB2, etc. to get those integration tests working.)

Adjustments made based on MySQL documentation: https://dev.mysql.com/doc/refman/8.0/en/data-type-defaults.html#data-types-defaults-explicit

I am relatively certain this is not a breaking change, as based on the documentation, it does not look like UTC_TIMESTAMP would have worked in any MySQL version prior to 8.0.13.