### PR TITLE
Prevent unsafe conditional auto-reversal

### DIFF
--- a/docs-website/migration-types/auto-reversing.md
+++ b/docs-website/migration-types/auto-reversing.md
@@ -353,6 +353,7 @@ public class CustomReversalLogic : AutoReversingMigration
 2. **Don't assume auto-reversal works for custom SQL** - it only applies to fluent API operations
 3. **Don't forget to test rollback scenarios** even with auto-reversible migrations
 4. **Don't mix auto-reversal with partial custom Down() methods** without understanding the interaction
+5. **Don't use conditional DDL such as `IfNotExists()` or `IfExists()`** because FluentMigrator cannot know whether the database applied or skipped the operation
 
 ## Complex Scenarios
 

--- a/docs-website/operations/alter-tables.md
+++ b/docs-website/operations/alter-tables.md
@@ -77,7 +77,7 @@ public class RemoveColumns : Migration
 Use `IfExists()` to skip an `ALTER TABLE` statement when the target table doesn't exist. This avoids the boilerplate of manually checking `Schema.Table(...).Exists()` before altering a table, and is especially useful when a migration touches an optional or database-specific table.
 
 ```csharp
-public class AddColumnIfTableExists : Migration
+public class AddColumnIfTableExists : ForwardOnlyMigration
 {
     public override void Up()
     {
@@ -85,15 +85,12 @@ public class AddColumnIfTableExists : Migration
             .IfExists()
             .AddColumn("Total").AsDecimal(10, 2).Nullable();
     }
-
-    public override void Down()
-    {
-        Delete.Column("Total").FromTable("Products");
-    }
 }
 ```
 
 `IfExists()` applies to the columns added or altered via the same `Alter.Table(...)` call (`AddColumn`/`AlterColumn`). Support for a conditional `ALTER TABLE` varies by database provider; where a provider lacks native support, the clause is silently ignored (in `LOOSE` compatibility mode) or throws a `DatabaseOperationNotSupportedException` (in `STRICT` compatibility mode).
+
+Conditional column changes cannot be automatically reversed safely because the target table might not have existed when `Up()` ran. Use a `ForwardOnlyMigration`, or avoid `IfExists()` when the migration must support automatic reversal.
 
 
 ### Changing Column Properties

--- a/docs-website/operations/create-tables.md
+++ b/docs-website/operations/create-tables.md
@@ -244,7 +244,7 @@ Create.Table("Employees").InSchema("hr")
 ### Create Table If Not Exists
 ```csharp
 [Migration(1)]
-public class CreateProjectsTable : Migration
+public class CreateProjectsTable : ForwardOnlyMigration
 {
     public override void Up()
     {
@@ -255,15 +255,12 @@ public class CreateProjectsTable : Migration
             .WithColumn("Position").AsInt32().NotNullable()
             .WithColumn("Done").AsBoolean().NotNullable();
     }
-
-    public override void Down()
-    {
-        Delete.Table("Projects").IfExists();
-    }
 }
 ```
 
 `IfNotExists()` avoids errors when the table might already exist, removing the need for a manual `Schema.Table(...).Exists()` check before creating the table. Support for `CREATE TABLE IF NOT EXISTS` varies by database provider; where a provider lacks native support (for example Oracle, Firebird, and SQL Server), the clause is silently ignored (in `LOOSE` compatibility mode) or throws a `DatabaseOperationNotSupportedException` (in `STRICT` compatibility mode).
+
+Conditional table creation cannot be automatically reversed safely. If the table already existed, dropping it during rollback would delete an object the migration did not create. Use a `ForwardOnlyMigration`, or avoid `IfNotExists()` when the migration must support automatic reversal.
 
 ### Database-Specific Tables
 ```csharp

--- a/src/FluentMigrator.Abstractions/Expressions/CreateColumnExpression.cs
+++ b/src/FluentMigrator.Abstractions/Expressions/CreateColumnExpression.cs
@@ -64,6 +64,11 @@ namespace FluentMigrator.Expressions
         /// <inheritdoc />
         public override IMigrationExpression Reverse()
         {
+            if (IfExists)
+            {
+                return base.Reverse();
+            }
+
             return new DeleteColumnExpression
                     {
                         SchemaName = SchemaName,

--- a/src/FluentMigrator.Abstractions/Expressions/CreateTableExpression.cs
+++ b/src/FluentMigrator.Abstractions/Expressions/CreateTableExpression.cs
@@ -64,6 +64,11 @@ namespace FluentMigrator.Expressions
         /// <inheritdoc />
         public override IMigrationExpression Reverse()
         {
+            if (IfNotExists)
+            {
+                return base.Reverse();
+            }
+
             return new DeleteTableExpression
                     {
                         TableName = TableName,

--- a/test/FluentMigrator.Tests/Integration/MigrationRunnerTests.cs
+++ b/test/FluentMigrator.Tests/Integration/MigrationRunnerTests.cs
@@ -27,6 +27,7 @@ using System.Text.RegularExpressions;
 
 using FluentMigrator.Builder.SecurityLabel.Provider;
 using FluentMigrator.Expressions;
+using FluentMigrator.Infrastructure;
 using FluentMigrator.Postgres;
 using FluentMigrator.Runner;
 using FluentMigrator.Runner.Exceptions;
@@ -86,6 +87,43 @@ namespace FluentMigrator.Tests.Integration
                     processor.TableExists(null, "TestTable").ShouldBeFalse();
                 },
                 serverOptions);
+        }
+
+        [Test]
+        public void AutoReversingConditionalCreatePreservesAPreExistingTable()
+        {
+            ExecuteWithProcessor(
+                typeof(SQLiteProcessor),
+                services => services.WithMigrationsIn(RootNamespace),
+                (serviceProvider, processor) =>
+                {
+                    const long version = 999999999;
+                    const string tableName = "ConditionalProjects";
+
+                    processor.Execute($"CREATE TABLE {tableName} (Id INTEGER NOT NULL PRIMARY KEY, Value TEXT NOT NULL)");
+                    processor.Execute($"INSERT INTO {tableName} (Id, Value) VALUES (1, 'keep me')");
+
+                    var runner = (MigrationRunner)serviceProvider.GetRequiredService<IMigrationRunner>();
+                    runner.LoadVersionInfoIfRequired();
+                    var migrationInfo = new MigrationInfo(
+                        version,
+                        TransactionBehavior.Default,
+                        new TestConditionalCreateAutoReversingMigration());
+
+                    runner.ApplyMigrationUp(migrationInfo, true);
+
+                    processor.ReadTableData(null, "VersionInfo").Tables[0]
+                        .Select($"Version = {version}").Length.ShouldBe(1);
+                    processor.ReadTableData(null, tableName).Tables[0].Rows.Count.ShouldBe(1);
+
+                    Should.Throw<NotSupportedException>(() => runner.ApplyMigrationDown(migrationInfo, true));
+
+                    processor.TableExists(null, tableName).ShouldBeTrue();
+                    processor.ReadTableData(null, tableName).Tables[0].Rows.Count.ShouldBe(1);
+                    processor.ReadTableData(null, "VersionInfo").Tables[0]
+                        .Select($"Version = {version}").Length.ShouldBe(1);
+                },
+                () => IntegrationTestOptions.SQLite);
         }
 
         [Test]
@@ -2257,6 +2295,17 @@ namespace FluentMigrator.Tests.Integration
         public override void Up()
         {
             Create.UniqueConstraint("TestUnique").OnTable("TestTable2").WithSchema("TestSchema").Column("Name");
+        }
+    }
+
+    internal class TestConditionalCreateAutoReversingMigration : AutoReversingMigration
+    {
+        public override void Up()
+        {
+            Create.Table("ConditionalProjects")
+                .IfNotExists()
+                .WithColumn("Id").AsInt32().NotNullable().PrimaryKey()
+                .WithColumn("Value").AsString().NotNullable();
         }
     }
 

--- a/test/FluentMigrator.Tests/Unit/Expressions/CreateColumnExpressionTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Expressions/CreateColumnExpressionTests.cs
@@ -85,6 +85,19 @@ namespace FluentMigrator.Tests.Unit.Expressions
         }
 
         [Test]
+        public void ReverseThrowsWhenTableAlterIsConditional()
+        {
+            var expression = new CreateColumnExpression
+            {
+                TableName = "Bacon",
+                Column = { Name = "BaconId" },
+                IfExists = true
+            };
+
+            Should.Throw<System.NotSupportedException>(() => expression.Reverse());
+        }
+
+        [Test]
         public void ToStringIsDescriptive()
         {
             var expression = new CreateColumnExpression { TableName = "Bacon", Column = { Name = "BaconId", Type = DbType.Int32 } };

--- a/test/FluentMigrator.Tests/Unit/Expressions/CreateTableExpressionTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Expressions/CreateTableExpressionTests.cs
@@ -60,6 +60,18 @@ namespace FluentMigrator.Tests.Unit.Expressions
         }
 
         [Test]
+        public void ReverseThrowsWhenCreateIsConditional()
+        {
+            var expression = new CreateTableExpression
+            {
+                TableName = "table1",
+                IfNotExists = true
+            };
+
+            Should.Throw<System.NotSupportedException>(() => expression.Reverse());
+        }
+
+        [Test]
         public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsNotSetThenSchemaShouldBeNull()
         {
             var expression = new CreateTableExpression { TableName = "table1" };


### PR DESCRIPTION
## Summary

- Reject automatic reversal of conditional table creation and conditional column changes.
- Add unit and SQLite integration regression coverage that preserves pre-existing data and migration state.
- Document conditional DDL as forward-only when ownership cannot be established.

## Root cause

`CreateTableExpression.Reverse()` and `CreateColumnExpression.Reverse()` predated the conditional flags and always generated destructive reverse expressions. When the database skipped `CREATE TABLE IF NOT EXISTS` or `ALTER TABLE IF EXISTS`, rollback could still drop a pre-existing object or fail against a missing table.

Conditional expressions now delegate to the established base `Reverse()` implementation, which throws `NotSupportedException`. This requires an explicit or forward-only migration instead of silently producing an unsafe rollback.

## Verification

- Focused regression tests: 3 passed
- Release build succeeded for `net48`, `netstandard2.0`, and `net8.0`
- Full test suite: 5,157 passed, 909 skipped, 0 failed
- `git diff --check`: clean