### PR TITLE
Improve `MigrationAttribute`

### DIFF
--- a/src/FluentMigrator.Abstractions/Infrastructure/MigrationInfo.cs
+++ b/src/FluentMigrator.Abstractions/Infrastructure/MigrationInfo.cs
@@ -35,8 +35,9 @@ namespace FluentMigrator.Infrastructure
         /// <param name="version">The migration version</param>
         /// <param name="transactionBehavior">The desired transaction behavior</param>
         /// <param name="migration">The underlying migration</param>
-        public MigrationInfo(long version, TransactionBehavior transactionBehavior, IMigration migration)
-            : this(version, null, transactionBehavior, false, () => migration)
+        /// <param name="versionAsString"></param>
+        public MigrationInfo(long version, TransactionBehavior transactionBehavior, IMigration migration, string versionAsString = null)
+            : this(version, null, transactionBehavior, false, () => migration, versionAsString ?? version.ToString())
         {
         }
 
@@ -45,10 +46,11 @@ namespace FluentMigrator.Infrastructure
         /// </summary>
         /// <param name="version">The migration version</param>
         /// <param name="transactionBehavior">The desired transaction behavior</param>
-        /// <param name="isBreakingChange">Indicates wether the migration is a breaking change</param>
+        /// <param name="isBreakingChange">Indicates whether the migration is a breaking change</param>
         /// <param name="migration">The underlying migration</param>
-        public MigrationInfo(long version, TransactionBehavior transactionBehavior, bool isBreakingChange, IMigration migration)
-            : this(version, null, transactionBehavior, isBreakingChange, () => migration)
+        /// <param name="versionAsString">The human-readable version</param>
+        public MigrationInfo(long version, TransactionBehavior transactionBehavior, bool isBreakingChange, IMigration migration, string versionAsString = null)
+            : this(version, null, transactionBehavior, isBreakingChange, () => migration, versionAsString ?? version.ToString())
         {
         }
 
@@ -58,14 +60,16 @@ namespace FluentMigrator.Infrastructure
         /// <param name="version">The migration version</param>
         /// <param name="description">The migration description</param>
         /// <param name="transactionBehavior">The desired transaction behavior</param>
-        /// <param name="isBreakingChange">Indicates wether the migration is a breaking change</param>
+        /// <param name="isBreakingChange">Indicates whether the migration is a breaking change</param>
         /// <param name="migrationFunc">A function to get the <see cref="IMigration"/> instance</param>
+        /// <param name="versionAsString">The human-readable version</param>
         public MigrationInfo(
             long version,
             string description,
             TransactionBehavior transactionBehavior,
             bool isBreakingChange,
-            Func<IMigration> migrationFunc)
+            Func<IMigration> migrationFunc,
+            string versionAsString)
         {
             if (migrationFunc == null) throw new ArgumentNullException(nameof(migrationFunc));
 
@@ -74,6 +78,7 @@ namespace FluentMigrator.Infrastructure
             TransactionBehavior = transactionBehavior;
             IsBreakingChange = isBreakingChange;
             _lazyMigration = new Lazy<IMigration>(migrationFunc);
+            VersionAsString = versionAsString;
         }
 
         /// <inheritdoc />
@@ -91,6 +96,8 @@ namespace FluentMigrator.Infrastructure
         /// <inheritdoc />
         public bool IsBreakingChange { get; }
 
+        public string VersionAsString { get; }
+
         /// <inheritdoc />
         public object Trait(string name)
         {
@@ -106,7 +113,7 @@ namespace FluentMigrator.Infrastructure
         /// <inheritdoc />
         public string GetName()
         {
-            return string.Format("{0}: {1}", Version, Migration.GetType().Name);
+            return string.Format("{0}: {1}", VersionAsString, Migration.GetType().Name);
         }
 
         /// <summary>

--- a/src/FluentMigrator.Abstractions/MigrationAttribute.cs
+++ b/src/FluentMigrator.Abstractions/MigrationAttribute.cs
@@ -60,6 +60,11 @@ namespace FluentMigrator
         public long Version { get; }
 
         /// <summary>
+        /// Gets the human-readable version
+        /// </summary>
+        public virtual string VersionAsString => this.Version.ToString();
+
+        /// <summary>
         /// Gets the desired transaction behavior
         /// </summary>
         public TransactionBehavior TransactionBehavior { get; }

--- a/src/FluentMigrator.Runner.Core/Conventions/DefaultAutoNameConvention.cs
+++ b/src/FluentMigrator.Runner.Core/Conventions/DefaultAutoNameConvention.cs
@@ -56,7 +56,7 @@ namespace FluentMigrator.Runner.Conventions
                 .FirstOrDefault();
             if (migrationAttribute != null)
             {
-                var version = migrationAttribute.Version;
+                var version = migrationAttribute.VersionAsString;
                 foreach (var databaseType in databaseTypes)
                 {
                     yield return string.Format("Scripts.Up.{0}_{1}_{2}.sql"
@@ -75,7 +75,7 @@ namespace FluentMigrator.Runner.Conventions
                 .FirstOrDefault();
             if (migrationAttribute != null)
             {
-                var version = migrationAttribute.Version;
+                var version = migrationAttribute.VersionAsString;
                 foreach (var databaseType in databaseTypes)
                 {
                     yield return string.Format("Scripts.Down.{0}_{1}_{2}.sql"

--- a/src/FluentMigrator.Runner.Core/Infrastructure/DefaultMigrationConventions.cs
+++ b/src/FluentMigrator.Runner.Core/Infrastructure/DefaultMigrationConventions.cs
@@ -76,7 +76,7 @@ namespace FluentMigrator.Runner.Infrastructure
         {
             var migrationType = migration.GetType();
             var migrationAttribute = migrationType.GetCustomAttribute<MigrationAttribute>();
-            var migrationInfo = new MigrationInfo(migrationAttribute.Version, migrationAttribute.Description, migrationAttribute.TransactionBehavior, migrationAttribute.BreakingChange, () => migration);
+            var migrationInfo = new MigrationInfo(migrationAttribute.Version, migrationAttribute.Description, migrationAttribute.TransactionBehavior, migrationAttribute.BreakingChange, () => migration, migrationAttribute.VersionAsString);
 
             foreach (var traitAttribute in migrationType.GetCustomAttributes<MigrationTraitAttribute>(true))
                 migrationInfo.AddTrait(traitAttribute.Name, traitAttribute.Value);


### PR DESCRIPTION
Add VersionAsString to `MigrationAttribute` so customMigrationAttributes can display a decoded version of their numbering rule update `MigrationInfo` to also support new Property