### PR TITLE
add custom version info table for tool

### DIFF
--- a/src/FluentMigrator.DotNet.Cli/Commands/MigrationCommand.cs
+++ b/src/FluentMigrator.DotNet.Cli/Commands/MigrationCommand.cs
@@ -29,6 +29,9 @@ namespace FluentMigrator.DotNet.Cli.Commands
         [Required]
         public IEnumerable<string> TargetAssemblies { get; set;}
 
+        [Option("-v|--version-info-meta-data-json <VERSION_INFO_TABLE_META_DATA_JSON>", Description = "The json that describe metada (for example '{\"SchemaName\": \"custom_schema\", \"TableName\": \"custom_table_name\"}').")]
+        public string VersionInfoTableMetadataJson { get; set;}
+
         [Option("-n|--namespace <NAMESPACE>", Description = "The namespace contains the migrations you want to run. Default is all migrations found within the Target Assembly will be run.")]
         public string Namespace { get; set; }
 

--- a/src/FluentMigrator.DotNet.Cli/MigratorOptions.cs
+++ b/src/FluentMigrator.DotNet.Cli/MigratorOptions.cs
@@ -40,6 +40,7 @@ namespace FluentMigrator.DotNet.Cli
         public string ProcessorType { get; private set; }
         public string ProcessorSwitches { get; private set; }
         public IReadOnlyCollection<string> TargetAssemblies { get; private set; }
+        public string VersionInfoTableMetadataJson { get; set; }
         public long? TargetVersion { get; private set; }
         public int? Steps { get; private set; }
         public string Namespace { get; private set; }
@@ -136,6 +137,7 @@ namespace FluentMigrator.DotNet.Cli
         private MigratorOptions Init(MigrationCommand cmd)
         {
             TargetAssemblies = cmd.TargetAssemblies.ToList();
+            VersionInfoTableMetadataJson = cmd.VersionInfoTableMetadataJson;
             Namespace = cmd.Namespace;
             NestedNamespaces = cmd.NestedNamespaces;
             StartVersion = cmd.StartVersion;

--- a/src/FluentMigrator.DotNet.Cli/Setup.cs
+++ b/src/FluentMigrator.DotNet.Cli/Setup.cs
@@ -19,6 +19,7 @@ using System.Linq;
 
 using AutoMapper;
 
+using FluentMigrator.DotNet.Cli.VersionTableMetadata;
 using FluentMigrator.Runner;
 using FluentMigrator.Runner.Conventions;
 using FluentMigrator.Runner.Initialization;
@@ -103,6 +104,7 @@ namespace FluentMigrator.DotNet.Cli
                         .AddSqlServer2012()
                         .AddSqlServer2014()
                         .AddSqlServer2016()
+                        .AddCustomVersionTableInfo(options.VersionInfoTableMetadataJson)
                         );
 
             services

--- a/src/FluentMigrator.DotNet.Cli/VersionTableMetadata/CustomVersionTableMetaData.cs
+++ b/src/FluentMigrator.DotNet.Cli/VersionTableMetadata/CustomVersionTableMetaData.cs
@@ -1,0 +1,38 @@
+#region License
+// Copyright (c) 2024, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using FluentMigrator.Runner.VersionTableInfo;
+
+namespace FluentMigrator.DotNet.Cli.VersionTableMetadata;
+
+public class CustomVersionTableMetaData : IVersionTableMetaData
+{
+    public bool OwnsSchema { get; set; }
+
+    public string SchemaName { get; set; }
+
+    public string TableName { get; set; }
+
+    public string ColumnName { get; set; }
+
+    public string DescriptionColumnName { get; set; }
+
+    public string UniqueIndexName { get; set; }
+
+    public string AppliedOnColumnName { get; set; }
+
+    public bool CreateWithPrimaryKey { get; set; }
+}

--- a/src/FluentMigrator.DotNet.Cli/VersionTableMetadata/Extensions.cs
+++ b/src/FluentMigrator.DotNet.Cli/VersionTableMetadata/Extensions.cs
@@ -1,0 +1,38 @@
+#region License
+// Copyright (c) 2024, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System.Text.Json;
+
+using FluentMigrator.Runner;
+
+namespace FluentMigrator.DotNet.Cli.VersionTableMetadata
+{
+    public static class Extensions
+    {
+        public static IMigrationRunnerBuilder AddCustomVersionTableInfo(
+            this IMigrationRunnerBuilder builder,
+            string versionInfoTableMetadataJson)
+        {
+            if (!string.IsNullOrWhiteSpace(versionInfoTableMetadataJson))
+            {
+                var customVersionInfoTableMetadata =
+                    JsonSerializer.Deserialize<CustomVersionTableMetaData>(versionInfoTableMetadataJson);
+                builder.WithVersionTable(customVersionInfoTableMetadata);
+            }
+            return builder;
+        }
+    }
+}


### PR DESCRIPTION
We are using custom table info metadata for our projects. Dotnet tool for fluent migrator don't allow configure version info metadata, i added this feature in my merge request. To avoid adding many parameters i added one json paramter, where we can rewrite all parameters. `-v '{"ColumnName":"version","SchemaName":"public","TableName":"version_info","AppliedOnColumnName":"applied_on","DescriptionColumnName":"description"}'`