### PR TITLE
Make SqlServer2008TypeMap a public class

### DIFF
--- a/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2008TypeMap.cs
+++ b/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2008TypeMap.cs
@@ -20,7 +20,7 @@ using System.Data;
 
 namespace FluentMigrator.Runner.Generators.SqlServer
 {
-    internal class SqlServer2008TypeMap : SqlServer2005TypeMap
+    public class SqlServer2008TypeMap : SqlServer2005TypeMap
     {
         protected override void SetupSqlServerTypeMaps()
         {


### PR DESCRIPTION
Makes `SqlServer2008TypeMap` public, so that it can serve as a base class for further custom type maps and participate in custom runner configuration.

Fixes #2094 