### PR TITLE
Move FluentMigrator.Analyzers.Tests to NUnit 4 and drop the NUnit VersionOverride

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -101,7 +101,7 @@
     <PackageVersion Include="NUnit" Version="4.3.2" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.9.2" />
     <PackageVersion Include="NUnit.Console" Version="3.20.1" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="5.2.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="Testcontainers" Version="4.6.0" />
     <PackageVersion Include="Testcontainers.Db2" Version="4.6.0" />

--- a/test/FluentMigrator.Analyzers.Tests/FluentMigrator.Analyzers.Tests.csproj
+++ b/test/FluentMigrator.Analyzers.Tests/FluentMigrator.Analyzers.Tests.csproj
@@ -26,13 +26,10 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <!--
-      TODO: this project is still on NUnit 3 while FluentMigrator.Tests is on NUnit 4. Migrating it
-      means rewriting the classic asserts that NUnit 4 removed, so the two versions are pinned apart
-      here until that happens. Drop these overrides once this project moves to NUnit 4.
-    -->
-    <PackageReference Include="NUnit" VersionOverride="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" VersionOverride="5.2.0" />
+    <PackageReference Include="NUnit" />
+    <!-- Guards against classic asserts (NUnit2xxx) creeping back in; see FluentMigrator.Tests. -->
+    <PackageReference Include="NUnit.Analyzers" />
+    <PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #2328

## The premise turned out to be wrong, in a good way

The TODO I left in #2326 said this migration meant rewriting the classic asserts NUnit 4 removed. It doesn't — **there are none**. I surveyed the whole test tree:

| Check | Count |
| --- | --- |
| `NUnit.Framework.Legacy` usings | 0 |
| `ClassicAssert.*` calls | 0 |
| Bare classic `Assert.AreEqual` / `IsTrue` / `IsNull` / `AreSame` / … | 0 |
| `StringAssert` / `CollectionAssert` / `FileAssert` / `DirectoryAssert` | 0 |

Everything is already on the constraint model:

```
728 Assert.That        134 Assert.Throws        77 Assert.Multiple
 15 Assert.Ignore        8 Assert.EnterMultipleScope   <- NUnit 4.2+ API
  8 Assert.DoesNotThrow  6 Assert.Fail            1 Assert.DoesNotThrowAsync
```

`FluentMigrator.Tests` gets there via Shouldly (`.ShouldBe(...)`), and `FluentMigrator.Analyzers.Tests` touches exactly one NUnit API: `[Test]`. Its 3.12.0 pin was historical drift, not a real constraint.

So removing the overrides *is* the migration.

## Changes

- `NUnit` and `NUnit3TestAdapter` in `FluentMigrator.Analyzers.Tests` now come from `Directory.Packages.props`, putting the project on NUnit 4.3.2 alongside `FluentMigrator.Tests`. Both `VersionOverride` attributes and the TODO are gone.
- Central `NUnit3TestAdapter` moves **5.0.0 → 5.2.0** — the higher of the two versions that were previously pinned apart — so neither test project regresses. (`FluentMigrator.Analyzers.Tests` was on 5.2.0; `FluentMigrator.Tests` on 5.0.0.)
- Added `NUnit.Analyzers` to `FluentMigrator.Analyzers.Tests`. `FluentMigrator.Tests` already had it; the NUnit2xxx rules are exactly what stops classic asserts from coming back. It reports nothing today — the project builds with **0 warnings**.

The `VersionOverride` entries left in `FluentMigrator.Tests` / `FluentMigrator.Tests.Aot` are unrelated to NUnit (`Microsoft.Data.Sqlite`, `Microsoft.Extensions.Logging*` overriding the shipped `[8.0.0,)` floors) and stay.

## Verification

- `dotnet test test/FluentMigrator.Analyzers.Tests` — **11/11 passed** under `net48` on NUnit 4.
- `dotnet build FluentMigrator.sln -t:Rebuild` — 0 errors on the bumped adapter.
- `dotnet build test/FluentMigrator.Analyzers.Tests -t:Rebuild` — 0 warnings, 0 errors with `NUnit.Analyzers` active.

## Separate issue spotted (not fixed here)

`#2326` introduced a **NU1507** warning on every restore:

> There are 2 package sources defined in your configuration. When using central package management, please map your package sources with package source mapping … The following sources are defined: NuGet Feed, fluentmigrator

Central Package Management turns the multi-source `nuget.config` into a warning. I confirmed the Azure Artifacts feed hosts only `FluentMigrator.*` packages, so the mapping is unambiguous, but it is out of scope for this PR — happy to send it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
