### PR TITLE
Fix duplicate net8.0 target in Runner.Core breaking VS restore

### DIFF
--- a/src/FluentMigrator.Runner.Core/FluentMigrator.Runner.Core.csproj
+++ b/src/FluentMigrator.Runner.Core/FluentMigrator.Runner.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
     <Description>FluentMigrator is a database migration framework for .NET written in C#. The basic idea is that you can create migrations which are simply classes that derive from the Migration base class and have a Migration attribute with a unique version number attached to them. Upon executing FluentMigrator, you tell it which version to migrate to and it will run all necessary migrations in order to bring your database up to that version. In addition to forward migration support, FluentMigrator also supports different ways to execute the migrations along with selective migrations called profiles and executing arbitrary SQL.</Description>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\FluentMigrator.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
# Fix duplicate `net8.0` in FluentMigrator.Runner.Core target frameworks (Visual Studio restore failure)

## Summary

`FluentMigrator.Runner.Core` declares `net8.0` in its `<TargetFrameworks>` **and** imports `TrimAot.props`, which appends `net8.0` a second time. The effective value becomes `net48;netstandard2.0;net8.0;net8.0`.

The CLI (`dotnet build` / `dotnet restore`) tolerates the duplicate, so the issue is invisible in command-line and CI builds. Visual Studio's NuGet restore, however, deduplicates the target-framework aliases and then compares them against the raw original list. The lengths no longer match, and restore fails with:

```
Error occurred while restoring NuGet packages: Invalid restore input.
The original target frameworks value must match the aliases.
Original target frameworks: net48;netstandard2.0;net8.0;net8.0,
aliases: net48;netstandard2.0;net8.0.
Input files: ...\src\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj.
```

## Root cause

`TrimAot.props` (imported by every trimmable/AOT-capable library) is responsible for adding the `net8.0` target:

```xml
<!-- TrimAot.props -->
<TargetFrameworks>$(TargetFrameworks);net8.0</TargetFrameworks>
```

Every other project that imports it declares only the base frameworks and lets the import add `net8.0`:

`FluentMigrator.Runner.Core` was the only project that also listed `net8.0` in its base line, so the import produced a duplicate.

## Fix

Remove the redundant `net8.0` from the project's base `<TargetFrameworks>` so it follows the same pattern as every other project and lets `TrimAot.props` add the single `net8.0`.

```diff
-    <TargetFrameworks>net48;netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
```

## Verification

- `dotnet msbuild src/FluentMigrator.Runner.Core/FluentMigrator.Runner.Core.csproj -getProperty:TargetFrameworks`
  → `net48;netstandard2.0;net8.0` (no duplicate)
- Visual Studio NuGet restore no longer reports the error
