### PR TITLE
Check for existing Transaction when validating connection in Runner

### DIFF
--- a/src/FluentMigrator.Abstractions/IMigrationProcessor.cs
+++ b/src/FluentMigrator.Abstractions/IMigrationProcessor.cs
@@ -85,6 +85,12 @@ namespace FluentMigrator
         void RollbackTransaction();
 
         /// <summary>
+        /// Checks for active transaction
+        /// </summary>
+        /// <returns><c>true</c> when a transaction exists</returns>
+        bool HasTransaction();
+
+        /// <summary>
         /// Executes a <c>CREATE SCHEMA</c> SQL expression
         /// </summary>
         /// <param name="expression">The expression to execute</param>

--- a/src/FluentMigrator.Runner.Core/MigrationRunner.cs
+++ b/src/FluentMigrator.Runner.Core/MigrationRunner.cs
@@ -759,13 +759,13 @@ namespace FluentMigrator.Runner
                 throw new InvalidOperationException(
                     $"The caller forgot to configure an {nameof(IServiceProvider)} in the constructor of this class.");
             }
-            
+
             var connectionStringAccessor = _serviceProvider.GetRequiredService<IConnectionStringAccessor>();
             context = new MigrationContext(
                 Processor,
                 _serviceProvider,
                 connectionStringAccessor.ConnectionString);
-            
+
 
             getExpressions(migration, context);
 
@@ -935,6 +935,12 @@ namespace FluentMigrator.Runner
         {
             // Skip connection validation in preview mode as no actual database connection is needed
             if (_processorOptions.PreviewOnly)
+            {
+                return;
+            }
+
+            // Connection is fine, if we already have a transaction
+            if (Processor.HasTransaction())
             {
                 return;
             }

--- a/src/FluentMigrator.Runner.Core/Processors/ConnectionlessProcessor.cs
+++ b/src/FluentMigrator.Runner.Core/Processors/ConnectionlessProcessor.cs
@@ -159,6 +159,12 @@ namespace FluentMigrator.Runner.Processors
 
         }
 
+        /// <inheritdoc />
+        public bool HasTransaction()
+        {
+            return false;
+        }
+
         /// <summary>
         /// Executes the specified SQL statement using the connectionless processor.
         /// </summary>

--- a/src/FluentMigrator.Runner.Core/Processors/GenericProcessorBase.cs
+++ b/src/FluentMigrator.Runner.Core/Processors/GenericProcessorBase.cs
@@ -151,6 +151,12 @@ namespace FluentMigrator.Runner.Processors
         }
 
         /// <inheritdoc />
+        public override bool HasTransaction()
+        {
+            return Transaction is not null;
+        }
+
+        /// <inheritdoc />
         protected override void Dispose(bool isDisposing)
         {
             if (!isDisposing || _disposed)

--- a/src/FluentMigrator.Runner.Core/Processors/ProcessorBase.cs
+++ b/src/FluentMigrator.Runner.Core/Processors/ProcessorBase.cs
@@ -278,6 +278,9 @@ namespace FluentMigrator.Runner.Processors
         }
 
         /// <inheritdoc />
+        public abstract bool HasTransaction();
+
+        /// <inheritdoc />
         public abstract DataSet ReadTableData(string schemaName, string tableName);
 
         /// <inheritdoc />

--- a/src/FluentMigrator.Runner.Jet/Processors/Jet/JetProcessor.cs
+++ b/src/FluentMigrator.Runner.Jet/Processors/Jet/JetProcessor.cs
@@ -52,8 +52,8 @@ namespace FluentMigrator.Runner.Processors.Jet
         /// Gets the current transaction associated with the Jet database connection.
         /// </summary>
         /// <remarks>
-        /// This property provides access to the <see cref="System.Data.OleDb.OleDbTransaction"/> 
-        /// used for executing commands within a transactional context. Ensure that the connection 
+        /// This property provides access to the <see cref="System.Data.OleDb.OleDbTransaction"/>
+        /// used for executing commands within a transactional context. Ensure that the connection
         /// is open before accessing this property.
         /// </remarks>
         public OleDbTransaction Transaction => _transaction;
@@ -109,8 +109,8 @@ namespace FluentMigrator.Runner.Processors.Jet
         /// <inheritdoc />
         public override void Process(PerformDBOperationExpression expression)
         {
-            var message = string.IsNullOrEmpty(expression.Description) 
-                ? "Performing DB Operation" 
+            var message = string.IsNullOrEmpty(expression.Description)
+                ? "Performing DB Operation"
                 : $"Performing DB Operation: {expression.Description}";
             Logger.LogSay(message);
 
@@ -301,6 +301,12 @@ namespace FluentMigrator.Runner.Processors.Jet
             _transaction.Commit();
             WasCommitted = true;
             _transaction = null;
+        }
+
+        /// <inheritdoc />
+        public override bool HasTransaction()
+        {
+            return _transaction is not null;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION

## Problem

`ValidateConnection()` in `MigrationRunner.cs` wants to open and immediately close a transaction to validate the connection string.

This will force a preexisting Transaction to be rolled back, because the `BeginTransaction` will not open a new one, but the `RollbackTransaction` will roll back the existing one.

This causes the Processor later to create it's own Transaction per migration disregarding (pre-existing) transaction scopes.

## Fix

Introduce a `HasTransaction` helper method on processor, and check it on `ValidatingConenction()`.

