### PR TITLE
Fix RawSql script token replacement

### DIFF
--- a/src/FluentMigrator.Abstractions/SqlScriptTokenReplacer.cs
+++ b/src/FluentMigrator.Abstractions/SqlScriptTokenReplacer.cs
@@ -127,6 +127,7 @@ namespace FluentMigrator
             return value switch
             {
                 null => null,
+                RawSql rawSql => rawSql.Value,
                 IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
                 _ => value.ToString(),
             };

--- a/test/FluentMigrator.Tests/Unit/SqlScriptTokenReplacerTests.cs
+++ b/test/FluentMigrator.Tests/Unit/SqlScriptTokenReplacerTests.cs
@@ -75,6 +75,18 @@ namespace FluentMigrator.Tests.Unit
         }
 
         [Test]
+        public void ReplacesRawTokenWithRawSqlValue()
+        {
+            var parameters = new Dictionary<string, object>
+            {
+                ["CurrentTimestamp"] = RawSql.Insert("CURRENT_TIMESTAMP")
+            };
+
+            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT $(CurrentTimestamp)", parameters)
+                .ShouldBe("SELECT CURRENT_TIMESTAMP");
+        }
+
+        [Test]
         public void LeavesUnknownRawTokenUnchanged()
         {
             var parameters = new Dictionary<string, object> { ["Known"] = "Value" };


### PR DESCRIPTION
Closes #2332.

## Summary

- Render `RawSql` parameter values through `RawSql.Value` for raw `$(name)` script tokens.
- Add a regression test covering a typed parameter map with `RawSql.Insert("CURRENT_TIMESTAMP")`.

## Validation

- `dotnet test test/FluentMigrator.Tests/FluentMigrator.Tests.csproj --configuration Debug --no-restore --filter "FullyQualifiedName~SqlScriptTokenReplacerTests" --verbosity minimal`
- `dotnet test test/FluentMigrator.Tests/FluentMigrator.Tests.csproj --configuration Debug --no-restore --verbosity minimal`