### PR TITLE
fix: restore Postgres provider alias

### DIFF
--- a/src/FluentMigrator.Runner.Postgres/Generators/Postgres/Postgres15_0Generator.cs
+++ b/src/FluentMigrator.Runner.Postgres/Generators/Postgres/Postgres15_0Generator.cs
@@ -50,7 +50,7 @@ namespace FluentMigrator.Runner.Generators.Postgres
 
         /// <inheritdoc />
         public override List<string> GeneratorIdAliases =>
-            [GeneratorIdConstants.PostgreSQL15_0, GeneratorIdConstants.PostgreSQL];
+            [GeneratorIdConstants.PostgreSQL15_0, GeneratorIdConstants.PostgreSQL, GeneratorIdConstants.Postgres];
 
         /// <inheritdoc />
         protected override string GetWithNullsDistinctStringInWhere(IndexDefinition index)

--- a/src/FluentMigrator.Runner.Postgres/Processors/Postgres/Postgres15_0Processor.cs
+++ b/src/FluentMigrator.Runner.Postgres/Processors/Postgres/Postgres15_0Processor.cs
@@ -51,7 +51,7 @@ namespace FluentMigrator.Runner.Processors.Postgres
         public override string DatabaseType => ProcessorIdConstants.PostgreSQL15_0;
 
         /// <inheritdoc />
-        public override IList<string> DatabaseTypeAliases { get; } = new List<string> { ProcessorIdConstants.PostgreSQL15_0, ProcessorIdConstants.PostgreSQL };
+        public override IList<string> DatabaseTypeAliases { get; } = new List<string> { ProcessorIdConstants.PostgreSQL15_0, ProcessorIdConstants.PostgreSQL, ProcessorIdConstants.Postgres };
 
     }
 }

--- a/test/FluentMigrator.Tests/Unit/Runners/DatabaseIdentifierTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Runners/DatabaseIdentifierTests.cs
@@ -113,6 +113,7 @@ namespace FluentMigrator.Tests.Unit.Runners
         [TestCase(typeof(Postgres10_0Processor), typeof(Postgres10_0Generator), ProcessorIdConstants.PostgreSQL10_0, GeneratorIdConstants.PostgreSQL10_0, ProcessorIdConstants.PostgreSQL, GeneratorIdConstants.PostgreSQL, false)]
         [TestCase(typeof(Postgres11_0Processor), typeof(Postgres11_0Generator), ProcessorIdConstants.PostgreSQL11_0, GeneratorIdConstants.PostgreSQL11_0, ProcessorIdConstants.PostgreSQL, GeneratorIdConstants.PostgreSQL, false)]
         [TestCase(typeof(Postgres15_0Processor), typeof(Postgres15_0Generator), ProcessorIdConstants.PostgreSQL15_0, GeneratorIdConstants.PostgreSQL15_0, ProcessorIdConstants.PostgreSQL, GeneratorIdConstants.PostgreSQL, true)]
+        [TestCase(typeof(Postgres15_0Processor), typeof(Postgres15_0Generator), ProcessorIdConstants.PostgreSQL15_0, GeneratorIdConstants.PostgreSQL15_0, ProcessorIdConstants.Postgres, GeneratorIdConstants.Postgres, true)]
         // SQL Server
         [TestCase(typeof(SqlServer2000Processor), typeof(SqlServer2000Generator), ProcessorIdConstants.SqlServer2000, GeneratorIdConstants.SqlServer2000, ProcessorIdConstants.SqlServer, GeneratorIdConstants.SqlServer,  false)]
         [TestCase(typeof(SqlServer2005Processor), typeof(SqlServer2005Generator), ProcessorIdConstants.SqlServer2005, GeneratorIdConstants.SqlServer2005, ProcessorIdConstants.SqlServer, GeneratorIdConstants.SqlServer, false)]


### PR DESCRIPTION
## Summary

- restore `Postgres` as an alias for the latest PostgreSQL processor and generator
- add a regression case that resolves both accessors through the generic alias

Fixes #2305

## Validation

- `dotnet test test/FluentMigrator.Tests/FluentMigrator.Tests.csproj --framework net8.0 --configuration Release --no-restore --filter 'FullyQualifiedName~DatabaseIdentifierTests.EnsureAliasMatchesLatestVersion' --verbosity minimal -m:1 -p:BuildInParallel=false` (13 passed)
- `dotnet test test/FluentMigrator.Tests/FluentMigrator.Tests.csproj --framework net8.0 --configuration Release --no-build --verbosity minimal` (5,141 passed, 977 skipped)
- `git diff --check origin/main...HEAD`

I did not run the Windows/net48 or container-backed integration paths locally; CI covers those environments.
