### PR TITLE
"NULLS NOT DISTINCT" for indexes in PostgreSQL 15+

### DIFF
--- a/src/FluentMigrator.DotNet.Cli/Setup.cs
+++ b/src/FluentMigrator.DotNet.Cli/Setup.cs
@@ -92,6 +92,7 @@ namespace FluentMigrator.DotNet.Cli
                         .AddPostgres92()
                         .AddPostgres10_0()
                         .AddPostgres11_0()
+                        .AddPostgres15_0()
                         .AddRedshift()
                         .AddSnowflake()
                         .AddSQLite()

--- a/src/FluentMigrator.Runner.Postgres/Generators/Postgres/Postgres15_0Generator.cs
+++ b/src/FluentMigrator.Runner.Postgres/Generators/Postgres/Postgres15_0Generator.cs
@@ -1,0 +1,61 @@
+using System.Linq;
+
+using FluentMigrator.Infrastructure.Extensions;
+using FluentMigrator.Model;
+using FluentMigrator.Postgres;
+
+using JetBrains.Annotations;
+using Microsoft.Extensions.Options;
+
+namespace FluentMigrator.Runner.Generators.Postgres
+{
+    public class Postgres15_0Generator : Postgres11_0Generator
+    {
+        public Postgres15_0Generator([NotNull] PostgresQuoter quoter)
+            : this(quoter, new OptionsWrapper<GeneratorOptions>(new GeneratorOptions()))
+        {
+        }
+
+        public Postgres15_0Generator([NotNull] PostgresQuoter quoter, [NotNull] IOptions<GeneratorOptions> generatorOptions)
+            : base(new Postgres10_0Column(quoter, new Postgres92.Postgres92TypeMap()), quoter, generatorOptions)
+        {
+        }
+
+        protected Postgres15_0Generator([NotNull] PostgresQuoter quoter, [NotNull] IOptions<GeneratorOptions> generatorOptions, [NotNull] IPostgresTypeMap typeMap)
+            : base(new Postgres10_0Column(quoter, typeMap), quoter, generatorOptions)
+        {
+        }
+
+        protected Postgres15_0Generator(
+            [NotNull] IColumn column,
+            [NotNull] PostgresQuoter quoter,
+            [NotNull] IOptions<GeneratorOptions> generatorOptions)
+            : base(column, quoter, generatorOptions)
+        {
+        }
+
+        protected override string GetWithNullsDistinctStringInWhere(IndexDefinition index)
+        {
+            return string.Empty;
+        }
+
+        protected override string GetWithNullsDistinctString(IndexDefinition index)
+        {
+            bool? GetNullsDistinct(IndexColumnDefinition column)
+                => column.GetAdditionalFeature(PostgresExtensions.IndexColumnNullsDistinct, (bool?)null);
+
+            var indexNullsDistinct = index.GetAdditionalFeature(PostgresExtensions.IndexColumnNullsDistinct, (bool?)null);
+            var columnNullsDistinct = index.Columns.Select(c => GetNullsDistinct(c)).FirstOrDefault(nd => nd != null);
+            var nullsDistinct = columnNullsDistinct ?? indexNullsDistinct;
+
+            if (nullsDistinct != null && !index.IsUnique)
+            {
+                // Should never occur
+                CompatibilityMode.HandleCompatibility("With nulls distinct can only be used for unique indexes");
+                return string.Empty;
+            }
+
+            return nullsDistinct == false ? " NULLS NOT DISTINCT" : string.Empty;
+        }
+    }
+}

--- a/src/FluentMigrator.Runner.Postgres/Generators/Postgres/PostgresGenerator.cs
+++ b/src/FluentMigrator.Runner.Postgres/Generators/Postgres/PostgresGenerator.cs
@@ -224,7 +224,7 @@ namespace FluentMigrator.Runner.Generators.Postgres
 
             if (!string.IsNullOrWhiteSpace(filter) && !string.IsNullOrWhiteSpace(nullsDistinctString))
             {
-                CompatibilityMode.HandleCompatibility("With nulls distinct can not be used along with WHERE, in PostgreSQL 14 or older");
+                CompatibilityMode.HandleCompatibility("In PostgreSQL 14 or older, With nulls distinct can not be combined with WHERE");
                 return string.Empty;
             }
 

--- a/src/FluentMigrator.Runner.Postgres/Generators/Postgres/PostgresGenerator.cs
+++ b/src/FluentMigrator.Runner.Postgres/Generators/Postgres/PostgresGenerator.cs
@@ -220,15 +220,23 @@ namespace FluentMigrator.Runner.Generators.Postgres
         protected virtual string GetFilter(CreateIndexExpression expression)
         {
             var filter = expression.Index.GetAdditionalFeature<string>(PostgresExtensions.IndexFilter);
+            var nullsDistinctString = GetWithNullsDistinctStringInWhere(expression.Index);
+
+            if (!string.IsNullOrWhiteSpace(filter) && !string.IsNullOrWhiteSpace(nullsDistinctString))
+            {
+                CompatibilityMode.HandleCompatibility("With nulls distinct can not be used along with WHERE, in PostgreSQL 14 or older");
+                return string.Empty;
+            }
+
             if (!string.IsNullOrWhiteSpace(filter))
             {
                 return " WHERE " + filter;
             }
 
-            return string.Empty;
+            return nullsDistinctString;
         }
 
-        public virtual string GetWithNullsDistinctString(IndexDefinition index)
+        protected virtual string GetWithNullsDistinctStringInWhere(IndexDefinition index)
         {
             bool? GetNullsDistinct(IndexColumnDefinition column)
                 => column.GetAdditionalFeature(PostgresExtensions.IndexColumnNullsDistinct, (bool?)null);
@@ -254,6 +262,10 @@ namespace FluentMigrator.Runner.Generators.Postgres
             return condition.Length == 0 ? string.Empty : $" WHERE {condition}";
         }
 
+        protected virtual string GetWithNullsDistinctString(IndexDefinition index)
+        {
+            return string.Empty;
+        }
 
         protected virtual string GetAsConcurrently(CreateIndexExpression expression)
         {
@@ -436,10 +448,10 @@ namespace FluentMigrator.Runner.Generators.Postgres
 
             result.Append(")")
                 .Append(GetIncludeString(expression))
+                .Append(GetWithNullsDistinctString(expression.Index))
                 .Append(GetWithIndexStorageParameters(expression))
                 .Append(GetTablespace(expression))
                 .Append(GetFilter(expression))
-                .Append(GetWithNullsDistinctString(expression.Index))
                 .Append(";");
 
             return result.ToString();

--- a/src/FluentMigrator.Runner.Postgres/PostgresRunnerBuilderExtensions.cs
+++ b/src/FluentMigrator.Runner.Postgres/PostgresRunnerBuilderExtensions.cs
@@ -96,6 +96,21 @@ namespace FluentMigrator.Runner
         }
 
         /// <summary>
+        /// Adds Postgres 15.0 support
+        /// </summary>
+        /// <param name="builder">The builder to add the Postgres-specific services to</param>
+        /// <returns>The migration runner builder</returns>
+        public static IMigrationRunnerBuilder AddPostgres15_0(this IMigrationRunnerBuilder builder)
+        {
+            builder.Services
+                .AddScoped<Postgres15_0Processor>()
+                .AddScoped<IMigrationProcessor>(sp => sp.GetRequiredService<Postgres15_0Processor>())
+                .AddScoped<Postgres15_0Generator>()
+                .AddScoped<IMigrationGenerator>(sp => sp.GetRequiredService<Postgres15_0Generator>());
+            return builder.AddCommonPostgresServices();
+        }
+
+        /// <summary>
         /// Add common Postgres services.
         /// </summary>
         /// <param name="builder">The builder to add the Postgres-specific services to</param>

--- a/src/FluentMigrator.Runner.Postgres/Processors/Postgres/Postgres15_0Processor.cs
+++ b/src/FluentMigrator.Runner.Postgres/Processors/Postgres/Postgres15_0Processor.cs
@@ -1,0 +1,47 @@
+#region License
+// Copyright (c) 2018, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System.Collections.Generic;
+
+using FluentMigrator.Runner.Generators.Postgres;
+using FluentMigrator.Runner.Initialization;
+
+using JetBrains.Annotations;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace FluentMigrator.Runner.Processors.Postgres
+{
+    public class Postgres15_0Processor : PostgresProcessor
+    {
+        public Postgres15_0Processor(
+            [NotNull] PostgresDbFactory factory,
+            [NotNull] Postgres15_0Generator generator,
+            [NotNull] ILogger<Postgres15_0Processor> logger,
+            [NotNull] IOptionsSnapshot<ProcessorOptions> options,
+            [NotNull] IConnectionStringAccessor connectionStringAccessor,
+            [NotNull] PostgresOptions pgOptions)
+            : base(factory, generator, logger, options, connectionStringAccessor, pgOptions)
+        {
+        }
+
+        public override string DatabaseType => ProcessorId.PostgreSQL15_0;
+
+        public override IList<string> DatabaseTypeAliases { get; } = new List<string> { ProcessorId.PostgreSQL };
+
+    }
+}

--- a/src/FluentMigrator/ProcessorId.cs
+++ b/src/FluentMigrator/ProcessorId.cs
@@ -19,6 +19,7 @@ namespace FluentMigrator
         public const string PostgreSQL = nameof(PostgreSQL);
         public const string PostgreSQL10_0 = nameof(PostgreSQL10_0);
         public const string PostgreSQL11_0 = nameof(PostgreSQL11_0);
+        public const string PostgreSQL15_0 = nameof(PostgreSQL15_0);
         public const string Redshift = nameof(Redshift);
         public const string SQLite = nameof(SQLite);
         public const string SqlServer = nameof(SqlServer);

--- a/test/FluentMigrator.Tests/Unit/Generators/Postgres/PostgresIndexTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Postgres/PostgresIndexTests.cs
@@ -326,7 +326,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Postgres
         }
 
         [Test]
-        public void CanCreateMultiColumnUniqueIndexWithOneNonDistinctNulls()
+        public virtual void CanCreateMultiColumnUniqueIndexWithOneNonDistinctNulls()
         {
             var expression = GeneratorTestHelper.GetCreateUniqueMultiColumnIndexExpression();
             expression.Index.Columns.First().SetAdditionalFeature(PostgresExtensions.IndexColumnNullsDistinct, false);
@@ -336,7 +336,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Postgres
         }
 
         [Test]
-        public void CanCreateMultiColumnUniqueIndexWithTwoNonDistinctNulls()
+        public virtual void CanCreateMultiColumnUniqueIndexWithTwoNonDistinctNulls()
         {
             var expression = GeneratorTestHelper.GetCreateUniqueMultiColumnIndexExpression();
 

--- a/test/FluentMigrator.Tests/Unit/Generators/Postgres15_0/Postgres15_0IndexTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Postgres15_0/Postgres15_0IndexTests.cs
@@ -1,0 +1,48 @@
+using System.Linq;
+
+using FluentMigrator.Infrastructure.Extensions;
+using FluentMigrator.Postgres;
+using FluentMigrator.Runner.Generators.Postgres;
+using FluentMigrator.Tests.Unit.Generators.Postgres11_0;
+using FluentMigrator.Tests.Unit.Generators.Snowflake;
+
+using NUnit.Framework;
+
+using Shouldly;
+
+namespace FluentMigrator.Tests.Unit.Generators.Postgres15_0
+{
+    [TestFixture]
+    public class Postgres15_0IndexTests : Postgres11_0IndexTests
+    {
+        /// <inheritdoc />
+        protected override PostgresGenerator CreateGenerator(PostgresQuoter quoter)
+        {
+            return new Postgres15_0Generator(quoter);
+        }
+
+        [Test]
+        public override void CanCreateMultiColumnUniqueIndexWithOneNonDistinctNulls()
+        {
+            var expression = GeneratorTestHelper.GetCreateUniqueMultiColumnIndexExpression();
+            expression.Index.Columns.First().SetAdditionalFeature(PostgresExtensions.IndexColumnNullsDistinct, false);
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE UNIQUE INDEX \"TestIndex\" ON \"public\".\"TestTable1\" (\"TestColumn1\" ASC,\"TestColumn2\" DESC) NULLS NOT DISTINCT;");
+        }
+
+        [Test]
+        public override void CanCreateMultiColumnUniqueIndexWithTwoNonDistinctNulls()
+        {
+            var expression = GeneratorTestHelper.GetCreateUniqueMultiColumnIndexExpression();
+
+            foreach (var c in expression.Index.Columns)
+            {
+                c.SetAdditionalFeature(PostgresExtensions.IndexColumnNullsDistinct, false);
+            }
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE UNIQUE INDEX \"TestIndex\" ON \"public\".\"TestTable1\" (\"TestColumn1\" ASC,\"TestColumn2\" DESC) NULLS NOT DISTINCT;");
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds support of "NULLS NOT DISTINCT" option for PostgreSQL.

By default, unique indexes in PostgreSQL allow multiple null values (so, null values are considered not equal to each other). In PostgreSQL 15, new option was added: "NULLS NOT DISTINCT", which allows only single null value.
https://www.postgresql.org/docs/current/sql-createindex.html

Before PostgreSQL 15, there was a workaround with two indexes: https://stackoverflow.com/questions/8289100/create-unique-constraint-with-null-columns

To enable "NULLS NOT DISTINCT" for index, UniqueNullsNotDistinct method should be called:
```
Create.Index("MyIndex").OnTable("MyTable1").InSchema("public")
   .OnColumn("Column1").Ascending()
   .OnColumn("Column2").Ascending()
   .WithOptions().UniqueNullsNotDistinct();
```
Runner should be configured with AddPostgres15_0:
```
services
   .AddFluentMigratorCore()
   .ConfigureRunner(builder => builder.AddPostgres15_0());
```