### PR TITLE
Fix Snowflake migrations for #2113

### DIFF
--- a/src/FluentMigrator.Runner.Snowflake/Generators/Snowflake/SnowflakeQuoter.cs
+++ b/src/FluentMigrator.Runner.Snowflake/Generators/Snowflake/SnowflakeQuoter.cs
@@ -96,12 +96,10 @@ namespace FluentMigrator.Runner.Generators.Snowflake
                 case SystemMethods.NewGuid:
                     return "UUID_STRING()";
                 case SystemMethods.CurrentDateTimeOffset:
-                    return "CURRENT_TIMESTAMP()";
                 case SystemMethods.CurrentDateTime:
-                    // SYSDATE() returns TIMESTAMP_NTZ, compatible with VersionInfo table
-                    return "SYSDATE()";
+                    return "CURRENT_TIMESTAMP()";
                 case SystemMethods.CurrentUTCDateTime:
-                    return "CONVERT_TIMEZONE('UTC',CURRENT_TIMESTAMP())";
+                    return "SYSDATE()";
                 case SystemMethods.CurrentUser:
                     return "CURRENT_USER()";
                 default:

--- a/test/FluentMigrator.Tests/Unit/Generators/Snowflake/SnowflakeColumnTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Snowflake/SnowflakeColumnTests.cs
@@ -128,7 +128,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Snowflake
             var result = expressions.Select(x => (string)Generator.Generate((dynamic)x));
             result.ShouldBe(new [] {
                 @"ALTER TABLE ""TestSchema"".""TestTable1"" ADD COLUMN ""TestColumn1"" TIMESTAMP_NTZ;",
-                @"UPDATE ""TestSchema"".""TestTable1"" SET ""TestColumn1"" = SYSDATE() WHERE 1 = 1;"
+                @"UPDATE ""TestSchema"".""TestTable1"" SET ""TestColumn1"" = CURRENT_TIMESTAMP() WHERE 1 = 1;"
             }, _quotingEnabled);
         }
 
@@ -139,7 +139,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Snowflake
             var result = expressions.Select(x => (string)Generator.Generate((dynamic)x));
             result.ShouldBe(new[] {
                 @"ALTER TABLE ""PUBLIC"".""TestTable1"" ADD COLUMN ""TestColumn1"" TIMESTAMP_NTZ;",
-                @"UPDATE ""PUBLIC"".""TestTable1"" SET ""TestColumn1"" = SYSDATE() WHERE 1 = 1;",
+                @"UPDATE ""PUBLIC"".""TestTable1"" SET ""TestColumn1"" = CURRENT_TIMESTAMP() WHERE 1 = 1;",
             }, _quotingEnabled);
         }
 

--- a/test/FluentMigrator.Tests/Unit/Generators/Snowflake/SnowflakeGeneratorTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Snowflake/SnowflakeGeneratorTests.cs
@@ -64,7 +64,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Snowflake
             var expression = new CreateColumnExpression { TableName = "TestTable1", Column = column, SchemaName = "TestSchema" };
 
             var result = Generator.Generate(expression);
-            result.ShouldBe(@"ALTER TABLE ""TestSchema"".""TestTable1"" ADD COLUMN ""TestColumn1"" VARCHAR(5) NOT NULL DEFAULT SYSDATE();", _quotingEnabled);
+            result.ShouldBe(@"ALTER TABLE ""TestSchema"".""TestTable1"" ADD COLUMN ""TestColumn1"" VARCHAR(5) NOT NULL DEFAULT CURRENT_TIMESTAMP();", _quotingEnabled);
         }
 
         [Test]
@@ -81,7 +81,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Snowflake
             expression.Columns.Add(column);
 
             var result = Generator.Generate(expression);
-            result.ShouldBe(@"CREATE TABLE ""TestSchema"".""TestTable1"" (""TestColumn1"" VARCHAR(5) NOT NULL DEFAULT SYSDATE());", _quotingEnabled);
+            result.ShouldBe(@"CREATE TABLE ""TestSchema"".""TestTable1"" (""TestColumn1"" VARCHAR(5) NOT NULL DEFAULT CURRENT_TIMESTAMP());", _quotingEnabled);
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/Snowflake/SnowflakeQuoterTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Snowflake/SnowflakeQuoterTests.cs
@@ -27,7 +27,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Snowflake
             var result = _quoterQuotingEnabled.FormatSystemMethods(SystemMethods.CurrentDateTime);
 
             // Assert
-            Assert.That(result, Is.EqualTo("SYSDATE()"));
+            Assert.That(result, Is.EqualTo("CURRENT_TIMESTAMP()"));
         }
 
         [Test]
@@ -41,13 +41,13 @@ namespace FluentMigrator.Tests.Unit.Generators.Snowflake
         }
 
         [Test]
-        public void FormatSystemMethods_CurrentUTCDateTime_ReturnsConvertTimezone()
+        public void FormatSystemMethods_CurrentUTCDateTime_ReturnsSysdate()
         {
             // Act
             var result = _quoterQuotingEnabled.FormatSystemMethods(SystemMethods.CurrentUTCDateTime);
 
             // Assert
-            Assert.That(result, Is.EqualTo("CONVERT_TIMEZONE('UTC',CURRENT_TIMESTAMP())"));
+            Assert.That(result, Is.EqualTo("SYSDATE()"));
         }
 
         [Test]
@@ -57,7 +57,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Snowflake
             var result = _quoterQuotingDisabled.FormatSystemMethods(SystemMethods.CurrentDateTime);
 
             // Assert
-            Assert.That(result, Is.EqualTo("SYSDATE()"));
+            Assert.That(result, Is.EqualTo("CURRENT_TIMESTAMP()"));
         }
 
         [Test]


### PR DESCRIPTION
- Reverts changes made in #2149, restoring mapping for SystemMethods.CurrentDateTime back to CURRENT_TIMESTAMP() 
- Map SystemMethods.CurrentUTCDateTime to SYSDATE() in the Snowflake generator. 
- Updated all related unit tests.