### PR TITLE
Fix OracleManaged DI regression and broaden native Oracle client dete…

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,8 @@
   {
     "features": {
-      "ghcr.io/devcontainers/features/dotnet:2.3.0": {
-        "version": "9.0"
+      "ghcr.io/devcontainers/features/dotnet:2.5.0": {
+        "version": "9.0",
+        "dotnetRuntimeVersions": "8.0"
       }
     }
   }

--- a/src/FluentMigrator.Abstractions/CompatibilitySuppressions.xml
+++ b/src/FluentMigrator.Abstractions/CompatibilitySuppressions.xml
@@ -30,4 +30,18 @@
     <Right>lib/netstandard2.0/FluentMigrator.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:FluentMigrator.IMigrationProcessor.HasTransaction</Target>
+    <Left>lib/net48/FluentMigrator.Abstractions.dll</Left>
+    <Right>lib/net48/FluentMigrator.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:FluentMigrator.IMigrationProcessor.HasTransaction</Target>
+    <Left>lib/netstandard2.0/FluentMigrator.Abstractions.dll</Left>
+    <Right>lib/netstandard2.0/FluentMigrator.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
 </Suppressions>

--- a/src/FluentMigrator.Runner.Core/Processors/ProcessorBase.cs
+++ b/src/FluentMigrator.Runner.Core/Processors/ProcessorBase.cs
@@ -278,7 +278,7 @@ namespace FluentMigrator.Runner.Processors
         }
 
         /// <inheritdoc />
-        public abstract bool HasTransaction();
+        public virtual bool HasTransaction() => false;
 
         /// <inheritdoc />
         public abstract DataSet ReadTableData(string schemaName, string tableName);

--- a/src/FluentMigrator.Runner.Oracle/OracleRunnerBuilderExtensions.cs
+++ b/src/FluentMigrator.Runner.Oracle/OracleRunnerBuilderExtensions.cs
@@ -66,6 +66,7 @@ namespace FluentMigrator.Runner
             builder.Services
                 .AddScoped<IOracleTypeMap>(sp => new OracleTypeMap())
                 .TryAddScoped<IOracleManagedGenerator, OracleManagedGenerator>();
+            builder.Services.TryAddScoped<IOracleGenerator>(sp => sp.GetRequiredService<IOracleManagedGenerator>());
         }
 
         /// <summary>

--- a/src/FluentMigrator.Runner.Oracle/Processors/Oracle/Oracle12CManagedProcessor.cs
+++ b/src/FluentMigrator.Runner.Oracle/Processors/Oracle/Oracle12CManagedProcessor.cs
@@ -54,7 +54,7 @@ namespace FluentMigrator.Runner.Processors.Oracle
         }
 
         /// <inheritdoc />
-        public override string DatabaseType => "Oracle12cManaged";
+        public override string DatabaseType => ProcessorIdConstants.Oracle12cManaged;
 
         /// <inheritdoc />
         public override IList<string> DatabaseTypeAliases { get; } = new List<string>()

--- a/src/FluentMigrator.Runner.Postgres/Generators/Postgres/Postgres10_0Generator.cs
+++ b/src/FluentMigrator.Runner.Postgres/Generators/Postgres/Postgres10_0Generator.cs
@@ -97,6 +97,6 @@ namespace FluentMigrator.Runner.Generators.Postgres
 
         /// <inheritdoc />
         public override List<string> GeneratorIdAliases =>
-            [GeneratorIdConstants.PostgreSQL10_0, GeneratorIdConstants.PostgreSQL];
+            [GeneratorIdConstants.PostgreSQL10_0, GeneratorIdConstants.PostgreSQL, GeneratorIdConstants.Postgres];
     }
 }

--- a/src/FluentMigrator.Runner.Postgres/Generators/Postgres/Postgres11_0Generator.cs
+++ b/src/FluentMigrator.Runner.Postgres/Generators/Postgres/Postgres11_0Generator.cs
@@ -68,7 +68,7 @@ namespace FluentMigrator.Runner.Generators.Postgres
 
         /// <inheritdoc />
         public override List<string> GeneratorIdAliases =>
-            [GeneratorIdConstants.PostgreSQL11_0, GeneratorIdConstants.PostgreSQL];
+            [GeneratorIdConstants.PostgreSQL11_0, GeneratorIdConstants.PostgreSQL, GeneratorIdConstants.Postgres];
 
         /// <inheritdoc />
         protected override string GetIncludeString(CreateIndexExpression column)

--- a/src/FluentMigrator.Runner.Postgres/Generators/Postgres/Postgres15_0Generator.cs
+++ b/src/FluentMigrator.Runner.Postgres/Generators/Postgres/Postgres15_0Generator.cs
@@ -50,7 +50,7 @@ namespace FluentMigrator.Runner.Generators.Postgres
 
         /// <inheritdoc />
         public override List<string> GeneratorIdAliases =>
-            [GeneratorIdConstants.PostgreSQL15_0, GeneratorIdConstants.PostgreSQL];
+            [GeneratorIdConstants.PostgreSQL15_0, GeneratorIdConstants.PostgreSQL, GeneratorIdConstants.Postgres];
 
         /// <inheritdoc />
         protected override string GetWithNullsDistinctStringInWhere(IndexDefinition index)

--- a/src/FluentMigrator.Runner.Postgres/Processors/Postgres/Postgres10_0Processor.cs
+++ b/src/FluentMigrator.Runner.Postgres/Processors/Postgres/Postgres10_0Processor.cs
@@ -47,6 +47,6 @@ namespace FluentMigrator.Runner.Processors.Postgres
         public override string DatabaseType => ProcessorIdConstants.PostgreSQL10_0;
 
         /// <inheritdoc />
-        public override IList<string> DatabaseTypeAliases { get; } = new List<string> { ProcessorIdConstants.PostgreSQL10_0, ProcessorIdConstants.PostgreSQL };
+        public override IList<string> DatabaseTypeAliases { get; } = new List<string> { ProcessorIdConstants.PostgreSQL10_0, ProcessorIdConstants.PostgreSQL, ProcessorIdConstants.Postgres };
     }
 }

--- a/src/FluentMigrator.Runner.Postgres/Processors/Postgres/Postgres11_0Processor.cs
+++ b/src/FluentMigrator.Runner.Postgres/Processors/Postgres/Postgres11_0Processor.cs
@@ -51,7 +51,7 @@ namespace FluentMigrator.Runner.Processors.Postgres
         public override string DatabaseType => ProcessorIdConstants.PostgreSQL11_0;
 
         /// <inheritdoc />
-        public override IList<string> DatabaseTypeAliases { get; } = new List<string> { ProcessorIdConstants.PostgreSQL11_0, ProcessorIdConstants.PostgreSQL };
+        public override IList<string> DatabaseTypeAliases { get; } = new List<string> { ProcessorIdConstants.PostgreSQL11_0, ProcessorIdConstants.PostgreSQL, ProcessorIdConstants.Postgres };
 
     }
 }

--- a/src/FluentMigrator.Runner.Postgres/Processors/Postgres/Postgres15_0Processor.cs
+++ b/src/FluentMigrator.Runner.Postgres/Processors/Postgres/Postgres15_0Processor.cs
@@ -51,7 +51,7 @@ namespace FluentMigrator.Runner.Processors.Postgres
         public override string DatabaseType => ProcessorIdConstants.PostgreSQL15_0;
 
         /// <inheritdoc />
-        public override IList<string> DatabaseTypeAliases { get; } = new List<string> { ProcessorIdConstants.PostgreSQL15_0, ProcessorIdConstants.PostgreSQL };
+        public override IList<string> DatabaseTypeAliases { get; } = new List<string> { ProcessorIdConstants.PostgreSQL15_0, ProcessorIdConstants.PostgreSQL, ProcessorIdConstants.Postgres };
 
     }
 }

--- a/src/FluentMigrator/ProcessorId.cs
+++ b/src/FluentMigrator/ProcessorId.cs
@@ -21,6 +21,7 @@ namespace FluentMigrator
         public const string Oracle = nameof(Oracle);
         public const string OracleManaged = nameof(OracleManaged);
         public const string Oracle12c = nameof(Oracle12c);
+        public const string Oracle12cManaged = nameof(Oracle12cManaged);
         public const string Postgres = nameof(Postgres);
         public const string PostgreSQL = nameof(PostgreSQL);
         public const string Postgres92 = nameof(Postgres92);

--- a/test/FluentMigrator.Tests/Integration/Processors/Oracle/OracleTestUtils.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Oracle/OracleTestUtils.cs
@@ -15,6 +15,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 using FluentMigrator.Runner.Processors.Oracle;
@@ -31,9 +32,46 @@ public static class OracleTestUtils
         {
             _ = oracleProcessor.Connection;
         }
-        catch (AggregateException e) when (e.InnerException is FileNotFoundException)
+        catch (Exception e) when (IsMissingNativeClientException(e))
         {
             Assert.Ignore("Oracle Data Access Client not installed");
+        }
+    }
+
+    private static bool IsMissingNativeClientException(Exception exception)
+    {
+        foreach (var e in Flatten(exception))
+        {
+            if (e is FileNotFoundException or DllNotFoundException or BadImageFormatException or TypeLoadException)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<Exception> Flatten(Exception exception)
+    {
+        var current = exception;
+        while (current != null)
+        {
+            yield return current;
+
+            if (current is AggregateException aggregate)
+            {
+                foreach (var inner in aggregate.InnerExceptions)
+                {
+                    foreach (var flattened in Flatten(inner))
+                    {
+                        yield return flattened;
+                    }
+                }
+
+                yield break;
+            }
+
+            current = current.InnerException;
         }
     }
 }

--- a/test/FluentMigrator.Tests/Unit/Runners/DatabaseIdConstantsSelectionTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Runners/DatabaseIdConstantsSelectionTests.cs
@@ -1,0 +1,174 @@
+#region License
+//
+// Copyright (c) 2026, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using FluentMigrator.Runner;
+using FluentMigrator.Runner.Generators;
+using FluentMigrator.Runner.Processors;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using NUnit.Framework;
+
+namespace FluentMigrator.Tests.Unit.Runners
+{
+    /// <summary>
+    /// Verifies that <b>every</b> constant published in <see cref="ProcessorIdConstants"/> and
+    /// <see cref="GeneratorIdConstants"/> can actually be selected via
+    /// <c>SelectingProcessorAccessor</c> / <c>SelectingGeneratorAccessor</c> when all providers
+    /// are registered.
+    /// </summary>
+    /// <remarks>
+    /// Regression coverage for issue #2305: after #2018, no registered
+    /// <c>IMigrationProcessor</c> carried the ID <c>Postgres</c> anymore, so
+    /// <c>dotnet fm migrate -p Postgres</c> failed with
+    /// <c>ProcessorFactoryNotFoundException</c> even though
+    /// <c>ProcessorIdConstants.Postgres</c> exists and the documentation advertises it.
+    /// <para>
+    /// Unlike the hand-maintained test case lists in <see cref="DatabaseIdentifierTests"/>,
+    /// these tests enumerate the constants classes via reflection, so any constant added in the
+    /// future is covered automatically; a constant that is published but not selectable is a
+    /// bug in either the constant or the alias lists. Reflection also sidesteps the
+    /// <see cref="ObsoleteAttribute"/> on the Hana constants.
+    /// </para>
+    /// </remarks>
+    [TestFixture]
+    [Category("Runners")]
+    public class DatabaseIdConstantsSelectionTests
+    {
+        private static IEnumerable<TestCaseData> GetConstants(Type constantsClass)
+        {
+            var fields = constantsClass
+                .GetFields(BindingFlags.Public | BindingFlags.Static)
+                .Where(f => f.IsLiteral && f.FieldType == typeof(string))
+                .OrderBy(f => f.Name, StringComparer.Ordinal);
+
+            foreach (var field in fields)
+            {
+#if !NETFRAMEWORK
+                // The Jet provider is only functional on the .NET Framework; its test cases in
+                // DatabaseIdentifierTests are guarded the same way.
+                if (field.Name == "Jet")
+                {
+                    continue;
+                }
+#endif
+                var value = (string)field.GetRawConstantValue();
+                yield return new TestCaseData(value).SetArgDisplayNames($"{field.Name} (\"{value}\")");
+            }
+        }
+
+        private static IEnumerable<TestCaseData> ProcessorIdConstantValues()
+            => GetConstants(typeof(ProcessorIdConstants));
+
+        private static IEnumerable<TestCaseData> GeneratorIdConstantValues()
+            => GetConstants(typeof(GeneratorIdConstants));
+
+        [TestCaseSource(nameof(ProcessorIdConstantValues))]
+        public void EveryProcessorIdConstantIsSelectable(string processorId)
+        {
+            var serviceProvider = GetServiceProvider(processorId, generatorId: null);
+
+            var accessor = serviceProvider.GetRequiredService<IProcessorAccessor>();
+
+            Assert.That(accessor.Processor, Is.Not.Null);
+
+            var matchesId =
+                string.Equals(accessor.Processor.DatabaseType, processorId, StringComparison.OrdinalIgnoreCase)
+             || accessor.Processor.DatabaseTypeAliases.Any(
+                    alias => string.Equals(alias, processorId, StringComparison.OrdinalIgnoreCase));
+            Assert.That(
+                matchesId,
+                Is.True,
+                $"Processor {accessor.Processor.GetType().Name} was selected for ID \"{processorId}\" but neither its DatabaseType (\"{accessor.Processor.DatabaseType}\") nor its aliases match.");
+        }
+
+        [TestCaseSource(nameof(GeneratorIdConstantValues))]
+        public void EveryGeneratorIdConstantIsSelectable(string generatorId)
+        {
+            var serviceProvider = GetServiceProvider(processorId: null, generatorId);
+
+            var accessor = serviceProvider.GetRequiredService<IGeneratorAccessor>();
+
+            Assert.That(accessor.Generator, Is.Not.Null);
+
+            // Mirrors the three match strategies of SelectingGeneratorAccessor.FindGenerator:
+            // GeneratorId, GeneratorIdAliases, and the type name without the "Generator" suffix.
+            var matchesId =
+                string.Equals(accessor.Generator.GeneratorId, generatorId, StringComparison.OrdinalIgnoreCase)
+             || accessor.Generator.GeneratorIdAliases.Any(
+                    alias => string.Equals(alias, generatorId, StringComparison.OrdinalIgnoreCase))
+             || string.Equals(
+                    accessor.Generator.GetType().Name.Replace("Generator", string.Empty),
+                    generatorId,
+                    StringComparison.OrdinalIgnoreCase);
+            Assert.That(
+                matchesId,
+                Is.True,
+                $"Generator {accessor.Generator.GetType().Name} was selected for ID \"{generatorId}\" but neither its GeneratorId (\"{accessor.Generator.GeneratorId}\") nor its aliases match.");
+        }
+
+        private static IServiceProvider GetServiceProvider(string processorId, string generatorId)
+        {
+            // Keep the provider list in sync with DatabaseIdentifierTests.GetServiceProvider.
+            var serviceProvider = new ServiceCollection()
+                .AddFluentMigratorCore()
+                .ConfigureRunner(
+                    builder => builder
+                        .AddDb2()
+                        .AddDb2ISeries()
+                        .AddDotConnectOracle()
+                        .AddDotConnectOracle12C()
+                        .AddFirebird()
+                        .AddHana()
+                        .AddJet()
+                        .AddMySql()
+                        .AddMySql4()
+                        .AddMySql5()
+                        .AddMySql8()
+                        .AddOracle()
+                        .AddOracle12C()
+                        .AddOracleManaged()
+                        .AddOracle12CManaged()
+                        .AddPostgres()
+                        .AddPostgres92()
+                        .AddPostgres10_0()
+                        .AddPostgres11_0()
+                        .AddPostgres15_0()
+                        .AddRedshift()
+                        .AddSnowflake()
+                        .AddSQLite()
+                        .AddSqlServer()
+                        .AddSqlServer2000()
+                        .AddSqlServer2005()
+                        .AddSqlServer2008()
+                        .AddSqlServer2012()
+                        .AddSqlServer2014()
+                        .AddSqlServer2016()
+                )
+                .Configure<SelectingProcessorAccessorOptions>(opt => opt.ProcessorId = processorId)
+                .Configure<SelectingGeneratorAccessorOptions>(opt => opt.GeneratorId = generatorId)
+                .BuildServiceProvider();
+            return serviceProvider;
+        }
+    }
+}

--- a/test/FluentMigrator.Tests/Unit/Runners/DatabaseIdentifierTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Runners/DatabaseIdentifierTests.cs
@@ -110,6 +110,10 @@ namespace FluentMigrator.Tests.Unit.Runners
         [TestCase(typeof(MySql8Processor), typeof(MySql8Generator), ProcessorIdConstants.MySql8, GeneratorIdConstants.MySql8, ProcessorIdConstants.MySql, GeneratorIdConstants.MySql, true)]
         // PostgreSQL
         [TestCase(typeof(Postgres92Processor), typeof(Postgres92Generator), ProcessorIdConstants.Postgres92, GeneratorIdConstants.Postgres92, ProcessorIdConstants.PostgreSQL, GeneratorIdConstants.PostgreSQL, false)]
+        // PostgreSQL, generic "Postgres" alias (issue #2305: "dotnet fm migrate -p Postgres" must select the latest version)
+        [TestCase(typeof(Postgres10_0Processor), typeof(Postgres10_0Generator), ProcessorIdConstants.PostgreSQL10_0, GeneratorIdConstants.PostgreSQL10_0, ProcessorIdConstants.Postgres, GeneratorIdConstants.Postgres, false)]
+        [TestCase(typeof(Postgres11_0Processor), typeof(Postgres11_0Generator), ProcessorIdConstants.PostgreSQL11_0, GeneratorIdConstants.PostgreSQL11_0, ProcessorIdConstants.Postgres, GeneratorIdConstants.Postgres, false)]
+        [TestCase(typeof(Postgres15_0Processor), typeof(Postgres15_0Generator), ProcessorIdConstants.PostgreSQL15_0, GeneratorIdConstants.PostgreSQL15_0, ProcessorIdConstants.Postgres, GeneratorIdConstants.Postgres, true)]
         [TestCase(typeof(Postgres10_0Processor), typeof(Postgres10_0Generator), ProcessorIdConstants.PostgreSQL10_0, GeneratorIdConstants.PostgreSQL10_0, ProcessorIdConstants.PostgreSQL, GeneratorIdConstants.PostgreSQL, false)]
         [TestCase(typeof(Postgres11_0Processor), typeof(Postgres11_0Generator), ProcessorIdConstants.PostgreSQL11_0, GeneratorIdConstants.PostgreSQL11_0, ProcessorIdConstants.PostgreSQL, GeneratorIdConstants.PostgreSQL, false)]
         [TestCase(typeof(Postgres15_0Processor), typeof(Postgres15_0Generator), ProcessorIdConstants.PostgreSQL15_0, GeneratorIdConstants.PostgreSQL15_0, ProcessorIdConstants.PostgreSQL, GeneratorIdConstants.PostgreSQL, true)]

--- a/test/FluentMigrator.Tests/Unit/Runners/OracleRunnerBuilderExtensionsTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Runners/OracleRunnerBuilderExtensionsTests.cs
@@ -1,0 +1,167 @@
+#region License
+//
+// Copyright (c) 2026, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+using System;
+using System.Collections.Generic;
+
+using FluentMigrator.Runner;
+using FluentMigrator.Runner.Generators.Oracle;
+using FluentMigrator.Runner.Initialization;
+using FluentMigrator.Runner.Processors.Oracle;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using NUnit.Framework;
+
+namespace FluentMigrator.Tests.Unit.Runners
+{
+    /// <summary>
+    /// Verifies that each Oracle runner registration method produces a service collection
+    /// from which the processor can be activated <b>in isolation</b>.
+    /// </summary>
+    /// <remarks>
+    /// Regression coverage for the DI break introduced by PR #2269 and fixed by PR #2313:
+    /// <c>AddOracleManaged()</c> stopped registering <c>IOracleGenerator</c>, but
+    /// <c>OracleManagedProcessor</c>'s constructor still requires it, so every managed Oracle
+    /// integration test failed at setup with "Unable to resolve service for type
+    /// 'IOracleGenerator' while attempting to activate 'OracleManagedProcessor'".
+    /// <para>
+    /// <see cref="DatabaseIdentifierTests"/> did not catch this because it registers
+    /// <b>all</b> providers in one container: <c>AddOracle()</c> runs before
+    /// <c>AddOracleManaged()</c> and registers <c>IOracleGenerator</c> as a side effect.
+    /// These tests therefore build one container per registration method, mirroring how the
+    /// integration test fixtures (and real applications) configure a single provider.
+    /// </para>
+    /// </remarks>
+    [TestFixture]
+    [Category("Runners")]
+    public class OracleRunnerBuilderExtensionsTests
+    {
+        private static ServiceProvider CreateServiceProvider(Action<IMigrationRunnerBuilder> registerOracleServices)
+        {
+            return new ServiceCollection()
+                .AddFluentMigratorCore()
+                .ConfigureRunner(registerOracleServices)
+                // No connection is ever opened: GenericProcessorBase reads the connection
+                // string eagerly but opens the connection lazily.
+                .AddScoped<IConnectionStringReader>(
+                    _ => new PassThroughConnectionStringReader("Data Source=fake;User Id=fake;Password=fake"))
+                .BuildServiceProvider(validateScopes: true);
+        }
+
+        private static IEnumerable<TestCaseData> IsolatedRegistrationTestCases()
+        {
+            yield return new TestCaseData(
+                    (Action<IMigrationRunnerBuilder>)(r => r.AddOracle()),
+                    typeof(OracleProcessor),
+                    ProcessorIdConstants.Oracle,
+                    GeneratorIdConstants.Oracle)
+                .SetArgDisplayNames(nameof(OracleRunnerBuilderExtensions.AddOracle));
+
+            yield return new TestCaseData(
+                    (Action<IMigrationRunnerBuilder>)(r => r.AddOracleManaged()),
+                    typeof(OracleManagedProcessor),
+                    ProcessorIdConstants.OracleManaged,
+                    GeneratorIdConstants.OracleManaged)
+                .SetArgDisplayNames(nameof(OracleRunnerBuilderExtensions.AddOracleManaged));
+
+            yield return new TestCaseData(
+                    (Action<IMigrationRunnerBuilder>)(r => r.AddOracle12C()),
+                    typeof(Oracle12CProcessor),
+                    ProcessorIdConstants.Oracle12c,
+                    GeneratorIdConstants.Oracle12c)
+                .SetArgDisplayNames(nameof(OracleRunnerBuilderExtensions.AddOracle12C));
+
+            yield return new TestCaseData(
+                    (Action<IMigrationRunnerBuilder>)(r => r.AddOracle12CManaged()),
+                    typeof(Oracle12CManagedProcessor),
+                    ProcessorIdConstants.Oracle12cManaged,
+                    GeneratorIdConstants.Oracle12c)
+                .SetArgDisplayNames(nameof(OracleRunnerBuilderExtensions.AddOracle12CManaged));
+        }
+
+        [TestCaseSource(nameof(IsolatedRegistrationTestCases))]
+        public void IsolatedRegistrationResolvesProcessorAndGenerator(
+            Action<IMigrationRunnerBuilder> registerOracleServices,
+            Type expectedProcessorType,
+            string expectedDatabaseType,
+            string expectedGeneratorId)
+        {
+            using (var serviceProvider = CreateServiceProvider(registerOracleServices))
+            using (var scope = serviceProvider.CreateScope())
+            {
+                // Mirrors OracleProcessorTestsBase.SetUp()
+                var processor = scope.ServiceProvider.GetRequiredService<OracleProcessorBase>();
+                var migrationProcessor = scope.ServiceProvider.GetRequiredService<IMigrationProcessor>();
+                var generator = scope.ServiceProvider.GetRequiredService<IMigrationGenerator>();
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(processor, Is.TypeOf(expectedProcessorType));
+                    Assert.That(migrationProcessor, Is.SameAs(processor));
+                    Assert.That(processor.DatabaseType, Is.EqualTo(expectedDatabaseType));
+                    Assert.That(generator.GeneratorId, Is.EqualTo(expectedGeneratorId));
+                });
+            }
+        }
+
+        [Test]
+        public void AddOracleManagedMapsOracleGeneratorOntoManagedGenerator()
+        {
+            // PR #2313: IOracleGenerator must resolve on the managed path (the processor's
+            // constructor requires it) and must be the same instance as IOracleManagedGenerator
+            // so the processor and the runner use one generator with GeneratorId "OracleManaged".
+            using (var serviceProvider = CreateServiceProvider(r => r.AddOracleManaged()))
+            using (var scope = serviceProvider.CreateScope())
+            {
+                var oracleGenerator = scope.ServiceProvider.GetRequiredService<IOracleGenerator>();
+                var managedGenerator = scope.ServiceProvider.GetRequiredService<IOracleManagedGenerator>();
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(oracleGenerator, Is.SameAs(managedGenerator));
+                    Assert.That(oracleGenerator.GeneratorId, Is.EqualTo(GeneratorIdConstants.OracleManaged));
+                });
+            }
+        }
+
+        [Test]
+        public void OracleAndOracleManagedResolveWhenRegisteredTogether([Values] bool oracleFirst)
+        {
+            // IOracleGenerator uses TryAdd semantics, so registration order determines which
+            // implementation backs it when both providers are registered. Both processors must
+            // remain activatable in either order.
+            Action<IMigrationRunnerBuilder> register = oracleFirst
+                ? r => r.AddOracle().AddOracleManaged()
+                : r => r.AddOracleManaged().AddOracle();
+
+            using (var serviceProvider = CreateServiceProvider(register))
+            using (var scope = serviceProvider.CreateScope())
+            {
+                var oracleProcessor = scope.ServiceProvider.GetRequiredService<OracleProcessor>();
+                var oracleManagedProcessor = scope.ServiceProvider.GetRequiredService<OracleManagedProcessor>();
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(oracleProcessor.DatabaseType, Is.EqualTo(ProcessorIdConstants.Oracle));
+                    Assert.That(oracleManagedProcessor.DatabaseType, Is.EqualTo(ProcessorIdConstants.OracleManaged));
+                });
+            }
+        }
+    }
+}


### PR DESCRIPTION
…ction

PR #2269 changed AddOracleManaged to register only IOracleManagedGenerator, but OracleManagedProcessor's constructor still requires IOracleGenerator. Because the managed path no longer registers IOracleGenerator, the DI container cannot construct OracleManagedProcessor and every managed Oracle integration test fails at setup with "Unable to resolve service for type 'IOracleGenerator' while attempting to activate 'OracleManagedProcessor'".

- OracleRunnerBuilderExtensions: register IOracleGenerator as a mapping onto IOracleManagedGenerator (which already derives from IOracleGenerator) so the processor's constructor dependency resolves. Preserves the OracleManaged GeneratorId introduced by #2269.
- OracleTestUtils: broaden CheckNativeOracleDataAccess to flatten the full exception chain and match FileNotFoundException/DllNotFoundException/ BadImageFormatException/TypeLoadException, so the "client not installed" skip works on Linux CI. This was previously masked by the DI failure.


Claude-Session: https://claude.ai/code/session_01MbUUrNE8tnVG2wjPyGAQdc