### PR TITLE
Bugfixes/1848 issues with non english culture

### DIFF
--- a/src/FluentMigrator.Runner.Postgres/Generators/Postgres/PostgresGenerator.cs
+++ b/src/FluentMigrator.Runner.Postgres/Generators/Postgres/PostgresGenerator.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -364,7 +365,7 @@ namespace FluentMigrator.Runner.Generators.Postgres
             var cleanup = GetIndexStorageParameters<float?>(PostgresExtensions.IndexVacuumCleanupIndexScaleFactor, "VacuumCleanupIndexScaleFactor");
             if (cleanup.HasValue)
             {
-                parameters.Add($"VACUUM_CLEANUP_INDEX_SCALE_FACTOR = {cleanup.Value.ToString().ToUpper()}");
+                parameters.Add($"VACUUM_CLEANUP_INDEX_SCALE_FACTOR = {cleanup.Value.ToString(CultureInfo.InvariantCulture)}");
             }
 
             if (parameters.Count == 0)

--- a/test/FluentMigrator.Tests/Unit/Builders/Delete/DeleteDataExpressionTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Builders/Delete/DeleteDataExpressionTests.cs
@@ -109,7 +109,7 @@ namespace FluentMigrator.Tests.Unit.Builders.Delete
         }
 
         [Test]
-        [SetUICulture("en-US")] // Ensure validation messages are in English
+        [SetUICulture("")] // Ensure validation messages are in English
         public void DefaultMigrationExpressionValidatorShouldReturnErrorWhenTableNameIsNotSpecified()
         {
             var mockServiceProvider = new Mock<IServiceProvider>();

--- a/test/FluentMigrator.Tests/Unit/Builders/Delete/DeleteDataExpressionTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Builders/Delete/DeleteDataExpressionTests.cs
@@ -109,11 +109,9 @@ namespace FluentMigrator.Tests.Unit.Builders.Delete
         }
 
         [Test]
+        [SetUICulture("en-US")] // Ensure validation messages are in English
         public void DefaultMigrationExpressionValidatorShouldReturnErrorWhenTableNameIsNotSpecified()
         {
-            // Ensure error messages are in English
-            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
-
             var mockServiceProvider = new Mock<IServiceProvider>();
             var validator = new DefaultMigrationExpressionValidator(mockServiceProvider.Object);
             var expressionMock = new Mock<DeleteDataExpression>();

--- a/test/FluentMigrator.Tests/Unit/Builders/Delete/DeleteDataExpressionTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Builders/Delete/DeleteDataExpressionTests.cs
@@ -26,6 +26,7 @@ using FluentMigrator.Builders.Delete;
 using FluentMigrator.Validation;
 
 using Shouldly;
+using System.Globalization;
 
 namespace FluentMigrator.Tests.Unit.Builders.Delete
 {
@@ -110,10 +111,13 @@ namespace FluentMigrator.Tests.Unit.Builders.Delete
         [Test]
         public void DefaultMigrationExpressionValidatorShouldReturnErrorWhenTableNameIsNotSpecified()
         {
+            // Ensure error messages are in English
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+
             var mockServiceProvider = new Mock<IServiceProvider>();
             var validator = new DefaultMigrationExpressionValidator(mockServiceProvider.Object);
             var expressionMock = new Mock<DeleteDataExpression>();
-            
+
             var builder = new DeleteDataExpressionBuilder(expressionMock.Object);
             builder.IsNull("TestColumn");
 

--- a/test/FluentMigrator.Tests/Unit/Validation/DefaultMigrationExpressionValidatorTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Validation/DefaultMigrationExpressionValidatorTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 using FluentMigrator.Builders.Create.Constraint;
@@ -30,6 +31,13 @@ namespace FluentMigrator.Tests.Unit.Validation
     [Category("Validation")]
     public class DefaultMigrationExpressionValidatorTests
     {
+        [SetUp]
+        public void Setup()
+        {
+            // Ensure validation messages are in English
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+        }
+
         [Test]
         public void ValidateInsertDataExpressionWithoutTableNameShouldReturnError()
         {

--- a/test/FluentMigrator.Tests/Unit/Validation/DefaultMigrationExpressionValidatorTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Validation/DefaultMigrationExpressionValidatorTests.cs
@@ -29,14 +29,9 @@ namespace FluentMigrator.Tests.Unit.Validation
 {
     [TestFixture]
     [Category("Validation")]
+    [SetUICulture("en-US")] // Ensure validation messages are in English
     public class DefaultMigrationExpressionValidatorTests
     {
-        [SetUp]
-        public void Setup()
-        {
-            // Ensure validation messages are in English
-            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
-        }
 
         [Test]
         public void ValidateInsertDataExpressionWithoutTableNameShouldReturnError()

--- a/test/FluentMigrator.Tests/Unit/Validation/DefaultMigrationExpressionValidatorTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Validation/DefaultMigrationExpressionValidatorTests.cs
@@ -29,7 +29,7 @@ namespace FluentMigrator.Tests.Unit.Validation
 {
     [TestFixture]
     [Category("Validation")]
-    [SetUICulture("en-US")] // Ensure validation messages are in English
+    [SetUICulture("")] // Ensure validation messages are in English
     public class DefaultMigrationExpressionValidatorTests
     {
 


### PR DESCRIPTION
- Ensure tests checking against validation messages have invariant (english) culture
- Fix bug in `PostgresGenerator` if `IndexVacuumCleanupIndexScaleFactor` is used with a floating point number (should use invariant culture).

Fixes #1848 

> [!NOTE]
> Maybe other `ToString()` calls need to be investigated to ensure they do not cause the same issues as in `PostgresGenerator`.