### PR TITLE
Use database function to set the value of `AppliedOn`

### DIFF
--- a/src/FluentMigrator.Runner.Core/ConnectionlessVersionLoader.cs
+++ b/src/FluentMigrator.Runner.Core/ConnectionlessVersionLoader.cs
@@ -200,10 +200,26 @@ namespace FluentMigrator.Runner
 
         protected virtual InsertionDataDefinition CreateVersionInfoInsertionData(long version, string description)
         {
+            object appliedOnValue;
+
+            if (_quoter is null)
+            {
+                appliedOnValue = DateTime.UtcNow;
+            }
+            else
+            {
+                var quotedCurrentDate = _quoter.QuoteValue(SystemMethods.CurrentUTCDateTime);
+
+                // Default to using DateTime if no system method could be obtained
+                appliedOnValue = string.IsNullOrWhiteSpace(quotedCurrentDate)
+                    ? (object) DateTime.UtcNow
+                    : RawSql.Insert(quotedCurrentDate);
+            }
+
             return new InsertionDataDefinition
             {
                 new KeyValuePair<string, object>(VersionTableMetaData.ColumnName, version),
-                new KeyValuePair<string, object>(VersionTableMetaData.AppliedOnColumnName, DateTime.UtcNow),
+                new KeyValuePair<string, object>(VersionTableMetaData.AppliedOnColumnName, appliedOnValue),
                 new KeyValuePair<string, object>(VersionTableMetaData.DescriptionColumnName, description)
             };
         }

--- a/src/FluentMigrator.Runner.Core/ConnectionlessVersionLoader.cs
+++ b/src/FluentMigrator.Runner.Core/ConnectionlessVersionLoader.cs
@@ -42,6 +42,8 @@ namespace FluentMigrator.Runner
         [NotNull]
         private readonly IMigrationInformationLoader _migrationInformationLoader;
 
+        private readonly IQuoter _quoter;
+
         private bool _versionsLoaded;
 
         [Obsolete]
@@ -55,6 +57,7 @@ namespace FluentMigrator.Runner
         {
             _migrationInformationLoader = runner.MigrationLoader;
             _processor = runner.Processor;
+            _quoter = _processor.GetQuoter();
 
             Runner = runner;
             Assemblies = assemblies;
@@ -88,6 +91,7 @@ namespace FluentMigrator.Runner
         {
             _processor = processorAccessor.Processor;
             _migrationInformationLoader = migrationInformationLoader;
+            _quoter = _processor.GetQuoter();
             Conventions = conventions;
             StartVersion = runnerOptions.Value.StartVersion;
             TargetVersion = runnerOptions.Value.Version;

--- a/src/FluentMigrator.Runner.Core/Processors/ProcessorExtensions.cs
+++ b/src/FluentMigrator.Runner.Core/Processors/ProcessorExtensions.cs
@@ -1,0 +1,55 @@
+#region License
+// Copyright (c) 2024, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using FluentMigrator.Runner.Generators;
+using FluentMigrator.Runner.Generators.Generic;
+
+namespace FluentMigrator.Runner.Processors
+{
+    public static class ProcessorExtensions
+    {
+        /// <summary>
+        /// A helper method to get the <see cref="IQuoter"/> for the given migration processor since the
+        /// <see cref="IMigrationProcessor"/> interface does not expose the quoter directly.
+        /// </summary>
+        /// <remarks>
+        /// This method relies on the <see cref="IMigrationProcessor"/> being a <see cref="GenericProcessorBase"/> or a
+        /// <see cref="ConnectionlessProcessor"/> and its <see cref="GenericProcessorBase.Generator"/> being a
+        /// <see cref="GenericGenerator"/>. If this is not the case, there is no way to get the <see cref="IQuoter"/> so
+        /// this method will return <see langword="null"/>.
+        /// </remarks>
+        public static IQuoter GetQuoter(this IMigrationProcessor processor)
+        {
+            IMigrationGenerator generator;
+
+            switch (processor)
+            {
+                case GenericProcessorBase genericProcessorBase:
+                    generator = genericProcessorBase.Generator;
+                    break;
+                case ConnectionlessProcessor connectionlessProcessor:
+                    generator = connectionlessProcessor.Generator;
+                    break;
+                default:
+                    generator = null;
+                    break;
+            }
+
+            // Safe cast to GenericGenerator since IMigrationGenerator does not expose the quoter
+            return (generator as GenericGenerator)?.Quoter;
+        }
+    }
+}

--- a/src/FluentMigrator.Runner.Core/VersionLoader.cs
+++ b/src/FluentMigrator.Runner.Core/VersionLoader.cs
@@ -40,6 +40,7 @@ namespace FluentMigrator.Runner
         private readonly IMigrationProcessor _processor;
 
         private readonly IConventionSet _conventionSet;
+        private readonly IQuoter _quoter;
         private bool _versionSchemaMigrationAlreadyRun;
         private bool _versionMigrationAlreadyRun;
         private bool _versionUniqueMigrationAlreadyRun;
@@ -80,6 +81,7 @@ namespace FluentMigrator.Runner
         {
             _conventionSet = conventionSet;
             _processor = runner.Processor;
+            _quoter = _processor.GetQuoter();
 
             Runner = runner;
             Assemblies = assemblies;
@@ -103,6 +105,7 @@ namespace FluentMigrator.Runner
         {
             _conventionSet = conventionSet;
             _processor = processorAccessor.Processor;
+            _quoter = _processor.GetQuoter();
 
             Runner = runner;
 

--- a/src/FluentMigrator.Runner.Core/VersionLoader.cs
+++ b/src/FluentMigrator.Runner.Core/VersionLoader.cs
@@ -142,10 +142,26 @@ namespace FluentMigrator.Runner
 
         protected virtual InsertionDataDefinition CreateVersionInfoInsertionData(long version, string description)
         {
+            object appliedOnValue;
+
+            if (_quoter is null)
+            {
+                appliedOnValue = DateTime.UtcNow;
+            }
+            else
+            {
+                var quotedCurrentDate = _quoter.QuoteValue(SystemMethods.CurrentUTCDateTime);
+
+                // Default to using DateTime if no system method could be obtained
+                appliedOnValue = string.IsNullOrWhiteSpace(quotedCurrentDate)
+                    ? (object) DateTime.UtcNow
+                    : RawSql.Insert(quotedCurrentDate);
+            }
+
             return new InsertionDataDefinition
                        {
                            new KeyValuePair<string, object>(VersionTableMetaData.ColumnName, version),
-                           new KeyValuePair<string, object>(VersionTableMetaData.AppliedOnColumnName, DateTime.UtcNow),
+                           new KeyValuePair<string, object>(VersionTableMetaData.AppliedOnColumnName, appliedOnValue),
                            new KeyValuePair<string, object>(VersionTableMetaData.DescriptionColumnName, description),
                        };
         }


### PR DESCRIPTION
Use a database function to set the value of the `AppliedOn` column of the `VersionInfo` table whenever the version info is updated.

Previously, the value of `AppliedOn` would be decided when the migrations are generated and then hardcoded into the SQL script.

This is not an issue when the database is updated directly but it is a problem when updating the database through SQL scripts.

---

### Before

```sql
INSERT INTO [dbo].[VersionInfo] ([Version], [AppliedOn], [Description]) VALUES (20240101010101, '2024-07-30T09:27:42', N'MyMigrationName');
```

### After

```sql
INSERT INTO [dbo].[VersionInfo] ([Version], [AppliedOn], [Description]) VALUES (20240101010101, GETUTCDATE(), N'MyMigrationName');
```

---

Fixes #1846 