### PR TITLE
Enable Package Validation

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -43,6 +43,7 @@ jobs:
         versionSpec: 6.3.x
 
     - name: Execute GitVersion
+      id: gitversion
       uses: gittools/actions/gitversion/execute@v4.5.0
       env:
         BUILD_BUILDNUMBER: ${{ env.GitVersion.NuGetVersionV2 }}
@@ -130,6 +131,20 @@ jobs:
     - name: AOT Smoke Tests
       if: matrix.dotnet-tfm == 'net8.0'
       run: dotnet run --project test/FluentMigrator.Tests.Aot/FluentMigrator.Tests.Aot.csproj --configuration ${{ env.buildConfiguration }} --verbosity quiet\
+
+    # Pack triggers .NET package validation (EnablePackageValidation in PackageLibrary.props),
+    # which fails the build on breaking public-API changes against PackageValidationBaselineVersion.
+    # Windows-only because the libraries multi-target net48, which builds natively there.
+    # Version must be >= the baseline, so use the GitVersion-computed package version.
+    # Build first, then pack --no-build: the analyzer packs (and is validated) during build via
+    # GeneratePackageOnBuild, and --no-build avoids its NU5019 on a subsequent CLI pack.
+    - name: Validate package API compatibility
+      if: matrix.os == 'windows-latest' && (!cancelled())
+      shell: pwsh
+      run: |
+        dotnet build ${{ env.solution }} --configuration ${{ env.buildConfiguration }} --verbosity minimal -p:Version=${{ steps.gitversion.outputs.fullSemVer }}
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        dotnet pack ${{ env.solution }} --configuration ${{ env.buildConfiguration }} --no-build --verbosity minimal -p:Version=${{ steps.gitversion.outputs.fullSemVer }}
 
     - name: Verify test results coverage files exists
       if: matrix.os == 'ubuntu-latest' && (!cancelled())

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -142,9 +142,9 @@ jobs:
       if: matrix.os == 'windows-latest' && (!cancelled())
       shell: pwsh
       run: |
-        dotnet build ${{ env.solution }} --configuration ${{ env.buildConfiguration }} --verbosity minimal -p:Version=${{ steps.gitversion.outputs.fullSemVer }}
+        dotnet build ${{ env.solution }} --configuration ${{ env.buildConfiguration }} --verbosity minimal -p:Version=${{ steps.gitversion.outputs.majorMinorPatch }}
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-        dotnet pack ${{ env.solution }} --configuration ${{ env.buildConfiguration }} --no-build --verbosity minimal -p:Version=${{ steps.gitversion.outputs.fullSemVer }}
+        dotnet pack ${{ env.solution }} --configuration ${{ env.buildConfiguration }} --no-build --verbosity minimal -p:Version=${{ steps.gitversion.outputs.majorMinorPatch }}
 
     - name: Verify test results coverage files exists
       if: matrix.os == 'ubuntu-latest' && (!cancelled())

--- a/PackageLibrary.props
+++ b/PackageLibrary.props
@@ -9,6 +9,9 @@
     <DebugType Condition=" '$(Configuration)' == 'Release' ">portable</DebugType> <!-- Required for EmbedSources -->
     <DebugType Condition=" '$(Configuration)' == 'Debug' ">full</DebugType> <!-- Required for EmbedSources -->
     <IsPackable>true</IsPackable>
+    <!-- Validate that the public API does not introduce breaking changes against the last released version. See https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/overview -->
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>8.0.1</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/FluentMigrator.Analyzers/MigrationAttributeVersionShouldBeUniqueAnalyzer.cs
+++ b/src/FluentMigrator.Analyzers/MigrationAttributeVersionShouldBeUniqueAnalyzer.cs
@@ -94,8 +94,18 @@ namespace FluentMigrator.Analyzers
         }
 
         private static long? GetMigrationAttributeVersion(FluentMigratorContext fluentMigratorContext, IEnumerable<AttributeData> attributes)
-            => attributes
-                .FirstOrDefault(a => fluentMigratorContext.MigrationAttributeType.IsAssignableFrom(a.AttributeClass))
-                ?.ConstructorArguments[0].Value as long?;
+        {
+            var attribute = attributes
+                .FirstOrDefault(a => fluentMigratorContext.MigrationAttributeType.IsAssignableFrom(a.AttributeClass));
+
+            // ConstructorArguments can be empty when the attribute fails to bind (e.g. the compilation
+            // has errors). Guard against it so the analyzer degrades gracefully instead of throwing.
+            if (attribute is null || attribute.ConstructorArguments.Length == 0)
+            {
+                return null;
+            }
+
+            return attribute.ConstructorArguments[0].Value as long?;
+        }
     }
 }

--- a/src/FluentMigrator.Extensions.Postgres/Builder/SecurityLabel/Provider/AnonSecurityLabelBuilder.Dummy.cs
+++ b/src/FluentMigrator.Extensions.Postgres/Builder/SecurityLabel/Provider/AnonSecurityLabelBuilder.Dummy.cs
@@ -63,9 +63,18 @@ public partial class AnonSecurityLabelBuilder
     /// <summary>
     /// Masks the column with a dummy last name.
     /// </summary>
-    /// <param name="locale">Optional locale code (e.g., "en_US", "fr_FR"). If null, uses default locale.</param>
     /// <returns>The current builder instance for method chaining.</returns>
-    public AnonSecurityLabelBuilder MaskedWithDummyLastName(string locale = null)
+    public AnonSecurityLabelBuilder MaskedWithDummyLastName()
+    {
+        return MaskedWithDummyLastName(null);
+    }
+
+    /// <summary>
+    /// Masks the column with a dummy last name.
+    /// </summary>
+    /// <param name="locale">Locale code (e.g., "en_US", "fr_FR"). If null, uses default locale.</param>
+    /// <returns>The current builder instance for method chaining.</returns>
+    public AnonSecurityLabelBuilder MaskedWithDummyLastName(string locale)
     {
         return MaskedWithLocale("anon.dummy_last_name", locale);
     }

--- a/src/FluentMigrator.Extensions.Postgres/Builder/SecurityLabel/Provider/AnonSecurityLabelBuilder.Obsolete.cs
+++ b/src/FluentMigrator.Extensions.Postgres/Builder/SecurityLabel/Provider/AnonSecurityLabelBuilder.Obsolete.cs
@@ -72,12 +72,7 @@ public partial class AnonSecurityLabelBuilder
     [EditorBrowsable(EditorBrowsableState.Never)]
     public AnonSecurityLabelBuilder MaskedWithRandomInt(int min, int max)
     {
-        if (min > max)
-        {
-            throw new ArgumentException("Min value cannot be greater than max value.", nameof(min));
-        }
-        RawLabel($"MASKED WITH FUNCTION anon.random_int_between({min}, {max})");
-        return this;
+        return MaskedWithRandomIntBetween(min, max);
     }
 
     /// <summary>

--- a/src/FluentMigrator.Extensions.Postgres/Builder/SecurityLabel/Provider/AnonSecurityLabelBuilder.Obsolete.cs
+++ b/src/FluentMigrator.Extensions.Postgres/Builder/SecurityLabel/Provider/AnonSecurityLabelBuilder.Obsolete.cs
@@ -1,0 +1,106 @@
+#region License
+// Copyright (c) 2007-2024, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+using System.ComponentModel;
+
+namespace FluentMigrator.Builder.SecurityLabel.Provider;
+
+// Backwards-compatibility shims for public methods that shipped in 8.0.1 and were renamed or
+// reshaped afterwards. They are restored here with their original signatures and behavior so that
+// code compiled against 8.0.1 keeps working when the assembly is swapped without recompilation
+// (see package validation in PackageLibrary.props). Hidden from IntelliSense via EditorBrowsable.
+public partial class AnonSecurityLabelBuilder
+{
+    /// <summary>
+    /// Masks the column with a fake phone number.
+    /// </summary>
+    /// <returns>The current builder instance for method chaining.</returns>
+    [Obsolete("Use MaskedWithRandomPhone(string prefix) instead.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public AnonSecurityLabelBuilder MaskedWithFakePhone()
+    {
+        RawLabel("MASKED WITH FUNCTION anon.fake_phone()");
+        return this;
+    }
+
+    /// <summary>
+    /// Masks the column with a fake SIREN number (French business identifier).
+    /// </summary>
+    /// <returns>The current builder instance for method chaining.</returns>
+    [Obsolete("anon.fake_siren() is no longer provided by PostgreSQL Anonymizer; use MaskedWithFunction(string, params object[]) for custom functions.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public AnonSecurityLabelBuilder MaskedWithFakeSiren()
+    {
+        RawLabel("MASKED WITH FUNCTION anon.fake_siren()");
+        return this;
+    }
+
+    /// <summary>
+    /// Masks the column with a random integer.
+    /// </summary>
+    /// <returns>The current builder instance for method chaining.</returns>
+    [Obsolete("Use MaskedWithRandomIntBetween(int min, int max) instead.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public AnonSecurityLabelBuilder MaskedWithRandomInt()
+    {
+        RawLabel("MASKED WITH FUNCTION anon.random_int()");
+        return this;
+    }
+
+    /// <summary>
+    /// Masks the column with a random integer within the specified range.
+    /// </summary>
+    /// <param name="min">The minimum value (inclusive).</param>
+    /// <param name="max">The maximum value (inclusive).</param>
+    /// <returns>The current builder instance for method chaining.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="min"/> is greater than <paramref name="max"/>.</exception>
+    [Obsolete("Use MaskedWithRandomIntBetween(int min, int max) instead.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public AnonSecurityLabelBuilder MaskedWithRandomInt(int min, int max)
+    {
+        if (min > max)
+        {
+            throw new ArgumentException("Min value cannot be greater than max value.", nameof(min));
+        }
+        RawLabel($"MASKED WITH FUNCTION anon.random_int_between({min}, {max})");
+        return this;
+    }
+
+    /// <summary>
+    /// Masks the column with partial scrambling, preserving a prefix and suffix.
+    /// </summary>
+    /// <param name="prefix">The number of characters to preserve at the beginning.</param>
+    /// <param name="padding">The padding character to use for the scrambled portion.</param>
+    /// <param name="suffix">The number of characters to preserve at the end.</param>
+    /// <returns>The current builder instance for method chaining.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="prefix"/> or <paramref name="suffix"/> is negative.</exception>
+    [Obsolete("Use MaskedWithPartialScrambling(string value, int prefixLength, char paddingCharacter, int suffixLength) instead.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public AnonSecurityLabelBuilder MaskedWithPartialScrambling(int prefix, char padding, int suffix)
+    {
+        if (prefix < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(prefix), "Prefix cannot be negative.");
+        }
+        if (suffix < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(suffix), "Suffix cannot be negative.");
+        }
+        RawLabel($"MASKED WITH FUNCTION anon.partial({prefix}, '{padding}', {suffix})");
+        return this;
+    }
+}

--- a/src/FluentMigrator.Extensions.Postgres/Builder/SecurityLabel/Provider/AnonSecurityLabelBuilder.Obsolete.cs
+++ b/src/FluentMigrator.Extensions.Postgres/Builder/SecurityLabel/Provider/AnonSecurityLabelBuilder.Obsolete.cs
@@ -1,5 +1,5 @@
 #region License
-// Copyright (c) 2007-2024, Fluent Migrator Project
+// Copyright (c) 2007-2026, Fluent Migrator Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/FluentMigrator.Extensions.Postgres/Builder/SecurityLabel/Provider/AnonSecurityLabelBuilder.Pseudo.cs
+++ b/src/FluentMigrator.Extensions.Postgres/Builder/SecurityLabel/Provider/AnonSecurityLabelBuilder.Pseudo.cs
@@ -81,10 +81,21 @@ public partial class AnonSecurityLabelBuilder
     /// Masks the column with a pseudo-random email based on a seed column.
     /// </summary>
     /// <param name="seed">The column name to use as seed for reproducible generation.</param>
-    /// <param name="salt">Optional salt value to further randomize the output.</param>
     /// <returns>The current builder instance for method chaining.</returns>
     /// <exception cref="ArgumentException">Thrown when <paramref name="seed"/> is null or whitespace.</exception>
-    public AnonSecurityLabelBuilder MaskedWithPseudoEmail([NotNull] string seed, string salt = null)
+    public AnonSecurityLabelBuilder MaskedWithPseudoEmail([NotNull] string seed)
+    {
+        return MaskedWithPseudoEmail(seed, null);
+    }
+
+    /// <summary>
+    /// Masks the column with a pseudo-random email based on a seed column.
+    /// </summary>
+    /// <param name="seed">The column name to use as seed for reproducible generation.</param>
+    /// <param name="salt">Salt value to further randomize the output.</param>
+    /// <returns>The current builder instance for method chaining.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="seed"/> is null or whitespace.</exception>
+    public AnonSecurityLabelBuilder MaskedWithPseudoEmail([NotNull] string seed, string salt)
     {
         return MaskedWithSalt("anon.pseudo_email", seed, salt);
     }

--- a/src/FluentMigrator.Extensions.Postgres/Builder/SecurityLabel/Provider/AnonSecurityLabelBuilder.cs
+++ b/src/FluentMigrator.Extensions.Postgres/Builder/SecurityLabel/Provider/AnonSecurityLabelBuilder.cs
@@ -121,6 +121,17 @@ public partial class AnonSecurityLabelBuilder : SecurityLabelSyntaxBuilderBase
         return this;
     }
 
+    /// <summary>
+    /// Masks the column with a custom function call.
+    /// </summary>
+    /// <param name="functionCall">The function call expression (e.g., "anon.my_function()").</param>
+    /// <returns>The current builder instance for method chaining.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="functionCall"/> is null or whitespace.</exception>
+    public AnonSecurityLabelBuilder MaskedWithFunction(string functionCall)
+    {
+        return MaskedWithFunction(functionCall, Array.Empty<object>());
+    }
+
 
     /// <summary>
     /// Marks the column as masked without specifying a masking function.

--- a/src/FluentMigrator.Runner.Core/MaintenanceLoader.cs
+++ b/src/FluentMigrator.Runner.Core/MaintenanceLoader.cs
@@ -79,6 +79,46 @@ namespace FluentMigrator.Runner
         /// <summary>
         /// Initializes a new instance of the <see cref="MaintenanceLoader"/> class.
         /// </summary>
+        /// <param name="assemblySource">
+        /// The source of assemblies containing migration and maintenance classes.
+        /// </param>
+        /// <param name="options">
+        /// The options for configuring the migration runner.
+        /// </param>
+        /// <param name="filterOptions">
+        /// The options used to filter maintenance migrations by namespace and nested namespaces.
+        /// </param>
+        /// <param name="conventions">
+        /// The conventions used to identify and process migrations and maintenance stages.
+        /// </param>
+        /// <param name="serviceProvider">
+        /// The service provider used to resolve dependencies for migration and maintenance instances.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if any of the required parameters are <c>null</c>.
+        /// </exception>
+        [Obsolete("Use the constructor that accepts ITypeSource instead")]
+#if NET
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("This constructor uses reflection-based assembly scanning via AssemblyTypeSource. Use the constructor that accepts ITypeSource for AOT-compatible usage.")]
+#endif
+        public MaintenanceLoader(
+            [NotNull] IAssemblySource assemblySource,
+            [NotNull] IOptions<RunnerOptions> options,
+            [NotNull] IOptions<TypeFilterOptions> filterOptions,
+            [NotNull] IMigrationRunnerConventions conventions,
+            [NotNull] IServiceProvider serviceProvider)
+            : this(
+                new AssemblyTypeSource(assemblySource),
+                options,
+                filterOptions,
+                conventions,
+                serviceProvider)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MaintenanceLoader"/> class.
+        /// </summary>
         /// <param name="typeSource">
         /// The source of types containing migration and maintenance classes.
         /// </param>

--- a/src/FluentMigrator.Runner.Core/Processors/ReflectionBasedDbFactory.cs
+++ b/src/FluentMigrator.Runner.Core/Processors/ReflectionBasedDbFactory.cs
@@ -807,6 +807,26 @@ namespace FluentMigrator.Runner.Processors
             /// <param name="dbProviderFactoryTypeName">
             /// The fully qualified name of the database provider factory type.
             /// </param>
+            /// <remarks>
+            /// The factory type is resolved via reflection-based assembly loading. For AOT-compatible usage,
+            /// use the overload that accepts a <see cref="GetTypeDelegate"/>.
+            /// </remarks>
+            public TestEntry(
+                [NotNull] string assemblyName,
+                [NotNull] string dbProviderFactoryTypeName)
+                : this(assemblyName, dbProviderFactoryTypeName, null)
+            {
+            }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="ReflectionBasedDbFactory.TestEntry"/> class.
+            /// </summary>
+            /// <param name="assemblyName">
+            /// The name of the assembly containing the database provider factory type.
+            /// </param>
+            /// <param name="dbProviderFactoryTypeName">
+            /// The fully qualified name of the database provider factory type.
+            /// </param>
             /// <param name="typeFactory">
             /// An optional delegate that returns the pre-loaded <see cref="Type"/> for the database provider factory.
             /// When provided, this delegate is invoked first to resolve the factory type without relying on reflection-based assembly loading.

--- a/test/FluentMigrator.Analyzers.Tests/MigrationAttributeVersionShouldBeUniqueUnitTests.cs
+++ b/test/FluentMigrator.Analyzers.Tests/MigrationAttributeVersionShouldBeUniqueUnitTests.cs
@@ -61,6 +61,11 @@ namespace FluentMigrator.Analyzers.Tests
             };
 
             ut.TestState.AdditionalReferences.Add(typeof(IMigration).Assembly);
+#if NET
+            // The referenced FluentMigrator assembly is loaded against the modern runtime, so align the
+            // compilation reference set to match and avoid CS1705 assembly-version conflicts.
+            ut.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+#endif
 
             await ut.RunAsync();
         }
@@ -101,6 +106,11 @@ namespace FluentMigrator.Analyzers.Tests
 
             ut.TestState.ExpectedDiagnostics.AddRange(expected);
             ut.TestState.AdditionalReferences.Add(typeof(IMigration).Assembly);
+#if NET
+            // The referenced FluentMigrator assembly is loaded against the modern runtime, so align the
+            // compilation reference set to match and avoid CS1705 assembly-version conflicts.
+            ut.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+#endif
 
             await ut.RunAsync();
         }


### PR DESCRIPTION
Validates if all the API's are still present. The baseline is 8.0.0
In 8.0.1 there were some methods removed (API diff), these are restored.
And in the AOT branch there were 2 constructors removed - readded.

Fixes #2289