### PR TITLE
Map NuGet package sources to silence NU1507 and close the confusion gap

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -6,4 +6,28 @@
         <add key="NuGet Feed" value="https://api.nuget.org/v3/index.json" />
         <add key="fluentmigrator" value="https://pkgs.dev.azure.com/fluentmigrator/fluentmigrator/_packaging/fluentmigrator/nuget/v3/index.json" />
     </packageSources>
+    <!--
+        Central Package Management warns (NU1507) when more than one source is configured without a
+        mapping, because "search every feed for every package" is how dependency-confusion attacks
+        land: anyone who can publish to the Azure Artifacts feed could shadow a package we expect
+        from nuget.org.
+
+        The Azure Artifacts feed only ever hosts our own CI-built FluentMigrator* packages, so the
+        mapping below says exactly that. FluentMigrator* keeps resolving from both feeds - the
+        longest matching pattern wins, and both sources declare it - which preserves today's
+        behaviour for the samples that consume released FluentMigrator packages. Everything else
+        matches only the "*" pattern on nuget.org and can no longer be served by the private feed.
+
+        Adding a package from a new source means adding a pattern here too, or restore will not
+        find it. See https://learn.microsoft.com/nuget/consume-packages/package-source-mapping
+    -->
+    <packageSourceMapping>
+        <packageSource key="NuGet Feed">
+            <package pattern="*" />
+            <package pattern="FluentMigrator*" />
+        </packageSource>
+        <packageSource key="fluentmigrator">
+            <package pattern="FluentMigrator*" />
+        </packageSource>
+    </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
Follow-up to #2326.

## Problem

Central Package Management made NuGet start warning **NU1507** on every restore:

> There are 2 package sources defined in your configuration. When using central package management, please map your package sources with package source mapping … The following sources are defined: NuGet Feed, fluentmigrator

The warning is well-founded rather than noise. Without a mapping, NuGet searches *every* configured feed for *every* package. That is the shape dependency-confusion attacks exploit: anyone able to publish to the Azure Artifacts feed could shadow a package we expect to come from nuget.org, and restore would happily take it.

## Fix

I checked what the Azure Artifacts feed actually serves. Its search endpoint returns only our own CI-built packages — `FluentMigrator`, `FluentMigrator.Abstractions`, `FluentMigrator.Runner.*`, `FluentMigrator.Extensions.*`, `FluentMigrator.MSBuild`, `FluentMigrator.Tools`, and so on. Nothing third-party. So the mapping writes down exactly that:

```xml
<packageSourceMapping>
    <packageSource key="NuGet Feed">
        <package pattern="*" />
        <package pattern="FluentMigrator*" />
    </packageSource>
    <packageSource key="fluentmigrator">
        <package pattern="FluentMigrator*" />
    </packageSource>
</packageSourceMapping>
```

Two things follow from this:

- **`FluentMigrator*` still resolves from both feeds.** NuGet picks the longest matching pattern, and both sources declare `FluentMigrator*`, so both stay eligible. This preserves today's behaviour for the samples that consume released FluentMigrator packages (`FluentMigrator.MSBuild 7.1.0`) and for anyone restoring a CI prerelease.
- **Everything else is locked to nuget.org.** `Npgsql`, `Testcontainers.*`, `Oracle.*` and friends match only the `*` pattern, which only "NuGet Feed" declares. The private feed can no longer serve them. That is the actual security win, and it costs nothing because the private feed never had them.

I deliberately did *not* use the stricter form (`FluentMigrator*` on the Azure feed only). It reads cleaner, but it makes restore depend on every FluentMigrator package version we consume being present on the private feed — a footgun for a sample that pins a public release.

The `nuget.config` comment explains the reasoning and notes the one maintenance obligation this creates: a package from a genuinely new source needs a pattern here, or restore will not find it.

## Verification

- `dotnet restore FluentMigrator.sln --force` — **NU1507 is gone**, exit 0.
- `dotnet restore FluentMigrator.sln --packages <empty-dir> --no-cache` — restores from an empty package folder with the HTTP cache bypassed, so every package is resolved through the mapping against the live feeds rather than served from `~/.nuget/packages`. Exit 0, no NU1101/NU1102 (package-not-found), and `FluentMigrator.MSBuild 7.1.0` downloads as expected.

The only warnings left on restore are the pre-existing `log4net 2.0.12` (moderate, via `Snowflake.Data`) and `SQLitePCLRaw.lib.e_sqlite3 2.1.11` (high) advisories, unchanged from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
