### PR TITLE
added separate OracleManagedGenerator and test case

### DIFF
--- a/src/FluentMigrator.Runner.Oracle/Generators/Oracle/IOracleManagedGenerator.cs
+++ b/src/FluentMigrator.Runner.Oracle/Generators/Oracle/IOracleManagedGenerator.cs
@@ -1,0 +1,27 @@
+#region License
+// Copyright (c) 2026, Fluent Migrator Project
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace FluentMigrator.Runner.Generators.Oracle;
+
+/// <summary>
+/// Defines the interface for the Oracle Managed SQL generator used in FluentMigrator.
+/// </summary>
+/// <remarks>
+/// This interface extends <see cref="IOracleGenerator"/> to provide functionality specific to Oracle Databases.
+/// </remarks>
+public interface IOracleManagedGenerator : IOracleGenerator
+{
+}

--- a/src/FluentMigrator.Runner.Oracle/Generators/Oracle/OracleManagedGenerator.cs
+++ b/src/FluentMigrator.Runner.Oracle/Generators/Oracle/OracleManagedGenerator.cs
@@ -1,0 +1,26 @@
+#region License
+// Copyright (c) 2026, Fluent Migrator Project
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace FluentMigrator.Runner.Generators.Oracle;
+
+/// <summary>
+/// The Oracle Managed SQL generator for FluentMigrator.
+/// </summary>
+public class OracleManagedGenerator : OracleGenerator, IOracleManagedGenerator
+{
+    /// <inheritdoc />
+    public override string GeneratorId => GeneratorIdConstants.OracleManaged;
+}

--- a/src/FluentMigrator.Runner.Oracle/OracleRunnerBuilderExtensions.cs
+++ b/src/FluentMigrator.Runner.Oracle/OracleRunnerBuilderExtensions.cs
@@ -58,6 +58,17 @@ namespace FluentMigrator.Runner
         }
 
         /// <summary>
+        /// Register Oracle Managed generator
+        /// </summary>
+        /// <param name="builder">The builder to add the Oracle-specific services to</param>
+        private static void RegisterOracleManagedGenerator(IMigrationRunnerBuilder builder)
+        {
+            builder.Services
+                .AddScoped<IOracleTypeMap>(sp => new OracleTypeMap())
+                .TryAddScoped<IOracleManagedGenerator, OracleManagedGenerator>();
+        }
+
+        /// <summary>
         /// Register Oracle 12c generator
         /// </summary>
         /// <param name="builder">The builder to add the Oracle-specific services to</param>
@@ -137,11 +148,11 @@ namespace FluentMigrator.Runner
         /// <returns>The migration runner builder</returns>
         public static IMigrationRunnerBuilder AddOracleManaged(this IMigrationRunnerBuilder builder)
         {
-            RegisterOracleGenerator(builder);
+            RegisterOracleManagedGenerator(builder);
 
             RegisterOracleManagedProcessor<OracleManagedProcessor>(builder);
 
-            builder.Services.AddScoped<IMigrationGenerator>(sp => sp.GetRequiredService<IOracleGenerator>());
+            builder.Services.AddScoped<IMigrationGenerator>(sp => sp.GetRequiredService<IOracleManagedGenerator>());
 
             return builder;
         }

--- a/test/FluentMigrator.Tests/Unit/Runners/DatabaseIdentifierTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Runners/DatabaseIdentifierTests.cs
@@ -73,6 +73,7 @@ namespace FluentMigrator.Tests.Unit.Runners
         [TestCase(typeof(MySql5Processor), typeof(MySql5Generator), ProcessorIdConstants.MySql5, GeneratorIdConstants.MySql5)]
         [TestCase(typeof(MySql8Processor), typeof(MySql8Generator), ProcessorIdConstants.MySql8, GeneratorIdConstants.MySql8)]
         [TestCase(typeof(OracleProcessor), typeof(IOracleGenerator), ProcessorIdConstants.Oracle, GeneratorIdConstants.Oracle)]
+        [TestCase(typeof(OracleManagedProcessor), typeof(IOracleManagedGenerator), ProcessorIdConstants.OracleManaged, GeneratorIdConstants.OracleManaged)]
         [TestCase(typeof(Oracle12CProcessor), typeof(IOracle12CGenerator), ProcessorIdConstants.Oracle12c, GeneratorIdConstants.Oracle12c)]
         [TestCase(typeof(Postgres92Processor), typeof(Postgres92Generator), ProcessorIdConstants.Postgres92, GeneratorIdConstants.Postgres92)]
         [TestCase(typeof(Postgres10_0Processor), typeof(Postgres10_0Generator), ProcessorIdConstants.PostgreSQL10_0, GeneratorIdConstants.PostgreSQL10_0)]


### PR DESCRIPTION
Issue:
FM CLI commands using **OracleManaged** processor could not find the **OracleManaged** Id
For example, a command
`dotnet fm list migrations -p OracleManaged -a "MyAssembly.dll"`
throws:
`System.InvalidOperationException: A migration generator with the ID OracleManaged couldn't be found. Available generators are: Db2, Db2ISeries, Oracle, Oracle12C, Firebird, Hana, MySql4, MySql5, MySql8, Oracle, Oracle12C, Oracle, Oracle12C, Postgres15_0, Postgres92, Postgres10_0, Postgres11_0, Postgres15_0, Redshift, Snowflake, SQLite, SqlServer2016, SqlServer2000, SqlServer2005, SqlServer2008, SqlServer2012, SqlServer2014, SqlServer2016`
Fix:
register own generator with `GeneratorIdConstants.OracleManaged` key