### PR TITLE
Names for the primary key would be generated the same in all cases

### DIFF
--- a/test/FluentMigrator.Tests/Unit/DefaultMigrationConventionsTests.cs
+++ b/test/FluentMigrator.Tests/Unit/DefaultMigrationConventionsTests.cs
@@ -46,7 +46,7 @@ namespace FluentMigrator.Tests.Unit
         private static readonly IMigrationRunnerConventions _default = DefaultMigrationRunnerConventions.Instance;
 
         [Test]
-        public void GetPrimaryKeyNamePrefixeForColumnWithName()
+        public void GetPrimaryKeyNamePrefixForColumnWithName()
         {
             var expr = new CreateColumnExpression()
             {
@@ -64,7 +64,7 @@ namespace FluentMigrator.Tests.Unit
         }
 
         [Test]
-        public void GetPrimaryKeyNamePrefixeForColumnWithoutName()
+        public void GetPrimaryKeyNamePrefixForColumnWithoutName()
         {
             var expr = new CreateColumnExpression()
             {
@@ -82,7 +82,7 @@ namespace FluentMigrator.Tests.Unit
         }
 
         [Test]
-        public void GetPrimaryKeyNamePrefixeForMultipleColumns()
+        public void GetPrimaryKeyNamePrefixForMultipleColumns()
         {
             var expr = new CreateTableExpression()
             {

--- a/test/FluentMigrator.Tests/Unit/DefaultMigrationConventionsTests.cs
+++ b/test/FluentMigrator.Tests/Unit/DefaultMigrationConventionsTests.cs
@@ -46,7 +46,25 @@ namespace FluentMigrator.Tests.Unit
         private static readonly IMigrationRunnerConventions _default = DefaultMigrationRunnerConventions.Instance;
 
         [Test]
-        public void GetPrimaryKeyNamePrefixesTableNameWithPKAndUnderscore()
+        public void GetPrimaryKeyNamePrefixeForColumnWithName()
+        {
+            var expr = new CreateColumnExpression()
+            {
+                Column =
+                {
+                    Name = "Bar",
+                    TableName = "Foo",
+                    IsPrimaryKey = true,
+                }
+            };
+
+            var processed = expr.Apply(ConventionSets.NoSchemaName);
+
+            processed.Column.PrimaryKeyName.ShouldBe("PK_Foo_Bar");
+        }
+
+        [Test]
+        public void GetPrimaryKeyNamePrefixeForColumnWithoutName()
         {
             var expr = new CreateColumnExpression()
             {
@@ -57,8 +75,43 @@ namespace FluentMigrator.Tests.Unit
                 }
             };
 
-            var processed = expr.Apply(ConventionSets.NoSchemaName);
-            processed.Column.PrimaryKeyName.ShouldBe("PK_Foo");
+            var action = () => expr.Apply(ConventionSets.NoSchemaName);
+
+            var exception = action.ShouldThrow<ArgumentException>();
+            exception.Message.ShouldBe("An object or column name is missing or empty.");
+        }
+
+        [Test]
+        public void GetPrimaryKeyNamePrefixeForMultipleColumns()
+        {
+            var expr = new CreateTableExpression()
+            {
+                TableName = "Foo",
+                Columns =
+                [
+                    new ColumnDefinition
+                    {
+                        Name = "Bar1",
+                        IsPrimaryKey = true,
+                    },
+                    new ColumnDefinition
+                    {
+                        Name = "Bar2",
+                        IsPrimaryKey = true,
+                    }
+                ]
+            };
+
+            var action = () =>
+            {
+                foreach (var columnsConventions in ConventionSets.NoSchemaName.ColumnsConventions)
+                {
+                    columnsConventions.Apply(expr);
+                }
+            };
+
+            var exception = action.ShouldThrow<InvalidOperationException>();
+            exception.Message.ShouldBe("Error creating table with multiple primary keys.");
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/MigrationRunnerTests.cs
+++ b/test/FluentMigrator.Tests/Unit/MigrationRunnerTests.cs
@@ -666,7 +666,7 @@ namespace FluentMigrator.Tests.Unit
         {
             var invalidMigration = new Mock<IMigration>();
             var invalidExpression = new UpdateDataExpression { TableName = "Test" };
-            var secondInvalidExpression = new CreateColumnExpression();
+            var secondInvalidExpression = new CreateColumnExpression() { Column = { Name = "Test" } };
             invalidMigration.Setup(m => m.GetUpExpressions(It.IsAny<IMigrationContext>()))
                 .Callback((IMigrationContext mc) => { mc.Expressions.Add(invalidExpression); mc.Expressions.Add(secondInvalidExpression); });
 

--- a/test/FluentMigrator.Tests/Unit/ObsoleteMigrationRunnerTests.cs
+++ b/test/FluentMigrator.Tests/Unit/ObsoleteMigrationRunnerTests.cs
@@ -614,7 +614,7 @@ namespace FluentMigrator.Tests.Unit
         {
             var invalidMigration = new Mock<IMigration>();
             var invalidExpression = new UpdateDataExpression { TableName = "Test" };
-            var secondInvalidExpression = new CreateColumnExpression();
+            var secondInvalidExpression = new CreateColumnExpression() { Column = { Name = "Test" } };
             invalidMigration.Setup(m => m.GetUpExpressions(It.IsAny<IMigrationContext>()))
                 .Callback((IMigrationContext mc) => { mc.Expressions.Add(invalidExpression); mc.Expressions.Add(secondInvalidExpression); });
 


### PR DESCRIPTION
Eliminated the difference between classes `DefaultConstraintNameConvention` and `DefaultPrimaryKeyNameConvention` in the default generated primary key name. See issue https://github.com/fluentmigrator/fluentmigrator/issues/1800.