### PR TITLE
#1884: Register ProcessorOptions explicitly, required by MigrationScopeHandler

### DIFF
--- a/src/FluentMigrator.Runner.Core/FluentMigratorServiceCollectionExtensions.cs
+++ b/src/FluentMigrator.Runner.Core/FluentMigratorServiceCollectionExtensions.cs
@@ -131,7 +131,10 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddScoped<IMigrationExpressionValidator, DefaultMigrationExpressionValidator>()
                 .AddScoped<MigrationValidator>()
                 .AddScoped<MigrationScopeHandler>()
+                // Register ProcessorOptions explicitly, required by MigrationScopeHandler
+                .AddScoped(sp => sp.GetRequiredService<IOptionsSnapshot<ProcessorOptions>>().Value);
 
+            services
                 // The connection string readers
 #if NETFRAMEWORK
                 .AddScoped<INetConfigManager, NetConfigManager>()


### PR DESCRIPTION
Registers `ProcessorOptions` as a scoped service, as MigrationScopeHandler depends on it. This registration depends on the already registered `IOptionsSnapshot<ProcessorOptions>` via a factory method.

It's registered as scoped, because
  -  `MigrationScopeHandler` is scoped
  - `IOptionsSnapshot<>` is scoped
  - `IOptionsSnapshot<ProcessorOptions>` is already used in `MigrationRunner`'s constructors and passed on to `MigrationScopeHandler`
  - `MigrationRunner` is scoped

It's not registered with `TryAddScoped<>(...)`, because resolving `ProcessorOptions` and `IOptionsSnapshot<ProcessorOptions>` should _always_ return the same options.

Fixes #1884