### PR TITLE
Fixes #2054: Support Insert multiple rows from IEnumerable

### DIFF
--- a/src/FluentMigrator.Abstractions/Builders/Insert/IInsertDataSyntax.cs
+++ b/src/FluentMigrator.Abstractions/Builders/Insert/IInsertDataSyntax.cs
@@ -30,18 +30,35 @@ namespace FluentMigrator.Builders.Insert
         /// <summary>
         /// Specify the data to insert
         /// </summary>
-        /// <param name="dataAsAnonymousType">An anonymous object that is used to insert data</param>
+        /// <param name="recordAsAnonymousType">An anonymous object that is used to insert data</param>
         /// <remarks>
         /// The properties are the column names and their values are the row values.
         /// </remarks>
         /// <returns>The next step</returns>
-        IInsertDataSyntax Row(object dataAsAnonymousType);
+        IInsertDataSyntax Row(object recordAsAnonymousType);
 
         /// <summary>
         /// Specify the data to insert
         /// </summary>
-        /// <param name="data">The dictionary containing column name/value combinations</param>
+        /// <param name="recordsAsAnonymousTypes">An array of anonymous objects that are used to insert data</param>
+        /// <remarks>
+        /// The properties are the column names and their values are the row values.
+        /// </remarks>
         /// <returns>The next step</returns>
-        IInsertDataSyntax Row(IDictionary<string, object> data);
+        IInsertDataSyntax Rows(params object[] recordsAsAnonymousTypes);
+
+        /// <summary>
+        /// Specify the data to insert
+        /// </summary>
+        /// <param name="record">The dictionary containing column name/value combinations</param>
+        /// <returns>The next step</returns>
+        IInsertDataSyntax Row(IDictionary<string, object> record);
+
+        /// <summary>
+        /// Specify the data to insert
+        /// </summary>
+        /// <param name="records">An array of dictionaries each containing column name/value combinations</param>
+        /// <returns>The next step</returns>
+        IInsertDataSyntax Rows(params IDictionary<string, object>[] records);
     }
 }

--- a/src/FluentMigrator/Builders/Insert/InsertDataExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Insert/InsertDataExpressionBuilder.cs
@@ -18,6 +18,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 
 using FluentMigrator.Expressions;
 using FluentMigrator.Infrastructure;
@@ -45,21 +46,35 @@ namespace FluentMigrator.Builders.Insert
         public IDictionary<string, object> AdditionalFeatures => _expression.AdditionalFeatures;
 
         /// <inheritdoc />
-        public IInsertDataSyntax Row(object dataAsAnonymousType)
+        public IInsertDataSyntax Row(object recordAsAnonymousType)
         {
-            IDictionary<string, object> data = ExtractData(dataAsAnonymousType);
-
-            return Row(data);
+            return Rows(recordAsAnonymousType);
         }
 
         /// <inheritdoc />
-        public IInsertDataSyntax Row(IDictionary<string, object> data)
+        public IInsertDataSyntax Rows(params object[] recordsAsAnonymousTypes)
         {
-            var dataDefinition = new InsertionDataDefinition();
+            var records = recordsAsAnonymousTypes.Select(ExtractData).ToArray();
+            return Rows(records);
+        }
 
-            dataDefinition.AddRange(data);
+        /// <inheritdoc />
+        public IInsertDataSyntax Row(IDictionary<string, object> record)
+        {
+            return Rows(record);
+        }
 
-            _expression.Rows.Add(dataDefinition);
+        /// <inheritdoc />
+        public IInsertDataSyntax Rows(params IDictionary<string, object>[] records)
+        {
+            var dataDefinitions = records.Select(record =>
+            {
+                var dataDefinition = new InsertionDataDefinition();
+                dataDefinition.AddRange(record);
+                return dataDefinition;
+            });
+
+            _expression.Rows.AddRange(dataDefinitions);
 
             return this;
         }

--- a/test/FluentMigrator.Tests/Unit/Builders/Insert/InsertDataExpressionBuilderTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Builders/Insert/InsertDataExpressionBuilderTests.cs
@@ -65,22 +65,83 @@ namespace FluentMigrator.Tests.Unit.Builders.Insert
         }
 
         [Test]
-        public void RowsGetPopulatedWhenRowWithDictionaryIsCalled()
+        public void RowsGetSetWhenRowsIsCalled()
         {
-            var values = new Dictionary<string, object>();
-            values["Data1"] = "Row1Data1";
-            values["Data2"] = "Row1Data2";
-
             var expression = new InsertDataExpression();
 
-            new InsertDataExpressionBuilder(expression).Row(values);
+            var builder = new InsertDataExpressionBuilder(expression);
+            builder
+                .Rows(
+                    new { Data1 = "Row1Data1", Data2 = "Row1Data2" },
+                    new { Data1 = "Row2Data1", Data2 = "Row2Data2" }
+                );
+
+            expression.Rows.Count.ShouldBe(2);
+
+            expression.Rows[0][0].Key.ShouldBe("Data1");
+            expression.Rows[0][0].Value.ShouldBe("Row1Data1");
+
+            expression.Rows[0][1].Key.ShouldBe("Data2");
+            expression.Rows[0][1].Value.ShouldBe("Row1Data2");
+
+            expression.Rows[1][0].Key.ShouldBe("Data1");
+            expression.Rows[1][0].Value.ShouldBe("Row2Data1");
+
+            expression.Rows[1][1].Key.ShouldBe("Data2");
+            expression.Rows[1][1].Value.ShouldBe("Row2Data2");
+        }
+
+        [Test]
+        public void RowsGetPopulatedWhenRowWithDictionaryIsCalled()
+        {
+            var expression = new InsertDataExpression();
+
+            new InsertDataExpressionBuilder(expression).Row(
+                new Dictionary<string, object>
+                {
+                    ["Data1"] = "Row1Data1",
+                    ["Data2"] = "Row1Data2"
+                });
 
             expression.Rows.Count.ShouldBe(1);
 
             expression.Rows[0][0].Key.ShouldBe("Data1");
             expression.Rows[0][0].Value.ShouldBe("Row1Data1");
+
             expression.Rows[0][1].Key.ShouldBe("Data2");
             expression.Rows[0][1].Value.ShouldBe("Row1Data2");
+        }
+
+        [Test]
+        public void RowsGetPopulatedWhenRowsWithDictionaryIsCalled()
+        {
+            var expression = new InsertDataExpression();
+
+            new InsertDataExpressionBuilder(expression).Rows(
+                new Dictionary<string, object>
+                {
+                    ["Data1"] = "Row1Data1",
+                    ["Data2"] = "Row1Data2"
+                },
+                new Dictionary<string, object>
+                {
+                    ["Data1"] = "Row2Data1",
+                    ["Data2"] = "Row2Data2"
+                });
+
+            expression.Rows.Count.ShouldBe(2);
+
+            expression.Rows[0][0].Key.ShouldBe("Data1");
+            expression.Rows[0][0].Value.ShouldBe("Row1Data1");
+
+            expression.Rows[0][1].Key.ShouldBe("Data2");
+            expression.Rows[0][1].Value.ShouldBe("Row1Data2");
+
+            expression.Rows[1][0].Key.ShouldBe("Data1");
+            expression.Rows[1][0].Value.ShouldBe("Row2Data1");
+
+            expression.Rows[1][1].Key.ShouldBe("Data2");
+            expression.Rows[1][1].Value.ShouldBe("Row2Data2");
         }
 
         [Test]


### PR DESCRIPTION
For `Insert.IntoTable`, adds a new `Rows` method that allows inserting multiple records from a single method call, such as from an instance of `IEnumerable<object>`. The implementation is done with `params` for convenient use. Two `Rows` method were added: for anonymous types and for `IDictionary<string, object>`, matching the implementation of the existing `Row` methods.

Rather than using:
```csharp
foreach (var record in records)
{
    Insert.IntoTable("myTable").Row(record);
}
```

The code can be simplified to:
```csharp
Insert.IntoTable("myTable").Rows(records);
```

Because of `params`, this also allows developers that are making individual record calls:
```csharp
Insert.IntoTable("myTable")
    .Row(new { Data1 = "Row1Data1", Data2 = "Row1Data2" })
    .Row(new { Data1 = "Row2Data1", Data2 = "Row2Data2" });
```
to instead use a single `Rows` call:
```csharp
Insert.IntoTable("myTable")
    .Rows(
        new { Data1 = "Row1Data1", Data2 = "Row1Data2" },
        new { Data1 = "Row2Data1", Data2 = "Row2Data2" }
    );
```

This completes #2054.

Notes:
Regarding the `data` method argument on the `Row` method: because `data` is ambiguous regarding singular and plural use, the argument has been renamed to `record`/`records`.

Fixes #2054
