### PR TITLE
Remove obsolete IMigrationProcessor.Options

### DIFF
--- a/src/FluentMigrator.Abstractions/IMigrationProcessor.cs
+++ b/src/FluentMigrator.Abstractions/IMigrationProcessor.cs
@@ -33,12 +33,6 @@ namespace FluentMigrator
     public interface IMigrationProcessor : IQuerySchema, IDisposable
     {
         /// <summary>
-        /// Gets the migration processor options
-        /// </summary>
-        [Obsolete]
-        IMigrationProcessorOptions Options { get; }
-
-        /// <summary>
         /// Gets the connection string
         /// </summary>
         [Obsolete]

--- a/src/FluentMigrator.Runner.Core/MigrationScopeHandler.cs
+++ b/src/FluentMigrator.Runner.Core/MigrationScopeHandler.cs
@@ -27,13 +27,6 @@ namespace FluentMigrator.Runner
         private readonly IMigrationProcessor _processor;
         private readonly bool _previewOnly;
 
-        [Obsolete]
-        public MigrationScopeHandler(IMigrationProcessor processor)
-        {
-            _processor = processor;
-            _previewOnly = processor.Options?.PreviewOnly ?? false;
-        }
-
         public MigrationScopeHandler(IMigrationProcessor processor, ProcessorOptions processorOptions)
         {
             _processor = processor;

--- a/src/FluentMigrator.Runner.Core/Processors/ConnectionlessProcessor.cs
+++ b/src/FluentMigrator.Runner.Core/Processors/ConnectionlessProcessor.cs
@@ -37,24 +37,6 @@ namespace FluentMigrator.Runner.Processors
     public class ConnectionlessProcessor: IMigrationProcessor
     {
         [NotNull] private readonly ILogger _logger;
-#pragma warning disable 612
-        [Obsolete]
-        private readonly IMigrationProcessorOptions _legacyOptions;
-#pragma warning restore 612
-
-        [Obsolete]
-        public ConnectionlessProcessor(
-            IMigrationGenerator generator,
-            IRunnerContext context,
-            IMigrationProcessorOptions options)
-        {
-            _logger = new AnnouncerFluentMigratorLogger(context.Announcer);
-            _legacyOptions = options;
-            DatabaseType = context.Database;
-            Generator = generator;
-            Announcer = context.Announcer;
-            Options = options.GetProcessorOptions(connectionString: null);
-        }
 
         public ConnectionlessProcessor(
             [NotNull] IGeneratorAccessor generatorAccessor,
@@ -69,7 +51,6 @@ namespace FluentMigrator.Runner.Processors
             Options = options.Value;
 #pragma warning disable 612
             Announcer = new LoggerAnnouncer(logger, new AnnouncerOptions() { ShowElapsedTime = true, ShowSql = true });
-            _legacyOptions = options.Value;
 #pragma warning restore 612
         }
 
@@ -87,7 +68,6 @@ namespace FluentMigrator.Runner.Processors
             Options = options.Value;
 #pragma warning disable 612
             Announcer = new LoggerAnnouncer(logger, AnnouncerOptions.AllEnabled);
-            _legacyOptions = options.Value;
 #pragma warning restore 612
         }
 
@@ -99,9 +79,6 @@ namespace FluentMigrator.Runner.Processors
         [Obsolete]
         public IAnnouncer Announcer { get; set; }
         public ProcessorOptions Options {get; set;}
-
-        [Obsolete]
-        IMigrationProcessorOptions IMigrationProcessor.Options => _legacyOptions;
 
         /// <inheritdoc />
         public void Execute(string sql)

--- a/src/FluentMigrator.Runner.Core/Processors/ProcessorBase.cs
+++ b/src/FluentMigrator.Runner.Core/Processors/ProcessorBase.cs
@@ -33,10 +33,6 @@ namespace FluentMigrator.Runner.Processors
 {
     public abstract class ProcessorBase : IMigrationProcessor
     {
-#pragma warning disable 612
-        [Obsolete]
-        private readonly IMigrationProcessorOptions _legacyOptions;
-#pragma warning restore 612
 
         protected internal readonly IMigrationGenerator Generator;
 
@@ -60,8 +56,6 @@ namespace FluentMigrator.Runner.Processors
                 ProviderSwitches = options.ProviderSwitches,
                 Timeout = options.Timeout == null ? null : (TimeSpan?) TimeSpan.FromSeconds(options.Timeout.Value),
             };
-
-            _legacyOptions = options;
         }
 
         [Obsolete]
@@ -73,7 +67,6 @@ namespace FluentMigrator.Runner.Processors
             Generator = generator;
             Announcer = announcer;
             Options = options;
-            _legacyOptions = options;
             Logger = new AnnouncerFluentMigratorLogger(announcer);
         }
 
@@ -93,12 +86,8 @@ namespace FluentMigrator.Runner.Processors
                     ShowSql = true,
                     ShowElapsedTime = true,
                 });
-            _legacyOptions = options;
 #pragma warning restore 612
         }
-
-        [Obsolete]
-        IMigrationProcessorOptions IMigrationProcessor.Options => _legacyOptions;
 
         [Obsolete]
         public abstract string ConnectionString { get; }

--- a/src/FluentMigrator.Runner.Db2/Processors/Db2/Db2Processor.cs
+++ b/src/FluentMigrator.Runner.Db2/Processors/Db2/Db2Processor.cs
@@ -16,7 +16,6 @@
 //
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Data;
 
@@ -35,12 +34,6 @@ namespace FluentMigrator.Runner.Processors.DB2
 {
     public class Db2Processor : GenericProcessorBase
     {
-        [Obsolete]
-        public Db2Processor(IDbConnection connection, IMigrationGenerator generator, IAnnouncer announcer, IMigrationProcessorOptions options, IDbFactory factory)
-            : base(connection, factory, generator, announcer, options)
-        {
-            Quoter = new Db2Quoter();
-        }
 
         public Db2Processor(
             [NotNull] Db2DbFactory factory,

--- a/src/FluentMigrator.Runner.Db2/Processors/Db2/iSeries/Db2ISeriesProcessor.cs
+++ b/src/FluentMigrator.Runner.Db2/Processors/Db2/iSeries/Db2ISeriesProcessor.cs
@@ -16,14 +16,12 @@
 //
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 
 using FluentMigrator.Expressions;
 using FluentMigrator.Runner.Generators;
-using FluentMigrator.Runner.Generators.DB2;
 using FluentMigrator.Runner.Generators.DB2.iSeries;
 using FluentMigrator.Runner.Helpers;
 using FluentMigrator.Runner.Initialization;
@@ -37,12 +35,6 @@ namespace FluentMigrator.Runner.Processors.DB2.iSeries
 {
     public class Db2ISeriesProcessor : GenericProcessorBase
     {
-        [Obsolete]
-        public Db2ISeriesProcessor(IDbConnection connection, IMigrationGenerator generator, IAnnouncer announcer, IMigrationProcessorOptions options, IDbFactory factory)
-            : base(connection, factory, generator, announcer, options)
-        {
-            Quoter = new Db2Quoter();
-        }
 
         public Db2ISeriesProcessor(
             [NotNull] Db2ISeriesDbFactory factory,

--- a/src/FluentMigrator.Runner.Firebird/Processors/Firebird/FirebirdProcessor.cs
+++ b/src/FluentMigrator.Runner.Firebird/Processors/Firebird/FirebirdProcessor.cs
@@ -50,18 +50,6 @@ namespace FluentMigrator.Runner.Processors.Firebird
         protected List<string> DDLTouchedTables;
         protected Dictionary<string, List<string>> DDLTouchedColumns;
 
-        [Obsolete]
-        public FirebirdProcessor(IDbConnection connection, IMigrationGenerator generator, IAnnouncer announcer, IMigrationProcessorOptions options, IDbFactory factory, FirebirdOptions fbOptions)
-            : base(connection, factory, generator, announcer, options)
-        {
-            FBOptions = fbOptions ?? throw new ArgumentNullException(nameof(fbOptions));
-            _firebirdVersionFunc = new Lazy<Version>(GetFirebirdVersion);
-            _quoter = new FirebirdQuoter(fbOptions.ForceQuote);
-            truncator = new FirebirdTruncator(FBOptions.TruncateLongNames, FBOptions.PackKeyNames);
-            ClearLocks();
-            ClearDDLFollowers();
-        }
-
         public FirebirdProcessor(
             [NotNull] FirebirdDbFactory factory,
             [NotNull] FirebirdGenerator generator,

--- a/src/FluentMigrator.Runner.Hana/Processors/Hana/HanaProcessor.cs
+++ b/src/FluentMigrator.Runner.Hana/Processors/Hana/HanaProcessor.cs
@@ -19,11 +19,6 @@ namespace FluentMigrator.Runner.Processors.Hana
 {
     public class HanaProcessor : GenericProcessorBase
     {
-        [Obsolete]
-        public HanaProcessor(IDbConnection connection, IMigrationGenerator generator, IAnnouncer announcer, IMigrationProcessorOptions options, IDbFactory factory)
-            : base(connection, factory, generator, announcer, options)
-        {
-        }
 
         public HanaProcessor(
             [NotNull] HanaDbFactory factory,

--- a/src/FluentMigrator.Runner.Jet/Processors/Jet/JetProcessor.cs
+++ b/src/FluentMigrator.Runner.Jet/Processors/Jet/JetProcessor.cs
@@ -41,17 +41,6 @@ namespace FluentMigrator.Runner.Processors.Jet
         public OleDbTransaction Transaction => _transaction;
         private bool _disposed = false;
 
-        [Obsolete]
-        public JetProcessor(IDbConnection connection, IMigrationGenerator generator, IAnnouncer announcer, IMigrationProcessorOptions options)
-            : base(generator, announcer, options)
-        {
-            _connection = new Lazy<OleDbConnection>(() => (OleDbConnection) connection);
-
-            // Prefetch connectionstring as after opening the security info could no longer be present
-            // for instance on sql server
-            ConnectionString = connection.ConnectionString;
-        }
-
         public JetProcessor(
             [NotNull] JetGenerator generator,
             [NotNull] ILogger<JetProcessor> logger,

--- a/src/FluentMigrator.Runner.Oracle/Processors/DotConnectOracle/DotConnectOracleProcessor.cs
+++ b/src/FluentMigrator.Runner.Oracle/Processors/DotConnectOracle/DotConnectOracleProcessor.cs
@@ -37,12 +37,6 @@ namespace FluentMigrator.Runner.Processors.DotConnectOracle
 
         public override IList<string> DatabaseTypeAliases { get; } = new List<string>();
 
-        [Obsolete]
-        public DotConnectOracleProcessor(IDbConnection connection, IMigrationGenerator generator, IAnnouncer announcer, IMigrationProcessorOptions options, DotConnectOracleDbFactory factory)
-            : base(connection, factory, generator, announcer, options)
-        {
-        }
-
         public DotConnectOracleProcessor(
             [NotNull] DotConnectOracleDbFactory factory,
             [NotNull] IOracleGenerator generator,

--- a/src/FluentMigrator.Runner.Oracle/Processors/Oracle/OracleProcessor.cs
+++ b/src/FluentMigrator.Runner.Oracle/Processors/Oracle/OracleProcessor.cs
@@ -16,9 +16,6 @@
 //
 #endregion
 
-using System;
-using System.Data;
-
 using FluentMigrator.Runner.Generators.Oracle;
 using FluentMigrator.Runner.Initialization;
 
@@ -32,17 +29,6 @@ namespace FluentMigrator.Runner.Processors.Oracle
 {
     public class OracleProcessor : OracleProcessorBase
     {
-        [Obsolete]
-        public OracleProcessor(
-            IDbConnection connection,
-            IMigrationGenerator generator,
-            IAnnouncer announcer,
-            IMigrationProcessorOptions options,
-            IDbFactory factory)
-            : base(ProcessorId.Oracle, connection, generator, announcer, options, factory)
-        {
-        }
-
         public OracleProcessor(
             [NotNull] OracleDbFactory factory,
             [NotNull] IOracleGenerator generator,

--- a/src/FluentMigrator.Runner.Oracle/Processors/Oracle/OracleProcessorBase.cs
+++ b/src/FluentMigrator.Runner.Oracle/Processors/Oracle/OracleProcessorBase.cs
@@ -35,19 +35,6 @@ namespace FluentMigrator.Runner.Processors.Oracle
 {
     public class OracleProcessorBase : GenericProcessorBase
     {
-        [Obsolete]
-        protected OracleProcessorBase(
-            [NotNull] string databaseType,
-            IDbConnection connection,
-            IMigrationGenerator generator,
-            IAnnouncer announcer,
-            IMigrationProcessorOptions options,
-            IDbFactory factory)
-            : base(connection, factory, generator, announcer, options)
-        {
-            DatabaseType = databaseType;
-        }
-
         protected OracleProcessorBase(
             [NotNull] string databaseType,
             [NotNull] OracleBaseDbFactory factory,

--- a/src/FluentMigrator.Runner.Redshift/Processors/Redshift/RedshiftProcessor.cs
+++ b/src/FluentMigrator.Runner.Redshift/Processors/Redshift/RedshiftProcessor.cs
@@ -41,12 +41,6 @@ namespace FluentMigrator.Runner.Processors.Redshift
 
         public override IList<string> DatabaseTypeAliases { get; } = new List<string>();
 
-        [Obsolete]
-        public RedshiftProcessor(IDbConnection connection, IMigrationGenerator generator, IAnnouncer announcer, IMigrationProcessorOptions options, IDbFactory factory)
-            : base(connection, factory, generator, announcer, options)
-        {
-        }
-
         public RedshiftProcessor(
             [NotNull] RedshiftDbFactory factory,
             [NotNull] RedshiftGenerator generator,

--- a/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteProcessor.cs
+++ b/src/FluentMigrator.Runner.SQLite/Processors/SQLite/SQLiteProcessor.cs
@@ -51,19 +51,6 @@ namespace FluentMigrator.Runner.Processors.SQLite
 
         public override IList<string> DatabaseTypeAliases { get; } = new List<string>();
 
-        [Obsolete]
-        public SQLiteProcessor(
-            IDbConnection connection,
-            IMigrationGenerator generator,
-            IAnnouncer announcer,
-            [NotNull] IMigrationProcessorOptions options,
-            IDbFactory factory,
-            [NotNull] SQLiteQuoter quoter)
-            : base(connection, factory, generator, announcer, options)
-        {
-            _quoter = quoter;
-        }
-
         public SQLiteProcessor(
             [NotNull] SQLiteDbFactory factory,
             [NotNull] SQLiteGenerator generator,

--- a/src/FluentMigrator.Runner.SqlServer/Processors/SqlServer/SqlServer2000Processor.cs
+++ b/src/FluentMigrator.Runner.SqlServer/Processors/SqlServer/SqlServer2000Processor.cs
@@ -64,12 +64,6 @@ namespace FluentMigrator.Runner.Processors.SqlServer
         [CanBeNull]
         private readonly IServiceProvider _serviceProvider;
 
-        [Obsolete]
-        public SqlServer2000Processor(IDbConnection connection, IMigrationGenerator generator, IAnnouncer announcer, IMigrationProcessorOptions options, IDbFactory factory)
-            : base(connection, factory, generator, announcer, options)
-        {
-        }
-
         public SqlServer2000Processor(
             [NotNull] ILogger<SqlServer2000Processor> logger,
             [NotNull] SqlServer2000Generator generator,
@@ -241,7 +235,7 @@ namespace FluentMigrator.Runner.Processors.SqlServer
                 }
                 catch (Exception ex)
                 {
-                    using (var message = new StringWriter())
+                    using (_ = new StringWriter())
                     {
                         ReThrowWithSql(ex, sql);
                     }

--- a/test/FluentMigrator.Tests/Unit/Generators/Postgres11_0/Postgres11_0GeneratorTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Postgres11_0/Postgres11_0GeneratorTests.cs
@@ -34,10 +34,9 @@ namespace FluentMigrator.Tests.Unit.Generators.Postgres11_0
     [TestFixture]
     public class Postgres11_0GeneratorTests : Postgres92GeneratorTests
     {
-        protected PostgresGenerator Generator;
 
         [SetUp]
-        public void Setup()
+        public override void Setup()
         {
             var quoter = new PostgresQuoter(new PostgresOptions());
             Generator = new Postgres11_0Generator(quoter, new OptionsWrapper<GeneratorOptions>(new GeneratorOptions()));

--- a/test/FluentMigrator.Tests/Unit/Generators/Postgres92/Postgres92GeneratorTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Postgres92/Postgres92GeneratorTests.cs
@@ -37,7 +37,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Postgres92
         protected PostgresGenerator Generator;
 
         [SetUp]
-        public void Setup()
+        public virtual void Setup()
         {
             var quoter = new PostgresQuoter(new PostgresOptions());
             Generator = new Postgres92Generator(quoter, new OptionsWrapper<GeneratorOptions>(new GeneratorOptions()));

--- a/test/FluentMigrator.Tests/Unit/ObsoleteVersionLoaderTests.cs
+++ b/test/FluentMigrator.Tests/Unit/ObsoleteVersionLoaderTests.cs
@@ -23,7 +23,6 @@ using System.Reflection;
 using FluentMigrator.Expressions;
 using FluentMigrator.Runner;
 using FluentMigrator.Runner.Initialization;
-using FluentMigrator.Runner.Processors;
 using FluentMigrator.Runner.VersionTableInfo;
 
 using Moq;
@@ -39,12 +38,15 @@ namespace FluentMigrator.Tests.Unit
     public class ObsoleteVersionLoaderTests
     {
         [Test]
-        public void CanLoadCustomVersionTableMetaData()
+        public void CanLoadCustomVersionTableMetaData([Values] bool schemaExists)
         {
             var runnerContext = new Mock<IRunnerContext>();
 
             var runner = new Mock<IMigrationRunner>();
-            runner.SetupGet(r => r.Processor.Options).Returns(new ProcessorOptions());
+            var migrationProcessor = new Mock<IMigrationProcessor>();
+            migrationProcessor.Setup(mp => mp.SchemaExists(It.IsAny<string>()))
+                .Returns(schemaExists);
+            runner.SetupGet(r => r.Processor).Returns(migrationProcessor.Object);
             runner.SetupGet(r => r.RunnerContext).Returns(runnerContext.Object);
 
             var conventions = new MigrationRunnerConventions();
@@ -56,12 +58,15 @@ namespace FluentMigrator.Tests.Unit
         }
 
         [Test]
-        public void CanLoadDefaultVersionTableMetaData()
+        public void CanLoadDefaultVersionTableMetaData([Values] bool schemaExists)
         {
             var runnerContext = new Mock<IRunnerContext>();
 
             var runner = new Mock<IMigrationRunner>();
-            runner.SetupGet(r => r.Processor.Options).Returns(new ProcessorOptions());
+            var migrationProcessor = new Mock<IMigrationProcessor>();
+            migrationProcessor.Setup(mp => mp.SchemaExists(It.IsAny<string>()))
+                .Returns(schemaExists);
+            runner.SetupGet(r => r.Processor).Returns(migrationProcessor.Object);
             runner.SetupGet(r => r.RunnerContext).Returns(runnerContext.Object);
 
             var conventions = new MigrationRunnerConventions();


### PR DESCRIPTION
- Obsolete constructor on MigrationScopeHandler is now removed
- Obsolete property IMigrationProcessor.Options on ConnectionlessProcessor is now removed
- Obsolete constructors on the following Processors is now removed: ConnectionlessProcessor, Db2ISeriesProcessor, Db2Processor, FirebirdProcessor, HanaProcessor, JetProcessor, DotNetOracleProcessor, OracleProcessor, OracleProcessorBase, RedshiftProcessor, SQLiteProcessor, SqlServer2000Processor

- Fixed hidden method warnings in Postgres tests