### PR TITLE
Add token substitution path coverage; fix RawSql escaping on MySQL and the $[name] no-quoter fallback

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -63,3 +63,15 @@
 #*.RTF   diff=astextplain
 
 *.sh	eol=lf
+
+###############################################################################
+# Verify snapshot files.
+#
+# Verify refuses to read a *.verified.* file containing CR, and the `* text=auto`
+# rule above would otherwise hand it CRLF on a Windows checkout. Without this the
+# snapshot tests pass on a LF working tree and fail on Windows CI.
+# See https://github.com/verifytests/verify#text-file-settings
+###############################################################################
+*.verified.md   text eol=lf working-tree-encoding=UTF-8
+*.verified.txt  text eol=lf working-tree-encoding=UTF-8
+*.verified.json text eol=lf working-tree-encoding=UTF-8

--- a/.gitignore
+++ b/.gitignore
@@ -281,3 +281,6 @@ launchSettings.json
 /**/DROP/
 /**/TEMP/
 _site
+
+# Verify snapshot output from a failing run
+*.received.*

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -112,7 +112,7 @@
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="NUnit" Version="4.3.2" />
+    <PackageVersion Include="NUnit" Version="4.6.1" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.9.2" />
     <PackageVersion Include="NUnit.Console" Version="3.20.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="5.2.0" />
@@ -125,6 +125,7 @@
     <PackageVersion Include="Testcontainers.Oracle" Version="4.6.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.6.0" />
     <PackageVersion Include="TUnit" Version="1.18.21" />
+    <PackageVersion Include="Verify.NUnit" Version="31.27.0" />
   </ItemGroup>
 
   <ItemGroup Label="Samples - consumed as a real NuGet package on purpose">

--- a/src/FluentMigrator.Abstractions/SqlScriptTokenReplacer.cs
+++ b/src/FluentMigrator.Abstractions/SqlScriptTokenReplacer.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Text;
 using System.Text.RegularExpressions;
 
 using FluentMigrator.Generation;
@@ -54,16 +55,26 @@ namespace FluentMigrator
         /// <item>
         /// <description>
         /// <c>$[name]</c> is replaced with the parameter value rendered as a safely quoted SQL literal
-        /// using <paramref name="quoter"/> (falling back to a quoted/escaped string literal when no
-        /// <paramref name="quoter"/> is supplied). Use this style whenever a value should be treated as
+        /// using <paramref name="quoter"/>. Use this style whenever a value should be treated as
         /// data instead of raw SQL. Any value type supported by <see cref="IQuoter.QuoteValue"/> can be
         /// used, e.g. <see cref="string"/>, numbers, <see cref="System.DateTime"/>, <see cref="bool"/>,
-        /// <see cref="System.Guid"/>, or <see langword="null"/>.
+        /// <see cref="System.Guid"/>, or <see langword="null"/>. When no <paramref name="quoter"/> is
+        /// supplied, an invariant-culture rendering equivalent to the default
+        /// <c>GenericQuoter.QuoteValue</c> is used.
         /// </description>
         /// </item>
         /// </list>
+        /// <para>
+        /// <strong><see cref="RawSql"/> is exempt from quoting in both styles.</strong> It is an
+        /// explicit opt-in escape hatch, so a <see cref="RawSql"/> value is emitted verbatim even via
+        /// <c>$[name]</c>. That token style is therefore not an injection-safety boundary when the
+        /// value is a <see cref="RawSql"/> - the caller has already accepted responsibility for the
+        /// SQL. It is a safety boundary for every other value type.
+        /// </para>
+        /// <para>
         /// The literal text <c>$(name)</c> or <c>$[name]</c> can be produced (without substitution) by
         /// escaping it as <c>$$((name))</c> or <c>$$[[name]]</c> respectively.
+        /// </para>
         /// </remarks>
         public static string ReplaceSqlScriptTokens([StringSyntax("sql")] string sqlText, IDictionary<string, object> parameters, IQuoter quoter = null)
         {
@@ -88,7 +99,7 @@ namespace FluentMigrator
                             object value = keyValue;
                             return quoter != null
                                 ? quoter.QuoteValue(value)
-                                : QuoteSqlStringLiteral(value?.ToString());
+                                : QuoteSqlLiteral(value);
                         }
 
                         // Return the whole match value when the key
@@ -161,21 +172,120 @@ namespace FluentMigrator
         }
 
         /// <summary>
-        /// Renders a value as a safely quoted/escaped SQL string literal.
+        /// Renders a value as a SQL literal when no <see cref="IQuoter"/> was supplied.
+        /// </summary>
+        /// <param name="value">The value to render</param>
+        /// <returns>The value as a SQL literal</returns>
+        /// <exception cref="NotSupportedException">
+        /// <paramref name="value"/> is a <see cref="SystemMethods"/>, which has no dialect-independent
+        /// rendering.
+        /// </exception>
+        /// <remarks>
+        /// <para>
+        /// Deliberately mirrors the default rendering of <c>GenericQuoter.QuoteValue</c>, which lives
+        /// in <c>FluentMigrator.Runner.Core</c> and so cannot be referenced from this assembly. The
+        /// two must agree: a token expanded without a quoter and the same value written by
+        /// <c>Insert</c>/<c>Update</c>/<c>Delete</c> should produce the same literal. That agreement
+        /// is asserted by <c>TokenSubstitutionMatrixTests</c>.
+        /// </para>
+        /// <para>
+        /// Culture handling, precisely: numbers, <see cref="DateTime"/> and <see cref="DateTimeOffset"/>
+        /// are formatted with <see cref="CultureInfo.InvariantCulture"/>, as is any other
+        /// <see cref="IFormattable"/>. Enums render by name, which is culture-independent. Anything
+        /// else falls back to <see cref="object.ToString"/> and therefore renders however that type
+        /// chooses - <c>GenericQuoter.QuoteValue</c> has the same fallback. Before this, *every* value
+        /// was stringified with the ambient culture, so a German build agent emitted <c>'1234,5678'</c>
+        /// for a <see cref="double"/>.
+        /// </para>
+        /// </remarks>
+        private static string QuoteSqlLiteral(object value)
+        {
+            switch (value)
+            {
+                case null:
+                case DBNull _:
+                    return "NULL";
+
+                // An explicit opt-in escape hatch: the caller owns this SQL, so it must not be
+                // quoted, escaped or otherwise altered.
+                case RawSql rawSql:
+                    return rawSql.Value;
+
+                // Matched ahead of Enum, which would otherwise render it as the string literal
+                // 'CurrentDateTime' - valid SQL syntax that silently means the wrong thing. There is
+                // no dialect-independent rendering for these: CURRENT_TIMESTAMP, GETDATE(), SYSDATE
+                // and NOW() are all spelled differently, which is why GenericQuoter delegates to
+                // FormatSystemMethods and throws by default. Failing here says "supply an IQuoter"
+                // instead of emitting a string that looks like it worked.
+                case SystemMethods systemMethod:
+                    throw new NotSupportedException(
+                        $"The system method {systemMethod} cannot be rendered without an IQuoter, because its SQL " +
+                        "spelling is dialect-specific. Pass the processor's IQuoter to ReplaceSqlScriptTokens, " +
+                        "or substitute an explicit RawSql value.");
+
+                case bool b:
+                    return b ? "1" : "0";
+
+                case byte[] bytes:
+                    return FormatByteArray(bytes);
+
+                case DateTime dateTime:
+                    return QuoteString(dateTime.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture));
+
+                case DateTimeOffset dateTimeOffset:
+                    return QuoteString(dateTimeOffset.ToString("yyyy-MM-ddTHH:mm:sszzz", CultureInfo.InvariantCulture));
+
+                // Numeric literals are emitted unquoted so they keep their SQL type. Enum is
+                // deliberately matched before the integral types, since it renders as a string.
+                case Enum _:
+                    return QuoteString(value.ToString());
+
+                case sbyte _:
+                case byte _:
+                case short _:
+                case ushort _:
+                case int _:
+                case uint _:
+                case long _:
+                case ulong _:
+                case float _:
+                case double _:
+                case decimal _:
+                    return ((IFormattable)value).ToString(null, CultureInfo.InvariantCulture);
+
+                case IFormattable formattable:
+                    return QuoteString(formattable.ToString(null, CultureInfo.InvariantCulture));
+
+                default:
+                    return QuoteString(value.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Wraps a value in single quotes, escaping embedded single quotes by doubling them.
         /// </summary>
         /// <param name="value">The value to quote</param>
-        /// <returns>
-        /// <c>NULL</c> when <paramref name="value"/> is <see langword="null"/>, otherwise the value
-        /// wrapped in single quotes with any embedded single quotes escaped by doubling them.
-        /// </returns>
-        private static string QuoteSqlStringLiteral(string value)
+        /// <returns>The quoted value</returns>
+        private static string QuoteString(string value)
         {
-            if (value is null)
+            return "'" + value.Replace("'", "''") + "'";
+        }
+
+        /// <summary>
+        /// Renders a byte array as a hexadecimal SQL literal, matching <c>GenericQuoter</c>.
+        /// </summary>
+        /// <param name="value">The bytes to render</param>
+        /// <returns>The hexadecimal literal</returns>
+        private static string FormatByteArray(byte[] value)
+        {
+            var hex = new StringBuilder((value.Length * 2) + 2);
+            hex.Append("0x");
+            foreach (var b in value)
             {
-                return "NULL";
+                hex.AppendFormat(CultureInfo.InvariantCulture, "{0:x2}", b);
             }
 
-            return "'" + value.Replace("'", "''") + "'";
+            return hex.ToString();
         }
     }
 }

--- a/src/FluentMigrator.Runner.MySql/Generators/MySql/MySqlQuoter.cs
+++ b/src/FluentMigrator.Runner.MySql/Generators/MySql/MySqlQuoter.cs
@@ -30,8 +30,21 @@ namespace FluentMigrator.Runner.Generators.MySql
         public override string CloseQuote => "`";
 
         /// <inheritdoc />
+        /// <remarks>
+        /// MySQL treats the backslash as an escape character inside string literals, so backslashes
+        /// in a quoted value have to be doubled. That escaping must not be applied to
+        /// <see cref="RawSql"/>, which <see cref="GenericQuoter.QuoteValue"/> returns verbatim: the
+        /// caller has taken responsibility for that SQL and it has to reach the server unmodified.
+        /// Escaping it corrupted regex predicates, <c>LIKE</c> patterns and JSON paths.
+        /// See https://github.com/fluentmigrator/fluentmigrator/issues/2335.
+        /// </remarks>
         public override string QuoteValue(object value)
         {
+            if (value is RawSql rawSql)
+            {
+                return rawSql.Value;
+            }
+
             return base.QuoteValue(value).Replace(@"\", @"\\");
         }
 

--- a/test/FluentMigrator.Tests/FluentMigrator.Tests.csproj
+++ b/test/FluentMigrator.Tests/FluentMigrator.Tests.csproj
@@ -54,6 +54,7 @@
     <PackageReference Include="NUnit.Console" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Shouldly" />
+    <PackageReference Include="Verify.NUnit" />
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/FluentMigrator.Tests/Unit/Generators/MySql4/MySql4DataTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/MySql4/MySql4DataTests.cs
@@ -16,6 +16,10 @@
 //
 #endregion
 
+using System.Collections.Generic;
+
+using FluentMigrator.Expressions;
+using FluentMigrator.Model;
 using FluentMigrator.Runner.Generators.MySql;
 
 using NUnit.Framework;
@@ -191,5 +195,70 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql4
             var result = Generator.Generate(expression);
             result.ShouldBe("UPDATE `TestTable1` SET `Name` = 'Just''in', `Age` = 25 WHERE `Id` = 9 AND `Homepage` IS NULL;");
         }
+
+        #region RawSql backslash regression (#2335)
+
+        // Insert/Update/Delete all render their values through IQuoter.QuoteValue, so the MySQL
+        // string-literal backslash escaping reached RawSql values that were meant to pass through
+        // untouched. These reproduce the defect on the DML path alone - no SQL script token
+        // substitution is involved.
+
+        [Test]
+        public void CanUpdateDataWithRawSqlContainingBackslash()
+        {
+            var expression = new UpdateDataExpression
+            {
+                TableName = "TestTable1",
+                Set = new List<KeyValuePair<string, object>>
+                {
+                    new KeyValuePair<string, object>("Flagged", RawSql.Insert(@"`Code` REGEXP '\\d+'"))
+                },
+                Where = new List<KeyValuePair<string, object>>
+                {
+                    new KeyValuePair<string, object>("Id", 9)
+                }
+            };
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe(@"UPDATE `TestTable1` SET `Flagged` = `Code` REGEXP '\\d+' WHERE `Id` = 9;");
+        }
+
+        [Test]
+        public void CanDeleteDataWithRawSqlContainingBackslash()
+        {
+            var expression = new DeleteDataExpression
+            {
+                TableName = "TestTable1",
+                Rows =
+                {
+                    new DeletionDataDefinition
+                    {
+                        new KeyValuePair<string, object>("Path", RawSql.Insert(@"LIKE 'C:\\Temp\\%'"))
+                    }
+                }
+            };
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe(@"DELETE FROM `TestTable1` WHERE `Path` LIKE 'C:\\Temp\\%';");
+        }
+
+        [Test]
+        public void CanInsertDataWithRawSqlContainingBackslash()
+        {
+            var expression = new InsertDataExpression { TableName = "TestTable1" };
+            expression.Rows.Add(new InsertionDataDefinition
+            {
+                new KeyValuePair<string, object>("Pattern", RawSql.Insert(@"'\\d+'")),
+                new KeyValuePair<string, object>("Literal", @"a\b")
+            });
+
+            var result = Generator.Generate(expression);
+
+            // The RawSql column passes through untouched; the ordinary string column beside it is
+            // still escaped, which is what the escaping was written for.
+            result.ShouldBe(@"INSERT INTO `TestTable1` (`Pattern`, `Literal`) VALUES ('\\d+', 'a\\b');");
+        }
+
+        #endregion
     }
 }

--- a/test/FluentMigrator.Tests/Unit/Generators/MySql4/MySql4QuoterTest.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/MySql4/MySql4QuoterTest.cs
@@ -54,5 +54,33 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql4
             _quoter.QuoteValue(new TimeSpan(1,2, 13, 65))
                 .ShouldBe("'26:14:05'");
         }
+
+        /// <summary>
+        /// MySQL needs backslashes doubled inside a string literal, and that escaping is what
+        /// <see cref="MySqlQuoter.QuoteValue"/> adds on top of the generic quoter.
+        /// </summary>
+        [Test]
+        public void BackslashInStringIsEscaped()
+        {
+            _quoter.QuoteValue(@"a\b")
+                .ShouldBe(@"'a\\b'");
+        }
+
+        /// <summary>
+        /// Regression test for #2335. <see cref="RawSql"/> is an opt-in escape hatch: the caller has
+        /// taken responsibility for the SQL, so it must reach the server byte-for-byte. The
+        /// string-literal backslash escaping was being applied to it as well, which silently
+        /// corrupted regex predicates, LIKE patterns and JSON paths.
+        /// </summary>
+        [TestCase("CURRENT_TIMESTAMP")]
+        [TestCase(@"c REGEXP '\d+'")]
+        [TestCase(@"path LIKE 'C:\Temp\%'")]
+        [TestCase(@"json_col->'$.a\b'")]
+        [TestCase("name = 'O''Brien'")]
+        public void RawSqlIsPassedThroughVerbatim(string sql)
+        {
+            _quoter.QuoteValue(RawSql.Insert(sql))
+                .ShouldBe(sql);
+        }
     }
 }

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/BASELINE-FAILURES.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/BASELINE-FAILURES.md
@@ -1,0 +1,72 @@
+# Baseline: token substitution matrix against `main`
+
+Snapshot of the matrix as it stands **before** the fixes in this branch. Committed deliberately so
+the next commit's diff shows exactly which cells the fixes move.
+
+Run against `e25bf5ef` ("Fix RawSql script token replacement (#2333)") on `net48`, `en-US` host.
+
+```
+Failed!  - Failed: 48, Passed: 151, Skipped: 0, Total: 199 - FluentMigrator.Tests.dll (net48)
+```
+
+| Failing test | Count | Defect |
+|---|---|---|
+| `TokenMatrix_IsCultureInvariant` | 45 | `$[name]` no-quoter fallback calls plain `ToString()` |
+| `RawSql_RoundTripsVerbatim` | 3 | `MySqlQuoter` double-escapes backslashes in the `RawSql` passthrough (#2335) |
+
+45 is every dialect case; 3 is `MySql4`, `MySql5`, `MySql8`.
+
+## `TokenMatrix_IsCultureInvariant`
+
+#2324 routed `$(name)` through `IFormattable` + `InvariantCulture`, but the `$[name]` no-quoter
+fallback still calls plain `.ToString()`. Under `de-DE`:
+
+| Value | `$[x]` no quoter, `en-US` | `$[x]` no quoter, `de-DE` |
+|---|---|---|
+| `1234.5678d` | `'1234.5678'` | `'1234,5678'` |
+| `DateTime(2026,7,28,13,45,6)` | `'7/28/2026 1:45:06 PM'` | `'28.07.2026 13:45:06'` |
+
+Fails for every dialect because the fallback never reaches the provider quoter.
+
+## `RawSql_RoundTripsVerbatim`
+
+```
+RawSql_RoundTripsVerbatim(MySql8)
+  QuoteValueOrThrow(r.GeneratorQuoter, value)
+    should be  "c REGEXP '\d+'"
+    but was    "c REGEXP '\\d+'"
+```
+
+`MySqlQuoter.QuoteValue` applies string-literal backslash escaping to the value returned by
+`GenericQuoter.QuoteValue`, which for `RawSql` is a verbatim passthrough. Tracked as #2335.
+
+## What the snapshots already record but no assertion fails on yet
+
+The `*.verified.md` files in this directory capture the `$[name]` no-quoter fallback rendering
+non-string values as string literals:
+
+| Value | `$[x]` no quoter | `$[x]` with quoter |
+|---|---|---|
+| `1234.5678d` | `'1234.5678'` | `1234.5678` |
+| `-1234` | `'-1234'` | `-1234` |
+| `true` | `'True'` | `1` |
+| `new byte[]{0xDE,0xAD}` | `'System.Byte[]'` | `0xdead` |
+| `DBNull.Value` | `''` | `NULL` |
+| `RawSql.Insert("CURRENT_TIMESTAMP")` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` |
+
+These are visible in the golden tables rather than asserted individually, because the correct
+behaviour of the fallback is an API decision (see #2336) rather than an unambiguous bug.
+
+## Two claims this run disproved
+
+Recorded because both were asserted in the analysis on #2332 before being measured.
+
+1. **`SqlServerProcessor` / `Db2Processor` were expected to fail `ProcessorQuoter_Subsumes_GeneratorQuoter`.**
+   They do not. Both declare `public new IQuoter Quoter`, but the shadowing property and the
+   generator resolve the same scoped instance from the container, so the two paths agree across
+   every registration. The test passes and is kept as a regression guard.
+
+2. **`SafeToken_Agrees_With_QuoteValue` was expected to catch #2335.** It does not, and cannot:
+   both sides of the comparison run through the same `MySqlQuoter` and therefore agree on the
+   corrupted value. Catching a defect inside a shared component needs an absolute assertion, which
+   is why `RawSql_RoundTripsVerbatim` was added.

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/BASELINE-FAILURES.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/BASELINE-FAILURES.md
@@ -57,6 +57,49 @@ non-string values as string literals:
 These are visible in the golden tables rather than asserted individually, because the correct
 behaviour of the fallback is an API decision (see #2336) rather than an unambiguous bug.
 
+## After the fixes
+
+Same matrix, same host, after the fix commit on this branch:
+
+```
+Passed!  - Failed: 0, Passed: 199, Skipped: 0, Total: 199 - FluentMigrator.Tests.dll (net48)
+```
+
+Full `FluentMigrator.Tests` suite: `Failed: 0, Passed: 5406, Skipped: 940, Total: 6346`.
+
+The `*.verified.md` snapshots were regenerated in that commit, so its diff is the precise list of
+cells the fixes moved. For MySQL:
+
+| Value | `$[x]` no quoter, before | after | `$[x]` w/ quoter, before | after |
+|---|---|---|---|---|
+| `DBNull.Value` | `''` | `NULL` | `NULL` | `NULL` |
+| `true` | `'True'` | `1` | `1` | `1` |
+| `1234.5678d` | `'1234.5678'` | `1234.5678` | `1234.5678` | `1234.5678` |
+| `DateTime` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | unchanged |
+| `byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` | unchanged |
+| `RawSql` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | unchanged |
+| `RawSql` + `\d` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\\d+'` | `c REGEXP '\d+'` |
+
+The last row is #2335: the corruption was in the *with-quoter* column, i.e. the path real migrations
+take, and it is also what `Insert`/`Update`/`Delete` emit.
+
+One cell deliberately not changed: `$(x)` still renders a `DateTime` as `07/28/2026 13:45:06`. The
+raw token style is documented as verbatim `ToString()`, and it is invariant-culture, so this is
+consistent - but it is not a portable SQL datetime literal. Callers wanting one should use `$[x]`.
+Noted in #2336 rather than changed here.
+
+One cell changed to a throw rather than a value:
+
+| Value | `$[x]` no quoter, before | after |
+|---|---|---|
+| `SystemMethods.CurrentDateTime` | `'CurrentDateTime'` | `<throws NotSupportedException>` |
+
+`CURRENT_TIMESTAMP`, `GETDATE()`, `SYSDATE` and `NOW()` are all spelled differently, so there is no
+dialect-independent rendering to fall back to - which is why `GenericQuoter.FormatSystemMethods`
+throws by default and every provider overrides it. Emitting the string literal `'CurrentDateTime'`
+was syntactically valid SQL that silently meant the wrong thing. Failing tells the caller to supply
+an `IQuoter`.
+
 ## Two claims this run disproved
 
 Recorded because both were asserted in the analysis on #2332 before being measured.

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrix.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrix.md
@@ -1,0 +1,111 @@
+# Token substitution matrix
+
+Reference document for `TokenSubstitutionMatrixTests`. Describes *what* the matrix covers and *why*
+each axis exists. The measured output lives in the `*.verified.md` snapshots beside this file.
+
+Tracking issue: [#2336](https://github.com/fluentmigrator/fluentmigrator/issues/2336).
+
+## Why a matrix
+
+`SqlScriptTokenReplacer` is reached from `Execute.Sql`, `Execute.Script` and `Execute.EmbeddedScript`
+(`ExecuteSqlStatementExpression.ExecuteWith` and `ExecuteSqlScriptExpressionBase.ExecuteWith` are its
+only callers in `src/`). Those call sites pass `processor?.Quoter`, so token output depends on the
+whole DI graph, not just on the replacer.
+
+The axes multiply out to roughly 35,000 combinations. Enumerating each as an NUnit case would be
+unreadable, so the fixture multiplexes the **configuration** axes into `TestCaseSource` and treats the
+**value x token-style** grid as a snapshot payload. A regression is then a one-cell diff in a
+markdown table rather than one of 35,000 opaque case names.
+
+## Axes
+
+| # | Axis | Values | Why it matters |
+|---|---|---|---|
+| 1 | Token style | `$(name)` raw, `$[name]` safe-quoted | Different code paths: raw bypasses the quoter entirely |
+| 2 | Quoter presence | supplied vs `null` | The `IQuoter` parameter is optional and the fallback has its own semantics |
+| 3 | Value type | every branch of `GenericQuoter.QuoteValue`, plus uncased fall-through, plus `RawSql` | The reported defects are all value-type specific |
+| 4 | Dialect | ~30 `Add*()` registrations on `IMigrationRunnerBuilder` | Each wires a different quoter/typemap/generator triple |
+| 5 | `IQuoter` switch | `binaryGuid`, `QuoteIdentifiers`, `ForceQuote`, quoted-identifier variants | Orthogonal to dialect; changes value rendering |
+| 6 | `ITypeMap` switch | `useStrictTables`, version lineage | Orthogonal to dialect; must *not* change value rendering |
+| 7 | `IGenerator` switch | `GeneratorOptions.CompatibilityMode` | Orthogonal to both |
+| 8 | `CurrentCulture` | `en-US`, `de-DE` | Invariant-culture regressions are invisible on an en-US agent |
+
+Axes 4-7 become test cases. Axes 1-3 become the snapshot payload. Axis 8 is a dedicated invariance
+test rather than a doubling of the snapshot.
+
+## Value cases
+
+One entry per branch of `GenericQuoter.QuoteValue`, in source order, so a new `case` added to the
+quoter without a matching row here is visible as a gap.
+
+| Value case | Cased in `GenericQuoter.QuoteValue`? | Notes |
+|---|---|---|
+| `null` | yes | `FormatNull()` |
+| `DBNull.Value` | yes | shares the `FormatNull()` branch |
+| `string` | yes | `FormatNationalString`; uses `O'Brien` to exercise quote doubling |
+| `NonUnicodeString` | yes | `FormatAnsiString` |
+| `char` | yes | |
+| `bool` | yes | |
+| `Guid` | yes | |
+| `DateTime` | yes | |
+| `DateTimeOffset` | yes | |
+| `double` | yes | culture-sensitive if mishandled |
+| `float` | yes | culture-sensitive if mishandled |
+| `decimal` | yes | culture-sensitive if mishandled |
+| `int` | yes | |
+| `long` | **no** | falls through to `value.ToString()` |
+| `short` | **no** | falls through to `value.ToString()` |
+| `byte` | **no** | falls through to `value.ToString()` |
+| `SystemMethods` | yes | `GenericQuoter.FormatSystemMethods` throws; providers override |
+| `Enum` | yes | |
+| `byte[]` | yes | |
+| `TimeSpan` | yes | |
+| `RawSql` (plain) | yes | verbatim passthrough — subject of #2332 |
+| `RawSql` (backslash) | yes | verbatim passthrough — subject of #2335 |
+| `RawSql` (embedded quote) | yes | verbatim passthrough |
+
+`long`, `short` and `byte` are deliberately included *because* they are uncased. They render
+correctly by accident via `ToString()`, which is culture-sensitive. Pinning them means a future
+change to the fall-through is visible.
+
+## Assertions
+
+| Test | Claim |
+|---|---|
+| `TokenMatrix_IsStable` | Golden markdown table per dialect family |
+| `RawSql_RoundTripsVerbatim` | `RawSql` reaches the database byte-for-byte through every quoter and both token styles |
+| `SafeToken_Agrees_With_QuoteValue` | `$[x]` and `Insert`/`Update`/`Delete` render an identical literal for the same value, since both terminate in `IQuoter.QuoteValue` |
+| `ProcessorQuoter_Subsumes_GeneratorQuoter` | `processor.Quoter` and `generator.Quoter` agree |
+| `TypeMapSwitch_DoesNotAffect_TokenExpansion` | Flipping only an `ITypeMap` switch moves no cell |
+| `TokenMatrix_IsCultureInvariant` | The matrix is identical under `en-US` and `de-DE` |
+| `EscapeAndMissForms_AreDialectIndependent` | `$$((x))`, `$$[[x]]` and unmatched tokens do not vary by dialect |
+
+### On `RawSql_RoundTripsVerbatim`
+
+`RawSql` is an opt-in escape hatch: the caller has accepted responsibility for the SQL, so it must
+arrive unmodified. This is the assertion that catches #2335.
+
+It is worth being precise about why `SafeToken_Agrees_With_QuoteValue` does **not** catch #2335:
+both sides of that comparison run through the same `MySqlQuoter` instance, so they agree on the
+corrupted value. Agreement between two paths is only useful when the paths can differ; a defect
+inside the shared component needs an absolute assertion, not a relative one.
+
+### On `ProcessorQuoter_Subsumes_GeneratorQuoter`
+
+`IGenerator` is supposed to subsume `IQuoter`, and `ProcessorBase.Quoter => Generator.Quoter` honours
+that. `SqlServerProcessor` and `Db2Processor` additionally declare `public new IQuoter Quoter`, which
+shadows it - but in practice both resolve the same scoped instance from the container, so the paths
+agree today across every registration. This test passes as written; it exists to keep that true,
+because token substitution reads `processor.Quoter` while DML generation reads `generator.Quoter`.
+
+### On `TypeMapSwitch_DoesNotAffect_TokenExpansion`
+
+`ReplaceSqlScriptTokens` never receives an `ITypeMap` — that interface maps CLR/`DbType` to column
+type strings for DDL. The orthogonality is therefore true by construction today, and this test exists
+so that a future refactor cannot quietly couple them.
+
+## Known-wrong cells
+
+Cells that are wrong at the time of writing are marked in the snapshots and tracked in #2336. The
+snapshot is a record of *current* behaviour, not of *desired* behaviour; the assertion tests above
+encode desired behaviour and are the ones that fail while a defect is open.

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=MySql.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=MySql.verified.md
@@ -11,28 +11,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\\d+'` | `c REGEXP '\\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### MySql5
 
@@ -43,28 +43,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\\d+'` | `c REGEXP '\\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### MySql8
 
@@ -75,26 +75,26 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\\d+'` | `c REGEXP '\\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=MySql.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=MySql.verified.md
@@ -1,0 +1,100 @@
+﻿# Token substitution matrix - MySql
+
+See `TokenSubstitutionMatrix.md` for what each column means.
+
+### MySql4
+
+- generator: `MySql4Generator`
+- generator.Quoter: `MySqlQuoter`
+- processor.Quoter: `MySqlQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\\d+'` | `c REGEXP '\\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### MySql5
+
+- generator: `MySql5Generator`
+- generator.Quoter: `MySqlQuoter`
+- processor.Quoter: `MySqlQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\\d+'` | `c REGEXP '\\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### MySql8
+
+- generator: `MySql8Generator`
+- generator.Quoter: `MySqlQuoter`
+- processor.Quoter: `MySqlQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\\d+'` | `c REGEXP '\\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Oracle.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Oracle.verified.md
@@ -1,0 +1,196 @@
+﻿# Token substitution matrix - Oracle
+
+See `TokenSubstitutionMatrix.md` for what each column means.
+
+### Oracle
+
+- generator: `OracleGenerator`
+- generator.Quoter: `OracleQuoter`
+- processor.Quoter: `OracleQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### OracleManaged
+
+- generator: `OracleManagedGenerator`
+- generator.Quoter: `OracleQuoter`
+- processor.Quoter: `OracleQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### DotConnectOracle
+
+- generator: `OracleGenerator`
+- generator.Quoter: `OracleQuoter`
+- processor.Quoter: `OracleQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### Oracle12C
+
+- generator: `Oracle12CGenerator`
+- generator.Quoter: `OracleQuoter`
+- processor.Quoter: `OracleQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### Oracle12CManaged
+
+- generator: `Oracle12CGenerator`
+- generator.Quoter: `OracleQuoter`
+- processor.Quoter: `OracleQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### DotConnectOracle12C
+
+- generator: `Oracle12CGenerator`
+- generator.Quoter: `OracleQuoter`
+- processor.Quoter: `OracleQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Oracle.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Oracle.verified.md
@@ -11,28 +11,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### OracleManaged
 
@@ -43,28 +43,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### DotConnectOracle
 
@@ -75,28 +75,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Oracle12C
 
@@ -107,28 +107,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Oracle12CManaged
 
@@ -139,28 +139,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### DotConnectOracle12C
 
@@ -171,26 +171,26 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Other.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Other.verified.md
@@ -11,28 +11,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28-13.45.06'` | `'2026-07-28-13.45.06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28-13.45.06'` | `'2026-07-28-13.45.06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Db2ISeries
 
@@ -43,28 +43,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28-13.45.06'` | `'2026-07-28-13.45.06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28-13.45.06'` | `'2026-07-28-13.45.06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Firebird
 
@@ -75,28 +75,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28 13:45:06'` | `'2026-07-28 13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28 13:45:06'` | `'2026-07-28 13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Hana8
 
@@ -107,28 +107,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `TRUE` | `TRUE` |
+| bool | `True` | `1` | `TRUE` | `TRUE` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Hana10
 
@@ -139,28 +139,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `TRUE` | `TRUE` |
+| bool | `True` | `1` | `TRUE` | `TRUE` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Redshift
 
@@ -171,26 +171,26 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `true` | `true` |
+| bool | `True` | `1` | `true` | `true` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `SYSDATE` | `SYSDATE` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `SYSDATE` | `SYSDATE` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| byte[] | `System.Byte[]` | `0xdead` | `E'\\xDEAD'` | `E'\\xDEAD'` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Other.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Other.verified.md
@@ -1,0 +1,196 @@
+﻿# Token substitution matrix - Other
+
+See `TokenSubstitutionMatrix.md` for what each column means.
+
+### Db2
+
+- generator: `Db2Generator`
+- generator.Quoter: `Db2Quoter`
+- processor.Quoter: `Db2Quoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28-13.45.06'` | `'2026-07-28-13.45.06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### Db2ISeries
+
+- generator: `Db2ISeriesGenerator`
+- generator.Quoter: `Db2ISeriesQuoter`
+- processor.Quoter: `Db2ISeriesQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28-13.45.06'` | `'2026-07-28-13.45.06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### Firebird
+
+- generator: `FirebirdGenerator`
+- generator.Quoter: `FirebirdQuoter`
+- processor.Quoter: `FirebirdQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28 13:45:06'` | `'2026-07-28 13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### Hana8
+
+- generator: `HanaGenerator`
+- generator.Quoter: `HanaQuoter`
+- processor.Quoter: `HanaQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `TRUE` | `TRUE` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### Hana10
+
+- generator: `HanaGenerator`
+- generator.Quoter: `HanaQuoter`
+- processor.Quoter: `HanaQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `TRUE` | `TRUE` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### Redshift
+
+- generator: `RedshiftGenerator`
+- generator.Quoter: `RedshiftQuoter`
+- processor.Quoter: `RedshiftQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `true` | `true` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `SYSDATE` | `SYSDATE` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Postgres.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Postgres.verified.md
@@ -11,28 +11,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `true` | `true` |
+| bool | `True` | `1` | `true` | `true` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `now()` | `now()` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `now()` | `now()` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| byte[] | `System.Byte[]` | `0xdead` | `E'\\xDEAD'` | `E'\\xDEAD'` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Postgres92(ForceQuote=True)
 
@@ -43,28 +43,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `true` | `true` |
+| bool | `True` | `1` | `true` | `true` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `now()` | `now()` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `now()` | `now()` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| byte[] | `System.Byte[]` | `0xdead` | `E'\\xDEAD'` | `E'\\xDEAD'` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Postgres10_0(ForceQuote=True)
 
@@ -75,28 +75,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `true` | `true` |
+| bool | `True` | `1` | `true` | `true` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `now()` | `now()` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `now()` | `now()` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| byte[] | `System.Byte[]` | `0xdead` | `E'\\xDEAD'` | `E'\\xDEAD'` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Postgres11_0(ForceQuote=True)
 
@@ -107,28 +107,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `true` | `true` |
+| bool | `True` | `1` | `true` | `true` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `now()` | `now()` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `now()` | `now()` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| byte[] | `System.Byte[]` | `0xdead` | `E'\\xDEAD'` | `E'\\xDEAD'` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Postgres15_0(ForceQuote=True)
 
@@ -139,28 +139,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `true` | `true` |
+| bool | `True` | `1` | `true` | `true` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `now()` | `now()` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `now()` | `now()` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| byte[] | `System.Byte[]` | `0xdead` | `E'\\xDEAD'` | `E'\\xDEAD'` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Postgres(ForceQuote=False)
 
@@ -171,28 +171,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `true` | `true` |
+| bool | `True` | `1` | `true` | `true` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `now()` | `now()` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `now()` | `now()` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| byte[] | `System.Byte[]` | `0xdead` | `E'\\xDEAD'` | `E'\\xDEAD'` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Postgres92(ForceQuote=False)
 
@@ -203,28 +203,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `true` | `true` |
+| bool | `True` | `1` | `true` | `true` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `now()` | `now()` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `now()` | `now()` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| byte[] | `System.Byte[]` | `0xdead` | `E'\\xDEAD'` | `E'\\xDEAD'` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Postgres10_0(ForceQuote=False)
 
@@ -235,28 +235,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `true` | `true` |
+| bool | `True` | `1` | `true` | `true` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `now()` | `now()` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `now()` | `now()` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| byte[] | `System.Byte[]` | `0xdead` | `E'\\xDEAD'` | `E'\\xDEAD'` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Postgres11_0(ForceQuote=False)
 
@@ -267,28 +267,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `true` | `true` |
+| bool | `True` | `1` | `true` | `true` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `now()` | `now()` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `now()` | `now()` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| byte[] | `System.Byte[]` | `0xdead` | `E'\\xDEAD'` | `E'\\xDEAD'` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Postgres15_0(ForceQuote=False)
 
@@ -299,26 +299,26 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `true` | `true` |
+| bool | `True` | `1` | `true` | `true` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `now()` | `now()` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `now()` | `now()` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| byte[] | `System.Byte[]` | `0xdead` | `E'\\xDEAD'` | `E'\\xDEAD'` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Postgres.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Postgres.verified.md
@@ -1,0 +1,324 @@
+﻿# Token substitution matrix - Postgres
+
+See `TokenSubstitutionMatrix.md` for what each column means.
+
+### Postgres(ForceQuote=True)
+
+- generator: `Postgres15_0Generator`
+- generator.Quoter: `PostgresQuoter`
+- processor.Quoter: `PostgresQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `true` | `true` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `now()` | `now()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### Postgres92(ForceQuote=True)
+
+- generator: `Postgres92Generator`
+- generator.Quoter: `PostgresQuoter`
+- processor.Quoter: `PostgresQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `true` | `true` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `now()` | `now()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### Postgres10_0(ForceQuote=True)
+
+- generator: `Postgres10_0Generator`
+- generator.Quoter: `PostgresQuoter`
+- processor.Quoter: `PostgresQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `true` | `true` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `now()` | `now()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### Postgres11_0(ForceQuote=True)
+
+- generator: `Postgres11_0Generator`
+- generator.Quoter: `PostgresQuoter`
+- processor.Quoter: `PostgresQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `true` | `true` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `now()` | `now()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### Postgres15_0(ForceQuote=True)
+
+- generator: `Postgres15_0Generator`
+- generator.Quoter: `PostgresQuoter`
+- processor.Quoter: `PostgresQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `true` | `true` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `now()` | `now()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### Postgres(ForceQuote=False)
+
+- generator: `Postgres15_0Generator`
+- generator.Quoter: `PostgresQuoter`
+- processor.Quoter: `PostgresQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `true` | `true` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `now()` | `now()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### Postgres92(ForceQuote=False)
+
+- generator: `Postgres92Generator`
+- generator.Quoter: `PostgresQuoter`
+- processor.Quoter: `PostgresQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `true` | `true` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `now()` | `now()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### Postgres10_0(ForceQuote=False)
+
+- generator: `Postgres10_0Generator`
+- generator.Quoter: `PostgresQuoter`
+- processor.Quoter: `PostgresQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `true` | `true` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `now()` | `now()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### Postgres11_0(ForceQuote=False)
+
+- generator: `Postgres11_0Generator`
+- generator.Quoter: `PostgresQuoter`
+- processor.Quoter: `PostgresQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `true` | `true` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `now()` | `now()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### Postgres15_0(ForceQuote=False)
+
+- generator: `Postgres15_0Generator`
+- generator.Quoter: `PostgresQuoter`
+- processor.Quoter: `PostgresQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `true` | `true` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `now()` | `now()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=SQLite.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=SQLite.verified.md
@@ -1,0 +1,388 @@
+﻿# Token substitution matrix - SQLite
+
+See `TokenSubstitutionMatrix.md` for what each column means.
+
+### SQLite(guid=False,strict=False,compat=null)
+
+- generator: `SQLiteGenerator`
+- generator.Quoter: `SQLiteQuoter`
+- processor.Quoter: `SQLiteQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### SQLite(guid=False,strict=False,compat=STRICT)
+
+- generator: `SQLiteGenerator`
+- generator.Quoter: `SQLiteQuoter`
+- processor.Quoter: `SQLiteQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### SQLite(guid=False,strict=False,compat=LOOSE)
+
+- generator: `SQLiteGenerator`
+- generator.Quoter: `SQLiteQuoter`
+- processor.Quoter: `SQLiteQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### SQLite(guid=False,strict=True,compat=null)
+
+- generator: `SQLiteGenerator`
+- generator.Quoter: `SQLiteQuoter`
+- processor.Quoter: `SQLiteQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### SQLite(guid=False,strict=True,compat=STRICT)
+
+- generator: `SQLiteGenerator`
+- generator.Quoter: `SQLiteQuoter`
+- processor.Quoter: `SQLiteQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### SQLite(guid=False,strict=True,compat=LOOSE)
+
+- generator: `SQLiteGenerator`
+- generator.Quoter: `SQLiteQuoter`
+- processor.Quoter: `SQLiteQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### SQLite(guid=True,strict=False,compat=null)
+
+- generator: `SQLiteGenerator`
+- generator.Quoter: `SQLiteQuoter`
+- processor.Quoter: `SQLiteQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### SQLite(guid=True,strict=False,compat=STRICT)
+
+- generator: `SQLiteGenerator`
+- generator.Quoter: `SQLiteQuoter`
+- processor.Quoter: `SQLiteQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### SQLite(guid=True,strict=False,compat=LOOSE)
+
+- generator: `SQLiteGenerator`
+- generator.Quoter: `SQLiteQuoter`
+- processor.Quoter: `SQLiteQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### SQLite(guid=True,strict=True,compat=null)
+
+- generator: `SQLiteGenerator`
+- generator.Quoter: `SQLiteQuoter`
+- processor.Quoter: `SQLiteQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### SQLite(guid=True,strict=True,compat=STRICT)
+
+- generator: `SQLiteGenerator`
+- generator.Quoter: `SQLiteQuoter`
+- processor.Quoter: `SQLiteQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### SQLite(guid=True,strict=True,compat=LOOSE)
+
+- generator: `SQLiteGenerator`
+- generator.Quoter: `SQLiteQuoter`
+- processor.Quoter: `SQLiteQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=SQLite.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=SQLite.verified.md
@@ -11,28 +11,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SQLite(guid=False,strict=False,compat=STRICT)
 
@@ -43,28 +43,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SQLite(guid=False,strict=False,compat=LOOSE)
 
@@ -75,28 +75,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SQLite(guid=False,strict=True,compat=null)
 
@@ -107,28 +107,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SQLite(guid=False,strict=True,compat=STRICT)
 
@@ -139,28 +139,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SQLite(guid=False,strict=True,compat=LOOSE)
 
@@ -171,28 +171,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SQLite(guid=True,strict=False,compat=null)
 
@@ -203,28 +203,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SQLite(guid=True,strict=False,compat=STRICT)
 
@@ -235,28 +235,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SQLite(guid=True,strict=False,compat=LOOSE)
 
@@ -267,28 +267,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SQLite(guid=True,strict=True,compat=null)
 
@@ -299,28 +299,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SQLite(guid=True,strict=True,compat=STRICT)
 
@@ -331,28 +331,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SQLite(guid=True,strict=True,compat=LOOSE)
 
@@ -363,26 +363,26 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `X'dead'` | `X'dead'` |
+| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Snowflake.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Snowflake.verified.md
@@ -11,28 +11,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28 13:45:06'` | `'2026-07-28 13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28 13:45:06 -04:00'` | `'2026-07-28 13:45:06 -04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `CURRENT_TIMESTAMP()` | `CURRENT_TIMESTAMP()` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28 13:45:06'` | `'2026-07-28 13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28 13:45:06 -04:00'` | `'2026-07-28 13:45:06 -04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `CURRENT_TIMESTAMP()` | `CURRENT_TIMESTAMP()` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Snowflake(QuoteIdentifiers=False)
 
@@ -43,26 +43,26 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28 13:45:06'` | `'2026-07-28 13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28 13:45:06 -04:00'` | `'2026-07-28 13:45:06 -04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `CURRENT_TIMESTAMP()` | `CURRENT_TIMESTAMP()` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28 13:45:06'` | `'2026-07-28 13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28 13:45:06 -04:00'` | `'2026-07-28 13:45:06 -04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `CURRENT_TIMESTAMP()` | `CURRENT_TIMESTAMP()` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Snowflake.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Snowflake.verified.md
@@ -1,0 +1,68 @@
+﻿# Token substitution matrix - Snowflake
+
+See `TokenSubstitutionMatrix.md` for what each column means.
+
+### Snowflake(QuoteIdentifiers=True)
+
+- generator: `SnowflakeGenerator`
+- generator.Quoter: `SnowflakeQuoter`
+- processor.Quoter: `SnowflakeQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28 13:45:06'` | `'2026-07-28 13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28 13:45:06 -04:00'` | `'2026-07-28 13:45:06 -04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `CURRENT_TIMESTAMP()` | `CURRENT_TIMESTAMP()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### Snowflake(QuoteIdentifiers=False)
+
+- generator: `SnowflakeGenerator`
+- generator.Quoter: `SnowflakeQuoter`
+- processor.Quoter: `SnowflakeQuoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28 13:45:06'` | `'2026-07-28 13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28 13:45:06 -04:00'` | `'2026-07-28 13:45:06 -04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `CURRENT_TIMESTAMP()` | `CURRENT_TIMESTAMP()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=SqlServer.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=SqlServer.verified.md
@@ -1,0 +1,196 @@
+﻿# Token substitution matrix - SqlServer
+
+See `TokenSubstitutionMatrix.md` for what each column means.
+
+### SqlServer2000
+
+- generator: `SqlServer2000Generator`
+- generator.Quoter: `SqlServer2000Quoter`
+- processor.Quoter: `SqlServer2000Quoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `GETDATE()` | `GETDATE()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### SqlServer2005
+
+- generator: `SqlServer2005Generator`
+- generator.Quoter: `SqlServer2005Quoter`
+- processor.Quoter: `SqlServer2005Quoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `GETDATE()` | `GETDATE()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### SqlServer2008
+
+- generator: `SqlServer2008Generator`
+- generator.Quoter: `SqlServer2008Quoter`
+- processor.Quoter: `SqlServer2008Quoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `GETDATE()` | `GETDATE()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### SqlServer2012
+
+- generator: `SqlServer2012Generator`
+- generator.Quoter: `SqlServer2008Quoter`
+- processor.Quoter: `SqlServer2008Quoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `GETDATE()` | `GETDATE()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### SqlServer2014
+
+- generator: `SqlServer2014Generator`
+- generator.Quoter: `SqlServer2008Quoter`
+- processor.Quoter: `SqlServer2008Quoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `GETDATE()` | `GETDATE()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
+### SqlServer2016
+
+- generator: `SqlServer2016Generator`
+- generator.Quoter: `SqlServer2008Quoter`
+- processor.Quoter: `SqlServer2008Quoter`
+
+| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` | `'x'` |
+| bool | `True` | `'True'` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
+| byte(uncased) | `7` | `'7'` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `GETDATE()` | `GETDATE()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=SqlServer.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=SqlServer.verified.md
@@ -11,28 +11,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `GETDATE()` | `GETDATE()` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `GETDATE()` | `GETDATE()` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SqlServer2005
 
@@ -43,28 +43,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `GETDATE()` | `GETDATE()` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `GETDATE()` | `GETDATE()` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SqlServer2008
 
@@ -75,28 +75,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `GETDATE()` | `GETDATE()` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `GETDATE()` | `GETDATE()` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SqlServer2012
 
@@ -107,28 +107,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `GETDATE()` | `GETDATE()` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `GETDATE()` | `GETDATE()` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SqlServer2014
 
@@ -139,28 +139,28 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `GETDATE()` | `GETDATE()` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `GETDATE()` | `GETDATE()` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SqlServer2016
 
@@ -171,26 +171,26 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
 |---|---|---|---|---|
 | null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `''` | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
 | string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
 | NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
 | char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `'True'` | `1` | `1` |
+| bool | `True` | `1` | `1` | `1` |
 | Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'7/28/2026 1:45:06 PM -04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `'1234.5'` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `'1234.5678'` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `'-1234'` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `'-12'` | `-12` | `-12` |
-| byte(uncased) | `7` | `'7'` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `'CurrentDateTime'` | `GETDATE()` | `GETDATE()` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `GETDATE()` | `GETDATE()` |
 | Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `'System.Byte[]'` | `0xdead` | `0xdead` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
 | TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `'FluentMigrator.RawSql'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `'FluentMigrator.RawSql'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.cs
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.cs
@@ -1,0 +1,599 @@
+#region License
+// Copyright (c) 2018, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentMigrator.Generation;
+using FluentMigrator.Runner;
+using FluentMigrator.Runner.Generators;
+using FluentMigrator.Runner.Initialization;
+using FluentMigrator.Runner.Processors;
+using FluentMigrator.Runner.Processors.Postgres;
+using FluentMigrator.Runner.Processors.Snowflake;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using NUnit.Framework;
+
+using Shouldly;
+
+using VerifyNUnit;
+
+// FluentMigrator.Runner.Generators also declares an IQuoter; the token replacer takes the
+// FluentMigrator.Generation one.
+using IQuoter = FluentMigrator.Generation.IQuoter;
+
+namespace FluentMigrator.Tests.Unit.TokenSubstitution
+{
+    /// <summary>
+    /// Path coverage for <see cref="SqlScriptTokenReplacer"/> across the full
+    /// <c>IQuoter</c> / <c>ITypeMap</c> / <c>IMigrationGenerator</c> product.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Read <c>TokenSubstitutionMatrix.md</c> (beside this file) first.</strong> It documents
+    /// every axis, why it exists, and what each assertion claims. This file is the executable form of
+    /// that document.
+    /// </para>
+    /// <para>
+    /// The axes multiply out to roughly 35,000 combinations, so the configuration axes (dialect,
+    /// quoter switch, typemap switch, generator switch) are multiplexed into <see cref="TestCaseSource"/>
+    /// while the value x token-style grid becomes a snapshot payload. A regression surfaces as a
+    /// one-cell diff in a markdown table rather than one of 35,000 opaque case names.
+    /// </para>
+    /// <para>Tracking issue: https://github.com/fluentmigrator/fluentmigrator/issues/2336</para>
+    /// </remarks>
+    [TestFixture]
+    [Category("SqlScriptTokenReplacer")]
+    [Category("TokenSubstitutionMatrix")]
+    public class TokenSubstitutionMatrixTests
+    {
+        private const string RawToken = "$(x)";
+        private const string SafeToken = "$[x]";
+
+        // ------------------------------------------------------------------ axes 4-7: configuration
+
+        /// <summary>
+        /// One fully-resolvable DI configuration.
+        /// </summary>
+        public sealed class DialectCase
+        {
+            public DialectCase(string id, string family, Action<IMigrationRunnerBuilder> configure, string typeMapVariantOf = null)
+            {
+                Id = id;
+                Family = family;
+                Configure = configure;
+                TypeMapVariantOf = typeMapVariantOf;
+            }
+
+            public string Id { get; }
+
+            public string Family { get; }
+
+            public Action<IMigrationRunnerBuilder> Configure { get; }
+
+            /// <summary>
+            /// Gets the id of the sibling case this one differs from by an <c>ITypeMap</c> switch only.
+            /// Drives <see cref="TypeMapSwitch_DoesNotAffect_TokenExpansion"/>.
+            /// </summary>
+            public string TypeMapVariantOf { get; }
+
+            public override string ToString() => Id;
+        }
+
+        private static IEnumerable<DialectCase> DialectCases()
+        {
+            // --- SQL Server -------------------------------------------------------------------
+            yield return new DialectCase("SqlServer2000", "SqlServer", b => b.AddSqlServer2000());
+            yield return new DialectCase("SqlServer2005", "SqlServer", b => b.AddSqlServer2005());
+            yield return new DialectCase("SqlServer2008", "SqlServer", b => b.AddSqlServer2008());
+            yield return new DialectCase("SqlServer2012", "SqlServer", b => b.AddSqlServer2012());
+            yield return new DialectCase("SqlServer2014", "SqlServer", b => b.AddSqlServer2014());
+            yield return new DialectCase("SqlServer2016", "SqlServer", b => b.AddSqlServer2016());
+
+            // --- MySQL: MySql4/5/8 differ only by ITypeMap, so their matrices must be identical.
+            yield return new DialectCase("MySql4", "MySql", b => b.AddMySql4());
+            yield return new DialectCase("MySql5", "MySql", b => b.AddMySql5(), typeMapVariantOf: "MySql4");
+            yield return new DialectCase("MySql8", "MySql", b => b.AddMySql8(), typeMapVariantOf: "MySql4");
+
+            // --- Postgres: version lineage x ForceQuote (an IQuoter switch).
+            //     PostgresOptions is resolved as a plain scoped service and the provider registers it
+            //     with TryAdd semantics, so pre-registering here wins.
+            foreach (var forceQuote in new[] { true, false })
+            {
+                var fq = forceQuote;
+
+                Action<IMigrationRunnerBuilder> WithOptions(Action<IMigrationRunnerBuilder> add) =>
+                    b =>
+                    {
+                        b.Services.AddScoped(_ => new PostgresOptions { ForceQuote = fq });
+                        add(b);
+                    };
+
+                yield return new DialectCase($"Postgres(ForceQuote={fq})", "Postgres", WithOptions(x => x.AddPostgres()));
+                yield return new DialectCase($"Postgres92(ForceQuote={fq})", "Postgres", WithOptions(x => x.AddPostgres92()));
+                yield return new DialectCase($"Postgres10_0(ForceQuote={fq})", "Postgres", WithOptions(x => x.AddPostgres10_0()));
+                yield return new DialectCase($"Postgres11_0(ForceQuote={fq})", "Postgres", WithOptions(x => x.AddPostgres11_0()));
+                yield return new DialectCase($"Postgres15_0(ForceQuote={fq})", "Postgres", WithOptions(x => x.AddPostgres15_0()));
+            }
+
+            // --- SQLite: the only provider exposing all three switches independently.
+            //     binaryGuid   -> IQuoter
+            //     strictTables -> ITypeMap    (must NOT move any cell)
+            //     compatMode   -> IMigrationGenerator
+            foreach (var binaryGuid in new[] { false, true })
+            {
+                foreach (var strictTables in new[] { false, true })
+                {
+                    foreach (var compat in new CompatibilityMode?[] { null, CompatibilityMode.STRICT, CompatibilityMode.LOOSE })
+                    {
+                        var bg = binaryGuid;
+                        var st = strictTables;
+                        var cm = compat;
+
+                        var compatLabel = cm?.ToString() ?? "null";
+                        var id = $"SQLite(guid={bg},strict={st},compat={compatLabel})";
+                        var baseline = $"SQLite(guid={bg},strict=False,compat={compatLabel})";
+
+                        yield return new DialectCase(
+                            id,
+                            "SQLite",
+                            b => b.AddSQLite(binaryGuid: bg, useStrictTables: st, compatibilityMode: cm),
+                            typeMapVariantOf: st ? baseline : null);
+                    }
+                }
+            }
+
+            // --- Snowflake: QuoteIdentifiers is an IQuoter switch.
+            foreach (var quoteIdentifiers in new[] { true, false })
+            {
+                var qi = quoteIdentifiers;
+                yield return new DialectCase(
+                    $"Snowflake(QuoteIdentifiers={qi})",
+                    "Snowflake",
+                    b => b.AddSnowflake(new SnowflakeOptions { QuoteIdentifiers = qi }));
+            }
+
+            // --- Oracle: OracleQuoter vs OracleQuoterQuotedIdentifier are distinct registrations.
+            yield return new DialectCase("Oracle", "Oracle", b => b.AddOracle());
+            yield return new DialectCase("OracleManaged", "Oracle", b => b.AddOracleManaged());
+            yield return new DialectCase("DotConnectOracle", "Oracle", b => b.AddDotConnectOracle());
+            yield return new DialectCase("Oracle12C", "Oracle", b => b.AddOracle12C());
+            yield return new DialectCase("Oracle12CManaged", "Oracle", b => b.AddOracle12CManaged());
+            yield return new DialectCase("DotConnectOracle12C", "Oracle", b => b.AddDotConnectOracle12C());
+
+            // --- remainder --------------------------------------------------------------------
+            yield return new DialectCase("Db2", "Other", b => b.AddDb2());
+            yield return new DialectCase("Db2ISeries", "Other", b => b.AddDb2ISeries());
+            yield return new DialectCase("Firebird", "Other", b => b.AddFirebird());
+            yield return new DialectCase("Hana8", "Other", b => b.AddHana8());
+            yield return new DialectCase("Hana10", "Other", b => b.AddHana10());
+            yield return new DialectCase("Redshift", "Other", b => b.AddRedshift());
+        }
+
+        private static IEnumerable<string> Families() =>
+            DialectCases().Select(d => d.Family).Distinct();
+
+        // ------------------------------------------------------------------ axis 3: values
+
+        public sealed class ValueCase
+        {
+            public ValueCase(string label, object value)
+            {
+                Label = label;
+                Value = value;
+            }
+
+            public string Label { get; }
+
+            public object Value { get; }
+
+            public override string ToString() => Label;
+        }
+
+        /// <summary>
+        /// One entry per branch of <c>GenericQuoter.QuoteValue</c>, in source order, plus the
+        /// uncased integral types that fall through to <c>value.ToString()</c>, plus the RawSql forms.
+        /// See the "Value cases" table in <c>TokenSubstitutionMatrix.md</c>.
+        /// </summary>
+        private static IEnumerable<ValueCase> ValueCases()
+        {
+            yield return new ValueCase("null", null);
+            yield return new ValueCase("DBNull", DBNull.Value);
+            yield return new ValueCase("string", "O'Brien");
+            yield return new ValueCase("NonUnicodeString", new NonUnicodeString("ansi"));
+            yield return new ValueCase("char", 'x');
+            yield return new ValueCase("bool", true);
+            yield return new ValueCase("Guid", new Guid("11111111-2222-3333-4444-555555555555"));
+            yield return new ValueCase("DateTime", new DateTime(2026, 7, 28, 13, 45, 6));
+            yield return new ValueCase("DateTimeOffset", new DateTimeOffset(2026, 7, 28, 13, 45, 6, TimeSpan.FromHours(-4)));
+            yield return new ValueCase("double", 1234.5678d);
+            yield return new ValueCase("float", 1234.5f);
+            yield return new ValueCase("decimal", 1234.5678m);
+            yield return new ValueCase("int", -1234);
+
+            // Not cased in GenericQuoter.QuoteValue: these reach value.ToString() and are therefore
+            // culture-sensitive on the DML path. Pinned deliberately so a change is visible.
+            yield return new ValueCase("long(uncased)", -1234L);
+            yield return new ValueCase("short(uncased)", (short)-12);
+            yield return new ValueCase("byte(uncased)", (byte)7);
+
+            yield return new ValueCase("SystemMethods", SystemMethods.CurrentDateTime);
+            yield return new ValueCase("Enum", DayOfWeek.Tuesday);
+            yield return new ValueCase("byte[]", new byte[] { 0xDE, 0xAD });
+            yield return new ValueCase("TimeSpan", new TimeSpan(1, 2, 3));
+
+            // The subjects of #2332 and #2335.
+            yield return new ValueCase("RawSql", RawSql.Insert("CURRENT_TIMESTAMP"));
+            yield return new ValueCase("RawSql+backslash", RawSql.Insert(@"c REGEXP '\d+'"));
+            yield return new ValueCase("RawSql+quote", RawSql.Insert("name = 'O''Brien'"));
+        }
+
+        // ------------------------------------------------------------------ container plumbing
+
+        private sealed class Resolved : IDisposable
+        {
+            private readonly ServiceProvider _root;
+            private readonly IServiceScope _scope;
+
+            public Resolved(DialectCase dialect)
+            {
+                var services = new ServiceCollection()
+                    .AddLogging()
+                    .AddFluentMigratorCore()
+                    .ConfigureRunner(rb =>
+                    {
+                        dialect.Configure(rb);
+                        rb.WithGlobalConnectionString("Data Source=:memory:");
+                    });
+
+                _root = services.BuildServiceProvider(validateScopes: false);
+                _scope = _root.CreateScope();
+
+                Generator = _scope.ServiceProvider.GetRequiredService<IMigrationGenerator>();
+                GeneratorQuoter = Generator.Quoter;
+
+                // Deliberately resolved through IMigrationProcessor, because that is what
+                // ExecuteSqlStatementExpression.ExecuteWith hands to the token replacer. Some
+                // processors shadow ProcessorBase.Quoter with `public new IQuoter Quoter`.
+                ProcessorQuoter = _scope.ServiceProvider.GetRequiredService<IMigrationProcessor>().Quoter;
+            }
+
+            public IMigrationGenerator Generator { get; }
+
+            public IQuoter GeneratorQuoter { get; }
+
+            public IQuoter ProcessorQuoter { get; }
+
+            public void Dispose()
+            {
+                _scope?.Dispose();
+                _root?.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Providers whose processor cannot be constructed without a native driver assembly are
+        /// reported Inconclusive rather than silently skipped.
+        /// </summary>
+        private static Resolved Resolve(DialectCase dialect)
+        {
+            try
+            {
+                return new Resolved(dialect);
+            }
+            catch (Exception ex)
+            {
+                Assert.Inconclusive($"{dialect.Id}: not constructible in this environment - {ex.GetType().Name}: {ex.Message}");
+                throw;
+            }
+        }
+
+        // ------------------------------------------------------------------ rendering
+
+        private static IDictionary<string, object> Params(object value) =>
+            new Dictionary<string, object> { ["x"] = value };
+
+        private static string Expand(string template, object value, IQuoter quoter)
+        {
+            try
+            {
+                return SqlScriptTokenReplacer.ReplaceSqlScriptTokens(template, Params(value), quoter) ?? "<null>";
+            }
+            catch (Exception ex)
+            {
+                return $"<throws {ex.GetType().Name}>";
+            }
+        }
+
+        private static string QuoteValueOrThrow(IQuoter quoter, object value)
+        {
+            try
+            {
+                return quoter.QuoteValue(value) ?? "<null>";
+            }
+            catch (Exception ex)
+            {
+                return $"<throws {ex.GetType().Name}>";
+            }
+        }
+
+        /// <summary>
+        /// Renders the value x token-style grid for one resolved configuration as a markdown table.
+        /// This is the snapshot payload.
+        /// </summary>
+        private static string RenderMatrix(DialectCase dialect, Resolved r)
+        {
+            var sb = new StringBuilder();
+
+            sb.AppendLine($"### {dialect.Id}");
+            sb.AppendLine();
+            sb.AppendLine($"- generator: `{r.Generator.GetType().Name}`");
+            sb.AppendLine($"- generator.Quoter: `{r.GeneratorQuoter.GetType().Name}`");
+            sb.AppendLine($"- processor.Quoter: `{r.ProcessorQuoter.GetType().Name}`");
+            sb.AppendLine();
+            sb.AppendLine("| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |");
+            sb.AppendLine("|---|---|---|---|---|");
+
+            foreach (var v in ValueCases())
+            {
+                sb.AppendLine(string.Join(
+                    " | ",
+                    "| " + v.Label,
+                    Cell(Expand(RawToken, v.Value, r.ProcessorQuoter)),
+                    Cell(Expand(SafeToken, v.Value, null)),
+                    Cell(Expand(SafeToken, v.Value, r.ProcessorQuoter)),
+                    Cell(QuoteValueOrThrow(r.GeneratorQuoter, v.Value)) + " |"));
+            }
+
+            sb.AppendLine();
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Escapes a rendered SQL fragment for display inside a markdown table cell.
+        /// </summary>
+        private static string Cell(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return "*(empty)*";
+            }
+
+            return "`" + value.Replace("|", "\\|") + "`";
+        }
+
+        // ------------------------------------------------------------------ tests
+
+        /// <summary>
+        /// Golden matrix per dialect family. The approved snapshot is a readable markdown document,
+        /// so a behavioural change is a one-line diff naming the dialect, the value and the token style.
+        /// </summary>
+        [TestCaseSource(nameof(Families))]
+        public Task TokenMatrix_IsStable(string family)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"# Token substitution matrix - {family}");
+            sb.AppendLine();
+            sb.AppendLine("See `TokenSubstitutionMatrix.md` for what each column means.");
+            sb.AppendLine();
+
+            foreach (var dialect in DialectCases().Where(d => d.Family == family))
+            {
+                using var r = Resolve(dialect);
+                sb.Append(RenderMatrix(dialect, r));
+            }
+
+            return Verifier.Verify(sb.ToString(), "md").UseParameters(family);
+        }
+
+        /// <summary>
+        /// <c>RawSql</c> is an opt-in escape hatch: the caller has taken responsibility for the SQL,
+        /// so it must reach the database byte-for-byte through every quoter.
+        /// </summary>
+        /// <remarks>
+        /// This is the assertion that catches #2335 (<c>MySqlQuoter</c> double-escaping backslashes
+        /// in the <c>RawSql</c> passthrough). Note that
+        /// <see cref="SafeToken_Agrees_With_QuoteValue"/> cannot catch it: both sides of that
+        /// comparison run through the same quoter and therefore agree on the corrupted value.
+        /// </remarks>
+        [TestCaseSource(nameof(DialectCases))]
+        public void RawSql_RoundTripsVerbatim(DialectCase dialect)
+        {
+            using var r = Resolve(dialect);
+
+            var rawSqlCases = new[]
+            {
+                "CURRENT_TIMESTAMP",
+                @"c REGEXP '\d+'",
+                "name = 'O''Brien'",
+                @"path LIKE 'C:\Temp\%'",
+                @"json_col->'$.a\b'",
+            };
+
+            Assert.Multiple(() =>
+            {
+                foreach (var sql in rawSqlCases)
+                {
+                    var value = RawSql.Insert(sql);
+
+                    QuoteValueOrThrow(r.GeneratorQuoter, value).ShouldBe(
+                        sql,
+                        $"{dialect.Id}: QuoteValue mangled RawSql instead of passing it through verbatim.");
+
+                    Expand(SafeToken, value, r.ProcessorQuoter).ShouldBe(
+                        sql,
+                        $"{dialect.Id}: $[x] mangled RawSql instead of passing it through verbatim.");
+
+                    Expand(RawToken, value, r.ProcessorQuoter).ShouldBe(
+                        sql,
+                        $"{dialect.Id}: $(x) mangled RawSql instead of passing it through verbatim.");
+                }
+            });
+        }
+
+        /// <summary>
+        /// <c>$[x]</c> and <c>Insert</c>/<c>Update</c>/<c>Delete</c> must render an identical literal
+        /// for the same value, because both mean "this value as SQL data" and both terminate in
+        /// <see cref="IQuoter.QuoteValue"/>.
+        /// </summary>
+        /// <remarks>
+        /// Guards against the two paths drifting apart, e.g. if the token path were changed to use a
+        /// different quoter or to pre-format values. It cannot catch a defect *inside* a shared
+        /// quoter - see <see cref="RawSql_RoundTripsVerbatim"/> for that.
+        /// </remarks>
+        [TestCaseSource(nameof(DialectCases))]
+        public void SafeToken_Agrees_With_QuoteValue(DialectCase dialect)
+        {
+            using var r = Resolve(dialect);
+
+            Assert.Multiple(() =>
+            {
+                foreach (var v in ValueCases())
+                {
+                    Expand(SafeToken, v.Value, r.ProcessorQuoter).ShouldBe(
+                        QuoteValueOrThrow(r.GeneratorQuoter, v.Value),
+                        $"{dialect.Id} / {v.Label}: $[x] and Insert/Update/Delete disagree.");
+                }
+            });
+        }
+
+        /// <summary>
+        /// Token substitution reads <c>processor.Quoter</c> while DML generation reads
+        /// <c>generator.Quoter</c>. If a processor shadows <c>ProcessorBase.Quoter</c> with a
+        /// separately registered instance, the two paths diverge silently.
+        /// </summary>
+        [TestCaseSource(nameof(DialectCases))]
+        public void ProcessorQuoter_Subsumes_GeneratorQuoter(DialectCase dialect)
+        {
+            using var r = Resolve(dialect);
+
+            r.ProcessorQuoter.GetType().ShouldBe(
+                r.GeneratorQuoter.GetType(),
+                $"{dialect.Id}: token substitution uses processor.Quoter but DML uses generator.Quoter; " +
+                "these must agree or $[x] and Insert/Update/Delete will render the same value differently.");
+
+            // Type equality is necessary but not sufficient: two same-typed quoters can carry
+            // different switch state, e.g. SQLiteQuoter(binaryGuid: true) vs (false).
+            Assert.Multiple(() =>
+            {
+                foreach (var v in ValueCases())
+                {
+                    QuoteValueOrThrow(r.ProcessorQuoter, v.Value).ShouldBe(
+                        QuoteValueOrThrow(r.GeneratorQuoter, v.Value),
+                        $"{dialect.Id} / {v.Label}: processor and generator quoters disagree.");
+                }
+            });
+        }
+
+        /// <summary>
+        /// <c>ITypeMap</c> is orthogonal to token expansion by construction - the replacer never
+        /// receives one. Pinned so a refactor cannot quietly couple them.
+        /// </summary>
+        [TestCaseSource(nameof(TypeMapVariantCases))]
+        public void TypeMapSwitch_DoesNotAffect_TokenExpansion(DialectCase variant, DialectCase baseline)
+        {
+            using var a = Resolve(variant);
+            using var b = Resolve(baseline);
+
+            RenderBody(variant, a).ShouldBe(
+                RenderBody(baseline, b),
+                $"{variant.Id} differs from {baseline.Id} only by an ITypeMap switch, " +
+                "which must not influence token expansion.");
+        }
+
+        /// <summary>
+        /// The matrix rows without the dialect-specific heading, for comparing two configurations.
+        /// </summary>
+        private static string RenderBody(DialectCase dialect, Resolved r)
+        {
+            var full = RenderMatrix(dialect, r);
+            var marker = "| value |";
+            var index = full.IndexOf(marker, StringComparison.Ordinal);
+            return index < 0 ? full : full.Substring(index);
+        }
+
+        private static IEnumerable<TestCaseData> TypeMapVariantCases()
+        {
+            var all = DialectCases().ToDictionary(d => d.Id);
+
+            foreach (var d in all.Values.Where(d => d.TypeMapVariantOf != null))
+            {
+                if (all.TryGetValue(d.TypeMapVariantOf, out var baseline))
+                {
+                    yield return new TestCaseData(d, baseline).SetName($"TypeMapSwitch_{d.Id}_vs_{d.TypeMapVariantOf}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Neither token style may depend on <see cref="CultureInfo.CurrentCulture"/>. #2324 fixed
+        /// <c>$(x)</c> via <c>IFormattable</c> + <c>InvariantCulture</c>; the <c>$[x]</c> no-quoter
+        /// fallback still calls plain <c>ToString()</c>.
+        /// </summary>
+        [TestCaseSource(nameof(DialectCases))]
+        public void TokenMatrix_IsCultureInvariant(DialectCase dialect)
+        {
+            using var r = Resolve(dialect);
+
+            var original = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+                var enUs = RenderBody(dialect, r);
+
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+                var deDe = RenderBody(dialect, r);
+
+                deDe.ShouldBe(enUs, $"{dialect.Id}: token expansion is culture-sensitive.");
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = original;
+            }
+        }
+
+        /// <summary>
+        /// Escape and miss handling is orthogonal to both the value and the dialect axes, so it gets
+        /// one small fixture rather than a full cross-product.
+        /// </summary>
+        [TestCase("$$((x))", "$(x)")]
+        [TestCase("$$[[x]]", "$[x]")]
+        [TestCase("$(unknown)", "$(unknown)")]
+        [TestCase("$[unknown]", "$[unknown]")]
+        public void EscapeAndMissForms_AreDialectIndependent(string template, string expected)
+        {
+            var parameters = Params(RawSql.Insert("CURRENT_TIMESTAMP"));
+
+            Assert.Multiple(() =>
+            {
+                foreach (var dialect in DialectCases())
+                {
+                    using var r = Resolve(dialect);
+
+                    SqlScriptTokenReplacer.ReplaceSqlScriptTokens(template, parameters, r.ProcessorQuoter)
+                        .ShouldBe(expected, $"{dialect.Id}: escape/miss handling should not vary by dialect.");
+                }
+            });
+        }
+    }
+}

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/VerifySetUpFixture.cs
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/VerifySetUpFixture.cs
@@ -1,0 +1,41 @@
+#region License
+// Copyright (c) 2018, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using DiffEngine;
+
+using NUnit.Framework;
+
+namespace FluentMigrator.Tests.Unit.TokenSubstitution
+{
+    /// <summary>
+    /// Verify configuration for the token substitution snapshots.
+    /// </summary>
+    /// <remarks>
+    /// Uses a <see cref="SetUpFixtureAttribute"/> rather than a <c>[ModuleInitializer]</c> so the
+    /// hook works identically on <c>net48</c> and <c>net8.0</c> without a polyfill.
+    /// </remarks>
+    [SetUpFixture]
+    public class VerifySetUpFixture
+    {
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            // Never try to pop a diff tool: this fixture runs unattended on CI and, when the
+            // snapshots are intentionally stale (see the "failing matrix" commit), locally too.
+            DiffRunner.Disabled = true;
+        }
+    }
+}


### PR DESCRIPTION
Claude `claude-opus-5[1m]` opening on behalf of @jzabroski.

**Stacked on #2344** — review that one first. Per @hopkienne's note, the `MySqlQuoter` backslash fix has been split into its own PR with a focused DML reproducer, since it affects the quoting path independently of script-token replacement. This PR targets that branch because `RawSql_RoundTripsVerbatim` cannot be green until it lands; once #2344 merges, this rebases onto `main` and that commit drops out as already-upstream.

Builds on #2333. That PR fixed the `$(name)` + `RawSql` case reported in #2332; this one adds the coverage that would have caught it, and fixes the remaining defects that coverage found.

Two commits, deliberately staged so the second commit's diff *is* the list of behaviour changes:

1. **`00aebcf`** adds the matrix and commits snapshots of behaviour **as it stands on `main`, defects included**. 48 tests fail.
2. **`6dc23cf`** applies the fixes and regenerates the snapshots. 0 fail.

## The matrix

Per #2336. `SqlScriptTokenReplacer` is reached from `Execute.Sql` / `Execute.Script`, which pass `processor?.Quoter`, so token output depends on the whole DI graph. The axes — token style, quoter presence, value type, ~30 `Add*()` registrations, and the orthogonal `IQuoter` / `ITypeMap` / `IGenerator` switches — multiply out to roughly 35,000 combinations.

Rather than generate 35,000 NUnit cases, the configuration axes become `TestCaseSource` and the value × token-style grid becomes a Verify snapshot rendered as a markdown table. A regression is a one-cell diff naming the dialect, the value and the token style.

`TokenSubstitutionMatrix.md` sits beside the fixture and documents every axis and assertion; the fixture's XML docs point at it.

199 tests across 7 assertions:

| Test | Claim |
|---|---|
| `TokenMatrix_IsStable` | Golden markdown table per dialect family |
| `RawSql_RoundTripsVerbatim` | `RawSql` reaches the database byte-for-byte through every quoter and both token styles |
| `SafeToken_Agrees_With_QuoteValue` | `$[x]` and `Insert`/`Update`/`Delete` render an identical literal |
| `ProcessorQuoter_Subsumes_GeneratorQuoter` | `processor.Quoter` and `generator.Quoter` agree |
| `TypeMapSwitch_DoesNotAffect_TokenExpansion` | Flipping only an `ITypeMap` switch moves no cell |
| `TokenMatrix_IsCultureInvariant` | Identical under `en-US` and `de-DE` |
| `EscapeAndMissForms_AreDialectIndependent` | `$$((x))`, `$$[[x]]`, unmatched tokens |

## What it found

**`MySqlQuoter` corrupts `RawSql` — fixes #2335.** `QuoteValue` applied string-literal backslash escaping to the value returned by `GenericQuoter.QuoteValue`, which for `RawSql` is a verbatim passthrough:

```
RawSql.Insert(@"c REGEXP '\d+'")  ->  c REGEXP '\\d+'
```

This is not token-specific — `Insert`, `Update` and `Delete` all terminate in `Quoter.QuoteValue`, so `Update.Set(new { flagged = RawSql.Insert(@"c REGEXP '\d+'") })` emitted corrupted SQL too. It has shipped in every release since 3.0.0.

**The `$[name]` no-quoter fallback produced wrong-typed and culture-dependent SQL.** It stringified every value with the ambient culture and wrapped the result in quotes:

| Value | before | after |
|---|---|---|
| `DBNull.Value` | `''` | `NULL` |
| `true` | `'True'` | `1` |
| `1234.5678d` | `'1234.5678'` | `1234.5678` |
| `new byte[]{0xDE,0xAD}` | `'System.Byte[]'` | `0xdead` |
| `DateTime` | `'7/28/2026 1:45:06 PM'` | `'2026-07-28T13:45:06'` |
| `RawSql` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` |

`'System.Byte[]'` and `''`-instead-of-`NULL` are silent data corruption. Under `de-DE` the same fallback emitted `'1234,5678'` — #2324 fixed the culture handling for `$(name)` but the `$[name]` fallback was left behind, which is why `TokenMatrix_IsCultureInvariant` failed for all 45 dialect cases.

The fallback now mirrors `GenericQuoter.QuoteValue`. That logic cannot be referenced from `FluentMigrator.Abstractions`, so the duplication is deliberate; `SafeToken_Agrees_With_QuoteValue` is what holds the two in sync.

**Documentation.** The XML doc claimed `$[name]` renders values "as a safely quoted SQL literal … treated as data instead of raw SQL". Not true for `RawSql`, which is exempt from quoting in both token styles by design. Now stated explicitly, because it determines whether `$[name]` can be relied on as an injection boundary. It can — for every value type except `RawSql`, where the caller has already accepted responsibility.

## Two claims from the #2332 analysis that this disproved

Both were asserted before being measured, and are recorded in `BASELINE-FAILURES.md` so the record is straight:

1. **`SqlServerProcessor` / `Db2Processor` were predicted to fail `ProcessorQuoter_Subsumes_GeneratorQuoter`.** They do not. Both declare `public new IQuoter Quoter`, but the shadowing property and the generator resolve the same scoped instance, so the paths agree across every registration. The test passes and is kept as a regression guard.

2. **`SafeToken_Agrees_With_QuoteValue` was predicted to catch #2335.** It cannot — both sides run through the same `MySqlQuoter` and agree on the corrupted value. Catching a defect *inside* a shared component needs an absolute assertion, which is why `RawSql_RoundTripsVerbatim` was added. That one catches it, on exactly the 3 MySQL cases.

## Dependency change

`Verify.NUnit` 31.27.0 requires NUnit ≥ 4.6.1, so the central NUnit pin moves 4.3.2 → 4.6.1. Verify.NUnit ships a `net48` target, so the Windows TFM for `FluentMigrator.Tests` is unaffected.

## Results

```
Matrix:      199 passed,    0 failed
Full suite: 5406 passed,  940 skipped,  0 failed   (net48)
```

## Reviewer notes

- **`$(x)` still renders a `DateTime` as `07/28/2026 13:45:06`.** Invariant, but not a portable SQL datetime literal. The raw token style is documented as verbatim `ToString()`, so this is consistent; left alone and noted in #2336 rather than changed here.
- **`SystemMethods` now throws from the no-quoter fallback** instead of emitting `'CurrentDateTime'`, matching `GenericQuoter.FormatSystemMethods`. A string literal there was never valid SQL, but it is a behaviour change and worth a second opinion.
- **Only `net48` was executed locally** (the repo lives on a WSL share; the net8.0 TFM needs a Linux host or a local checkout). CI covers the rest.
- The 7 `*.verified.md` files are large but are meant to be read — they are the human-readable form of the matrix.

Closes #2335.
Addresses #2336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

