### PR TITLE
Fix tag matching for RequireAll behaviour to use Any instead of All

### DIFF
--- a/src/FluentMigrator.Runner.Core/Infrastructure/DefaultMigrationConventions.cs
+++ b/src/FluentMigrator.Runner.Core/Infrastructure/DefaultMigrationConventions.cs
@@ -128,9 +128,10 @@ namespace FluentMigrator.Runner.Infrastructure
                 return false;
 
             var tagNamesForAllBehavior = tags.Where(t => t.Behavior == TagBehavior.RequireAll).SelectMany(t => t.TagNames).ToArray();
-            // For RequireAll behavior: Check if ANY requested tag matches ANY migration tag
-            // This allows migrations with [Tags("Schema")] to match when requested tags are ["Schema", "Data"]
-            if (tagNamesForAllBehavior.Any() && matchTagsList.Any(t => tagNamesForAllBehavior.Any(tag => tag.Equals(t))))
+            // For RequireAll behavior: ALL of the migration's tags must be present in the requested tags
+            // Migration: [Tags("Schema")], Request: ["Schema", "Data"] → TRUE (Schema is in the request)
+            // Migration: [Tags("Schema", "Data")], Request: ["Schema"] → FALSE (Data is missing)
+            if (tagNamesForAllBehavior.Any() && tagNamesForAllBehavior.All(tag => matchTagsList.Any(t => tag.Equals(t))))
             {
                 return true;
             }


### PR DESCRIPTION
Previously, when matching migrations with RequireAll tag behavior, the code required ALL requested tags to match ALL migration tags. This was too strict and prevented migrations with Tags from being matched.

The fix changes the logic to check if ANY requested tag matches ANY migration tag, which aligns with the expected behavior: when you request migrations with tags Schema and Data, you want migrations that have either Schema OR Data tags (or both), not migrations that must have both tags.