### PR TITLE
Handle partial assembly type load failures

### DIFF
--- a/src/FluentMigrator.Runner.Core/Initialization/AssemblyExtensions.cs
+++ b/src/FluentMigrator.Runner.Core/Initialization/AssemblyExtensions.cs
@@ -1,0 +1,41 @@
+#region License
+// Copyright (c) 2007-2024, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace FluentMigrator.Runner.Initialization
+{
+    internal static class AssemblyExtensions
+    {
+#if NET
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("This method gets the exported types from assemblies, which may not be preserved in trimmed applications.")]
+#endif
+        public static IEnumerable<Type> GetLoadableExportedTypes(this Assembly assembly)
+        {
+            try
+            {
+                return assembly.GetExportedTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                return ex.Types.Where(t => t != null);
+            }
+        }
+    }
+}

--- a/src/FluentMigrator.Runner.Core/Initialization/AssemblyExtensions.cs
+++ b/src/FluentMigrator.Runner.Core/Initialization/AssemblyExtensions.cs
@@ -34,7 +34,7 @@ namespace FluentMigrator.Runner.Initialization
             }
             catch (ReflectionTypeLoadException ex)
             {
-                return ex.Types.Where(t => t != null);
+                return ex.Types.OfType<Type>();
             }
         }
     }

--- a/src/FluentMigrator.Runner.Core/Initialization/AssemblyMigrationSourceItem.cs
+++ b/src/FluentMigrator.Runner.Core/Initialization/AssemblyMigrationSourceItem.cs
@@ -44,7 +44,7 @@ namespace FluentMigrator.Runner.Initialization
 
         /// <inheritdoc />
         public IEnumerable<Type> MigrationTypeCandidates => _assemblies
-            .SelectMany(a => a.GetExportedTypes())
+            .SelectMany(a => a.GetLoadableExportedTypes())
             .Where(t => typeof(IMigration).IsAssignableFrom(t) && !t.IsAbstract);
     }
 }

--- a/src/FluentMigrator.Runner.Core/Initialization/AssemblySourceConventionSetAccessor.cs
+++ b/src/FluentMigrator.Runner.Core/Initialization/AssemblySourceConventionSetAccessor.cs
@@ -89,7 +89,7 @@ namespace FluentMigrator.Runner.Initialization
         {
             if (assemblySource == null)
                 return Enumerable.Empty<Type>();
-            return assemblySource.Assemblies.SelectMany(a => a.GetExportedTypes())
+            return assemblySource.Assemblies.SelectMany(a => a.GetLoadableExportedTypes())
                 .Where(t => !t.IsAbstract && t.IsClass)
                 .Where(t => typeof(IConventionSet).IsAssignableFrom(t))
                 .Where(t => predicate(t));

--- a/src/FluentMigrator.Runner.Core/Initialization/AssemblySourceItem`1.cs
+++ b/src/FluentMigrator.Runner.Core/Initialization/AssemblySourceItem`1.cs
@@ -48,7 +48,7 @@ namespace FluentMigrator.Runner.Initialization
         /// <inheritdoc />
         public IEnumerable<Type> GetCandidates(Predicate<Type> predicate)
         {
-            return _assemblies.SelectMany(a => a.GetExportedTypes())
+            return _assemblies.SelectMany(a => a.GetLoadableExportedTypes())
                 .Where(t => !t.IsAbstract && t.IsClass)
                 .Where(t => typeof(T).IsAssignableFrom(t))
                 .Where(t => predicate(t));

--- a/src/FluentMigrator.Runner.Core/Initialization/AssemblySourceMigrationRunnerConventionsAccessor.cs
+++ b/src/FluentMigrator.Runner.Core/Initialization/AssemblySourceMigrationRunnerConventionsAccessor.cs
@@ -50,7 +50,7 @@ namespace FluentMigrator.Runner.Initialization
                     if (assemblySource == null)
                         return DefaultMigrationRunnerConventions.Instance;
 
-                    var matchedType = assemblySource.Assemblies.SelectMany(a => a.GetExportedTypes())
+                    var matchedType = assemblySource.Assemblies.SelectMany(a => a.GetLoadableExportedTypes())
                         .FirstOrDefault(t => typeof(IMigrationRunnerConventions).IsAssignableFrom(t));
 
                     if (matchedType != null)

--- a/src/FluentMigrator.Runner.Core/Initialization/AssemblySourceVersionTableMetaDataAccessor.cs
+++ b/src/FluentMigrator.Runner.Core/Initialization/AssemblySourceVersionTableMetaDataAccessor.cs
@@ -87,7 +87,7 @@ namespace FluentMigrator.Runner.Initialization
                 return Enumerable.Empty<Type>();
 
 #pragma warning disable IL2026 // Requires unreferenced code
-            return assemblySource.Assemblies.SelectMany(a => a.GetExportedTypes())
+            return assemblySource.Assemblies.SelectMany(a => a.GetLoadableExportedTypes())
                 .Where(t => !t.IsAbstract && t.IsClass)
                 .Where(t => typeof(IVersionTableMetaData).IsAssignableFrom(t))
                 .Where(t => predicate(t));

--- a/src/FluentMigrator.Runner.Core/Initialization/AssemblyVersionTableMetaDataSourceItem.cs
+++ b/src/FluentMigrator.Runner.Core/Initialization/AssemblyVersionTableMetaDataSourceItem.cs
@@ -48,7 +48,7 @@ namespace FluentMigrator.Runner.Initialization
         /// <inheritdoc />
         public IEnumerable<Type> GetCandidates(Predicate<Type> predicate)
         {
-            return _assemblies.SelectMany(a => a.GetExportedTypes())
+            return _assemblies.SelectMany(a => a.GetLoadableExportedTypes())
                 .Where(t => !t.IsAbstract && t.IsClass)
                 .Where(t => typeof(IVersionTableMetaData).IsAssignableFrom(t))
                 .Where(t => predicate(t));

--- a/src/FluentMigrator.Runner.Core/Initialization/TypeSource.cs
+++ b/src/FluentMigrator.Runner.Core/Initialization/TypeSource.cs
@@ -44,7 +44,7 @@ namespace FluentMigrator.Runner.Initialization
         /// <inheritdoc />
         public IEnumerable<Type> GetTypes()
         {
-            return _source.Assemblies.SelectMany(a => a.GetExportedTypes());
+            return _source.Assemblies.SelectMany(a => a.GetLoadableExportedTypes());
         }
     }
 }

--- a/test/FluentMigrator.Tests/Unit/Initialization/AssemblyTypeLoadingTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Initialization/AssemblyTypeLoadingTests.cs
@@ -1,0 +1,109 @@
+#region License
+//
+// Copyright (c) 2007-2024, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+
+using FluentMigrator.Runner;
+using FluentMigrator.Runner.Infrastructure;
+using FluentMigrator.Runner.Initialization;
+
+using NUnit.Framework;
+
+using Shouldly;
+
+namespace FluentMigrator.Tests.Unit.Initialization
+{
+    [TestFixture]
+    [Category("Initialization")]
+    public class AssemblyTypeLoadingTests
+    {
+        [Test]
+        public void AssemblyTypeSourceReturnsLoadableTypesWhenSomeExportedTypesFail()
+        {
+            var typeSource = new AssemblyTypeSource(
+                new TestAssemblySource(new PartiallyLoadableAssembly(typeof(LoadableMigration), null)));
+
+            typeSource.GetTypes().ShouldBe(new[] { typeof(LoadableMigration) });
+        }
+
+        [Test]
+        public void MigrationSourceItemReturnsLoadableMigrationCandidatesWhenSomeExportedTypesFail()
+        {
+            var sourceItem = new AssemblyMigrationSourceItem(
+                new[] { new PartiallyLoadableAssembly(typeof(LoadableMigration), null) });
+
+            sourceItem.MigrationTypeCandidates.ShouldBe(new[] { typeof(LoadableMigration) });
+        }
+
+        [Test]
+        public void MigrationRunnerConventionsAccessorFindsConventionsWhenSomeExportedTypesFail()
+        {
+            var accessor = new AssemblySourceMigrationRunnerConventionsAccessor(
+                null,
+                new TestAssemblySource(new PartiallyLoadableAssembly(typeof(CustomMigrationRunnerConventions), null)));
+
+            accessor.MigrationRunnerConventions.ShouldBeOfType<CustomMigrationRunnerConventions>();
+        }
+
+        [Migration(1)]
+        public class LoadableMigration : Migration
+        {
+            public override void Up()
+            {
+            }
+
+            public override void Down()
+            {
+            }
+        }
+
+        public class CustomMigrationRunnerConventions : MigrationRunnerConventions
+        {
+        }
+
+        private class TestAssemblySource : IAssemblySource
+        {
+            public TestAssemblySource(params Assembly[] assemblies)
+            {
+                Assemblies = assemblies;
+            }
+
+            public IReadOnlyCollection<Assembly> Assemblies { get; }
+        }
+
+        private class PartiallyLoadableAssembly : Assembly
+        {
+            private readonly Type[] _types;
+
+            public PartiallyLoadableAssembly(params Type[] types)
+            {
+                _types = types;
+            }
+
+            public override Type[] GetExportedTypes()
+            {
+                throw new ReflectionTypeLoadException(
+                    _types,
+                    new Exception[] { new FileNotFoundException("Could not load dependent assembly.") });
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2258

## Summary

This updates assembly type scanning so FluentMigrator can continue using loadable exported types when `Assembly.GetExportedTypes()` throws `ReflectionTypeLoadException`.

This can happen when a migration assembly contains public types that depend on assemblies provided by a shared framework, such as .NET 10 / `Microsoft.AspNetCore.App`, and those dependency DLLs are not copied beside the migration assembly.

## Changes

- Added `GetLoadableExportedTypes()` helper.
- Updated assembly-backed migration/convention/version metadata scanners to use loadable types from `ReflectionTypeLoadException.Types`.
- Added regression tests for:
  - `AssemblyTypeSource`
  - `AssemblyMigrationSourceItem`
  - `AssemblySourceMigrationRunnerConventionsAccessor`

## Verification

- `dotnet test test\FluentMigrator.Tests\FluentMigrator.Tests.csproj --configuration Debug --no-restore --filter "FullyQualifiedName~AssemblyTypeLoadingTests" --verbosity minimal`
  - Passed: 3
- `dotnet build src\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj --configuration Debug --no-restore --verbosity minimal`
  - Succeeded
- `dotnet test test\FluentMigrator.Tests\FluentMigrator.Tests.csproj --configuration Debug --no-restore --verbosity minimal`
  - Passed: 5157, Skipped: 909