### PR TITLE
Add FM0003 for double-quoted SQL tokens; fix FM0002 code fix corrupting quoted literals

### DIFF
--- a/src/FluentMigrator.Analyzers/Analysis/ExecuteSqlLiteral.cs
+++ b/src/FluentMigrator.Analyzers/Analysis/ExecuteSqlLiteral.cs
@@ -1,0 +1,165 @@
+#region License
+// Copyright (c) 2024, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace FluentMigrator.Analyzers.Analysis
+{
+    /// <summary>
+    /// A matched substitution token, carrying both its position in the SQL text and its span in the
+    /// C# source.
+    /// </summary>
+    internal readonly struct SqlTokenMatch
+    {
+        public SqlTokenMatch(string text, int sqlIndex, int sourceStart, int sourceLength)
+        {
+            Text = text;
+            SqlIndex = sqlIndex;
+            SourceStart = sourceStart;
+            SourceLength = sourceLength;
+        }
+
+        /// <summary>Gets the matched token, for example <c>$[name]</c>.</summary>
+        public string Text { get; }
+
+        /// <summary>Gets the index of the token within the SQL statement.</summary>
+        public int SqlIndex { get; }
+
+        /// <summary>Gets the start of the token within the C# source file.</summary>
+        public int SourceStart { get; }
+
+        /// <summary>Gets the length of the token within the C# source file.</summary>
+        public int SourceLength { get; }
+    }
+
+    /// <summary>
+    /// Locates <c>Execute.Sql("...")</c> invocations and the substitution tokens inside them.
+    /// </summary>
+    internal static class ExecuteSqlLiteral
+    {
+        /// <summary>
+        /// Tries to get the string literal argument of an <c>Execute.Sql(...)</c> invocation.
+        /// </summary>
+        /// <param name="invocation">The candidate invocation</param>
+        /// <param name="semanticModel">The semantic model</param>
+        /// <param name="executeExpressionRootType">The <c>IExecuteExpressionRoot</c> symbol</param>
+        /// <param name="cancellationToken">A cancellation token</param>
+        /// <param name="literal">The SQL string literal, when matched</param>
+        /// <returns><see langword="true"/> when the invocation is an <c>Execute.Sql(...)</c> call with a literal argument</returns>
+        public static bool TryGetSqlLiteral(
+            InvocationExpressionSyntax invocation,
+            SemanticModel semanticModel,
+            INamedTypeSymbol executeExpressionRootType,
+            System.Threading.CancellationToken cancellationToken,
+            out LiteralExpressionSyntax literal)
+        {
+            literal = null;
+
+            if (executeExpressionRootType == null)
+            {
+                return false;
+            }
+
+            if (!(semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is IMethodSymbol methodSymbol) ||
+                methodSymbol.Name != "Sql")
+            {
+                return false;
+            }
+
+            if (!IsSqlExecuteMethod(methodSymbol, executeExpressionRootType))
+            {
+                return false;
+            }
+
+            // The SQL statement is always the first argument of the `Sql(...)` overloads.
+            var sqlArgument = invocation.ArgumentList?.Arguments.FirstOrDefault();
+            if (!(sqlArgument?.Expression is LiteralExpressionSyntax candidate) ||
+                !candidate.IsKind(SyntaxKind.StringLiteralExpression))
+            {
+                return false;
+            }
+
+            literal = candidate;
+            return true;
+        }
+
+        /// <summary>
+        /// Matches <paramref name="pattern"/> against the SQL a literal actually produces, while
+        /// reporting spans in the C# source.
+        /// </summary>
+        /// <param name="token">The C# string literal token</param>
+        /// <param name="pattern">The token pattern to match</param>
+        /// <returns>The matches, in order</returns>
+        /// <remarks>
+        /// <para>
+        /// Matching runs against <see cref="SyntaxToken.ValueText"/> so that the scanner sees the SQL
+        /// as the runtime will, rather than the C# source with its own quoting and escapes. Spans are
+        /// recovered by matching the same pattern against <see cref="SyntaxToken.Text"/> and pairing
+        /// the two sequences positionally.
+        /// </para>
+        /// <para>
+        /// The pairing holds because substitution tokens contain no character that C# escaping can
+        /// introduce or remove. If the two match counts ever disagree - which needs something like
+        /// <c>"$[name]"</c> - no matches are reported rather than risk pointing a diagnostic at
+        /// the wrong span.
+        /// </para>
+        /// </remarks>
+        public static IReadOnlyList<SqlTokenMatch> MatchTokens(SyntaxToken token, Regex pattern)
+        {
+            var sqlMatches = pattern.Matches(token.ValueText);
+            var sourceMatches = pattern.Matches(token.Text);
+
+            if (sqlMatches.Count != sourceMatches.Count)
+            {
+                return new SqlTokenMatch[0];
+            }
+
+            var results = new List<SqlTokenMatch>(sqlMatches.Count);
+            for (var i = 0; i < sqlMatches.Count; i++)
+            {
+                results.Add(new SqlTokenMatch(
+                    sqlMatches[i].Value,
+                    sqlMatches[i].Index,
+                    token.SpanStart + sourceMatches[i].Index,
+                    sourceMatches[i].Length));
+            }
+
+            return results;
+        }
+
+        private static bool IsSqlExecuteMethod(IMethodSymbol methodSymbol, INamedTypeSymbol executeExpressionRootType)
+        {
+            var containingType = methodSymbol.ContainingType;
+            if (containingType == null)
+            {
+                return false;
+            }
+
+            if (SymbolEqualityComparer.Default.Equals(containingType, executeExpressionRootType))
+            {
+                return true;
+            }
+
+            return containingType.AllInterfaces.Contains(executeExpressionRootType, SymbolEqualityComparer.Default);
+        }
+    }
+}

--- a/src/FluentMigrator.Analyzers/Analysis/SqlDialect.cs
+++ b/src/FluentMigrator.Analyzers/Analysis/SqlDialect.cs
@@ -1,0 +1,64 @@
+#region License
+// Copyright (c) 2024, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace FluentMigrator.Analyzers.Analysis
+{
+    /// <summary>
+    /// The SQL dialect a statement is written for, insofar as an analyzer can determine it.
+    /// </summary>
+    /// <remarks>
+    /// Only the distinctions that change <em>string literal lexing</em> are modelled. Version
+    /// variants collapse into their family, because no supported version of any family changes how a
+    /// literal is delimited.
+    /// </remarks>
+    public enum SqlDialect
+    {
+        /// <summary>
+        /// The dialect could not be determined. Only dialect-independent diagnostics are reported.
+        /// </summary>
+        Unknown = 0,
+
+        /// <summary>Microsoft SQL Server (T-SQL).</summary>
+        SqlServer,
+
+        /// <summary>PostgreSQL.</summary>
+        Postgres,
+
+        /// <summary>Amazon Redshift. Postgres-derived, but without dollar quoting.</summary>
+        Redshift,
+
+        /// <summary>MySQL or MariaDB.</summary>
+        MySql,
+
+        /// <summary>Oracle Database.</summary>
+        Oracle,
+
+        /// <summary>SQLite.</summary>
+        SQLite,
+
+        /// <summary>Firebird.</summary>
+        Firebird,
+
+        /// <summary>IBM Db2, including iSeries.</summary>
+        Db2,
+
+        /// <summary>SAP HANA.</summary>
+        Hana,
+
+        /// <summary>Snowflake.</summary>
+        Snowflake,
+    }
+}

--- a/src/FluentMigrator.Analyzers/Analysis/SqlDialectResolver.cs
+++ b/src/FluentMigrator.Analyzers/Analysis/SqlDialectResolver.cs
@@ -1,0 +1,275 @@
+#region License
+// Copyright (c) 2024, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FluentMigrator.Analyzers.Analysis
+{
+    /// <summary>
+    /// Determines which <see cref="SqlDialect"/> a SQL statement is written for.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Two signals are available to a compile-time analyzer, in precedence order:
+    /// </para>
+    /// <list type="number">
+    /// <item>
+    /// <description>
+    /// An <c>IfDatabase("...")</c> call in the receiver chain of the statement. This is the most
+    /// specific signal available and scopes to exactly the statements it guards.
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <description>
+    /// The <c>fluent_migrator_sql_dialect</c> <c>.editorconfig</c> key, which applies to a whole
+    /// file, directory or project.
+    /// </description>
+    /// </item>
+    /// </list>
+    /// <para>
+    /// Referenced runner packages are deliberately <em>not</em> used as a signal. Projects routinely
+    /// reference several providers, so the inference would be wrong more often than useful.
+    /// </para>
+    /// </remarks>
+    internal static class SqlDialectResolver
+    {
+        /// <summary>
+        /// The <c>.editorconfig</c> key that pins the dialect for a file, directory or project.
+        /// </summary>
+        internal const string EditorConfigKey = "fluent_migrator_sql_dialect";
+
+        private const string IfDatabaseMethodName = "IfDatabase";
+
+        /// <summary>
+        /// Resolves the dialect for a specific <c>Sql(...)</c> invocation.
+        /// </summary>
+        /// <param name="invocation">The invocation being analyzed</param>
+        /// <param name="options">The analyzer options carrying <c>.editorconfig</c> values</param>
+        /// <returns>The resolved dialect, or <see cref="SqlDialect.Unknown"/> when neither signal applies</returns>
+        public static SqlDialect Resolve(InvocationExpressionSyntax invocation, AnalyzerOptions options)
+        {
+            var fromIfDatabase = FromIfDatabase(invocation);
+            if (fromIfDatabase != SqlDialect.Unknown)
+            {
+                return fromIfDatabase;
+            }
+
+            return FromEditorConfig(invocation, options);
+        }
+
+        /// <summary>
+        /// Walks the receiver chain looking for <c>IfDatabase("...")</c>.
+        /// </summary>
+        /// <remarks>
+        /// Matches the common shape <c>IfDatabase("Postgres").Execute.Sql("...")</c>. When
+        /// <c>IfDatabase</c> names more than one database, the dialect is only resolved if every
+        /// name maps to the same dialect - <c>IfDatabase("SqlServer2012", "SqlServer2016")</c>
+        /// resolves, <c>IfDatabase("SqlServer", "Postgres")</c> does not. Predicate-based overloads
+        /// carry no usable name and are ignored.
+        /// </remarks>
+        private static SqlDialect FromIfDatabase(InvocationExpressionSyntax invocation)
+        {
+            ExpressionSyntax current = invocation;
+
+            while (current != null)
+            {
+                switch (current)
+                {
+                    case InvocationExpressionSyntax candidate:
+                        if (GetMethodName(candidate) == IfDatabaseMethodName)
+                        {
+                            return FromIfDatabaseArguments(candidate);
+                        }
+
+                        current = candidate.Expression;
+                        break;
+
+                    case MemberAccessExpressionSyntax memberAccess:
+                        current = memberAccess.Expression;
+                        break;
+
+                    case ParenthesizedExpressionSyntax parenthesized:
+                        current = parenthesized.Expression;
+                        break;
+
+                    default:
+                        return SqlDialect.Unknown;
+                }
+            }
+
+            return SqlDialect.Unknown;
+        }
+
+        private static SqlDialect FromIfDatabaseArguments(InvocationExpressionSyntax ifDatabase)
+        {
+            var arguments = ifDatabase.ArgumentList?.Arguments;
+            if (arguments == null || arguments.Value.Count == 0)
+            {
+                return SqlDialect.Unknown;
+            }
+
+            var resolved = SqlDialect.Unknown;
+
+            foreach (var argument in arguments.Value)
+            {
+                if (!(argument.Expression is LiteralExpressionSyntax literal) ||
+                    !literal.IsKind(SyntaxKind.StringLiteralExpression))
+                {
+                    // A predicate overload, a constant reference, or anything else we cannot read.
+                    return SqlDialect.Unknown;
+                }
+
+                var dialect = FromProcessorId(literal.Token.ValueText);
+                if (dialect == SqlDialect.Unknown)
+                {
+                    return SqlDialect.Unknown;
+                }
+
+                if (resolved == SqlDialect.Unknown)
+                {
+                    resolved = dialect;
+                }
+                else if (resolved != dialect)
+                {
+                    // Guarded for several dialects at once; nothing dialect-specific is safe.
+                    return SqlDialect.Unknown;
+                }
+            }
+
+            return resolved;
+        }
+
+        private static SqlDialect FromEditorConfig(SyntaxNode node, AnalyzerOptions options)
+        {
+            var tree = node?.SyntaxTree;
+            if (tree == null || options == null)
+            {
+                return SqlDialect.Unknown;
+            }
+
+            var configOptions = options.AnalyzerConfigOptionsProvider.GetOptions(tree);
+            if (!configOptions.TryGetValue(EditorConfigKey, out var value))
+            {
+                return SqlDialect.Unknown;
+            }
+
+            return FromProcessorId(value);
+        }
+
+        /// <summary>
+        /// Maps a FluentMigrator processor id, or an <c>.editorconfig</c> value, onto a dialect.
+        /// </summary>
+        /// <remarks>
+        /// Accepts the <c>ProcessorIdConstants</c> spellings that <c>IfDatabase</c> takes, including
+        /// version-suffixed variants, since no supported version changes literal lexing.
+        /// </remarks>
+        internal static SqlDialect FromProcessorId(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return SqlDialect.Unknown;
+            }
+
+            var normalized = value.Trim().Replace(" ", string.Empty).Replace("-", string.Empty).ToUpperInvariant();
+
+            if (StartsWithAny(normalized, "SQLSERVER", "MSSQL", "TSQL"))
+            {
+                return SqlDialect.SqlServer;
+            }
+
+            // Checked before POSTGRES: Redshift is Postgres-derived but has no dollar quoting.
+            if (StartsWithAny(normalized, "REDSHIFT"))
+            {
+                return SqlDialect.Redshift;
+            }
+
+            if (StartsWithAny(normalized, "POSTGRES", "PGSQL"))
+            {
+                return SqlDialect.Postgres;
+            }
+
+            if (StartsWithAny(normalized, "MYSQL", "MARIADB"))
+            {
+                return SqlDialect.MySql;
+            }
+
+            if (StartsWithAny(normalized, "ORACLE", "DOTCONNECTORACLE"))
+            {
+                return SqlDialect.Oracle;
+            }
+
+            if (StartsWithAny(normalized, "SQLITE"))
+            {
+                return SqlDialect.SQLite;
+            }
+
+            if (StartsWithAny(normalized, "FIREBIRD"))
+            {
+                return SqlDialect.Firebird;
+            }
+
+            if (StartsWithAny(normalized, "DB2", "IBMDB2"))
+            {
+                return SqlDialect.Db2;
+            }
+
+            if (StartsWithAny(normalized, "HANA"))
+            {
+                return SqlDialect.Hana;
+            }
+
+            if (StartsWithAny(normalized, "SNOWFLAKE"))
+            {
+                return SqlDialect.Snowflake;
+            }
+
+            return SqlDialect.Unknown;
+        }
+
+        private static bool StartsWithAny(string value, params string[] prefixes)
+        {
+            foreach (var prefix in prefixes)
+            {
+                if (value.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static string GetMethodName(InvocationExpressionSyntax invocation)
+        {
+            switch (invocation.Expression)
+            {
+                case MemberAccessExpressionSyntax memberAccess:
+                    return memberAccess.Name.Identifier.ValueText;
+                case IdentifierNameSyntax identifier:
+                    return identifier.Identifier.ValueText;
+                case GenericNameSyntax generic:
+                    return generic.Identifier.ValueText;
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/src/FluentMigrator.Analyzers/Analysis/SqlLiteralScanner.cs
+++ b/src/FluentMigrator.Analyzers/Analysis/SqlLiteralScanner.cs
@@ -1,0 +1,450 @@
+#region License
+// Copyright (c) 2024, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+
+namespace FluentMigrator.Analyzers.Analysis
+{
+    /// <summary>
+    /// What kind of region a position in a SQL statement falls in.
+    /// </summary>
+    internal enum SqlRegionKind
+    {
+        /// <summary>Ordinary SQL code.</summary>
+        Code,
+
+        /// <summary>A single-quoted string literal, including any prefixed form such as <c>N'...'</c>.</summary>
+        StringLiteral,
+
+        /// <summary>A double-quoted run that this dialect treats as a string literal.</summary>
+        DoubleQuotedStringLiteral,
+
+        /// <summary>A double-quoted run that this dialect treats as a quoted identifier.</summary>
+        QuotedIdentifier,
+
+        /// <summary>
+        /// A PostgreSQL dollar-quoted block. These normally hold SQL or PL/pgSQL source rather than
+        /// data, so a quoted token inside one is not necessarily a mistake.
+        /// </summary>
+        DollarQuoted,
+
+        /// <summary>An Oracle alternative-quoted literal, <c>q'[...]'</c>.</summary>
+        AlternativeQuoted,
+
+        /// <summary>A line (<c>--</c>) or block (<c>/* */</c>) comment.</summary>
+        Comment,
+    }
+
+    /// <summary>
+    /// The region enclosing a position, and the syntax that opened it.
+    /// </summary>
+    internal readonly struct SqlRegion
+    {
+        public SqlRegion(SqlRegionKind kind, int start, int end, string opener)
+        {
+            Kind = kind;
+            Start = start;
+            End = end;
+            Opener = opener;
+        }
+
+        /// <summary>Gets the kind of region.</summary>
+        public SqlRegionKind Kind { get; }
+
+        /// <summary>Gets the index at which the region's opening delimiter starts.</summary>
+        public int Start { get; }
+
+        /// <summary>Gets the index just past the region's closing delimiter.</summary>
+        public int End { get; }
+
+        /// <summary>Gets the index of the first character of the region's content.</summary>
+        public int ContentStart => Start + (Opener?.Length ?? 0);
+
+        /// <summary>
+        /// Gets the opening delimiter as written, including any prefix - for example <c>'</c>,
+        /// <c>N'</c>, <c>E'</c>, <c>_utf8mb4'</c>, <c>q'[</c> or <c>$tag$</c>.
+        /// </summary>
+        public string Opener { get; }
+    }
+
+    /// <summary>
+    /// A single-pass scanner that answers one question: which region encloses a given index?
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is deliberately not a SQL parser. It tracks only what is needed to decide whether a
+    /// substitution token sits inside a string literal, which means it must model per-dialect escape
+    /// behaviour as lexer state - see <see cref="SqlLiteralSyntax"/> for why backslash handling
+    /// cannot be deferred to a later phase.
+    /// </para>
+    /// <para>
+    /// Where a construct cannot be resolved from the text alone (SQLite's schema-dependent double
+    /// quotes, any session-flippable mode), the scanner reports the region kind it can prove and
+    /// leaves the decision about whether to report a diagnostic to the caller.
+    /// </para>
+    /// </remarks>
+    internal static class SqlLiteralScanner
+    {
+        /// <summary>
+        /// Finds the region enclosing <paramref name="index"/>.
+        /// </summary>
+        /// <param name="sql">The SQL statement text</param>
+        /// <param name="index">The index to classify</param>
+        /// <param name="syntax">The dialect's literal rules</param>
+        /// <returns>The enclosing region</returns>
+        public static SqlRegion GetRegionAt(string sql, int index, SqlLiteralSyntax syntax)
+        {
+            if (sql == null)
+            {
+                throw new ArgumentNullException(nameof(sql));
+            }
+
+            if (syntax == null)
+            {
+                throw new ArgumentNullException(nameof(syntax));
+            }
+
+            var position = 0;
+            while (position < sql.Length && position <= index)
+            {
+                var c = sql[position];
+
+                // --- comments ---------------------------------------------------------------
+                if (c == '-' && Peek(sql, position + 1) == '-')
+                {
+                    var end = EndOfLine(sql, position);
+                    if (index < end)
+                    {
+                        return new SqlRegion(SqlRegionKind.Comment, position, end, "--");
+                    }
+
+                    position = end;
+                    continue;
+                }
+
+                if (c == '/' && Peek(sql, position + 1) == '*')
+                {
+                    var end = sql.IndexOf("*/", position + 2, StringComparison.Ordinal);
+                    end = end < 0 ? sql.Length : end + 2;
+                    if (index < end)
+                    {
+                        return new SqlRegion(SqlRegionKind.Comment, position, end, "/*");
+                    }
+
+                    position = end;
+                    continue;
+                }
+
+                // --- PostgreSQL dollar quoting ----------------------------------------------
+                // Must be checked before anything else that could consume a '$', and the closing
+                // tag must match the opening tag exactly.
+                if (syntax.DollarQuoting && c == '$')
+                {
+                    var tag = ReadDollarTag(sql, position);
+                    if (tag != null)
+                    {
+                        var bodyStart = position + tag.Length;
+                        var close = sql.IndexOf(tag, bodyStart, StringComparison.Ordinal);
+                        var bodyEnd = close < 0 ? sql.Length : close;
+                        var end = close < 0 ? sql.Length : close + tag.Length;
+
+                        if (index < end)
+                        {
+                            // A dollar-quoted block holds SQL or PL/pgSQL source, not data, so the
+                            // body is scanned as SQL in its own right. A literal nested inside one is
+                            // still a literal, and a token inside that is still quoted twice.
+                            if (index >= bodyStart && index < bodyEnd)
+                            {
+                                var body = sql.Substring(bodyStart, bodyEnd - bodyStart);
+                                var inner = GetRegionAt(body, index - bodyStart, syntax);
+
+                                if (inner.Kind != SqlRegionKind.Code)
+                                {
+                                    return new SqlRegion(
+                                        inner.Kind,
+                                        inner.Start + bodyStart,
+                                        inner.End + bodyStart,
+                                        inner.Opener);
+                                }
+                            }
+
+                            return new SqlRegion(SqlRegionKind.DollarQuoted, position, end, tag);
+                        }
+
+                        position = end;
+                        continue;
+                    }
+                }
+
+                // --- Oracle alternative quoting: q'[ ... ]' ---------------------------------
+                if (syntax.AlternativeQuoting && (c == 'q' || c == 'Q') && Peek(sql, position + 1) == '\'')
+                {
+                    var delimiter = Peek(sql, position + 2);
+                    if (delimiter != '\0')
+                    {
+                        var closer = MatchingDelimiter(delimiter);
+                        var bodyStart = position + 3;
+                        var close = IndexOfAlternativeClose(sql, bodyStart, closer);
+                        var end = close < 0 ? sql.Length : close + 2;
+                        if (index < end)
+                        {
+                            return new SqlRegion(
+                                SqlRegionKind.AlternativeQuoted,
+                                position,
+                                end,
+                                sql.Substring(position, Math.Min(3, sql.Length - position)));
+                        }
+
+                        position = end;
+                        continue;
+                    }
+                }
+
+                // --- single-quoted literals, with optional prefix ---------------------------
+                if (c == '\'')
+                {
+                    var prefixStart = ReadLiteralPrefixStart(sql, position);
+                    var end = EndOfSingleQuoted(sql, position, syntax);
+                    if (index < end)
+                    {
+                        return new SqlRegion(
+                            SqlRegionKind.StringLiteral,
+                            prefixStart,
+                            end,
+                            sql.Substring(prefixStart, position - prefixStart + 1));
+                    }
+
+                    position = end;
+                    continue;
+                }
+
+                // --- double-quoted runs -----------------------------------------------------
+                if (c == '"')
+                {
+                    var end = EndOfDoubleQuoted(sql, position, syntax);
+                    if (index < end)
+                    {
+                        var kind = syntax.DoubleQuoteIsStringLiteral
+                            ? SqlRegionKind.DoubleQuotedStringLiteral
+                            : SqlRegionKind.QuotedIdentifier;
+
+                        return new SqlRegion(kind, position, end, "\"");
+                    }
+
+                    position = end;
+                    continue;
+                }
+
+                position++;
+            }
+
+            return new SqlRegion(SqlRegionKind.Code, index, index, string.Empty);
+        }
+
+        private static char Peek(string sql, int index) =>
+            index >= 0 && index < sql.Length ? sql[index] : '\0';
+
+        private static int EndOfLine(string sql, int from)
+        {
+            var newline = sql.IndexOf('\n', from);
+            return newline < 0 ? sql.Length : newline + 1;
+        }
+
+        /// <summary>
+        /// Walks backwards over a literal prefix so the reported opener includes it - <c>N'</c>,
+        /// <c>E'</c>, <c>B'</c>, <c>X'</c>, <c>U&amp;'</c>, <c>_utf8mb4'</c>.
+        /// </summary>
+        private static int ReadLiteralPrefixStart(string sql, int quoteIndex)
+        {
+            var start = quoteIndex;
+
+            // U&'...' - the ampersand is part of the prefix.
+            if (quoteIndex >= 2 && sql[quoteIndex - 1] == '&' && (sql[quoteIndex - 2] == 'U' || sql[quoteIndex - 2] == 'u'))
+            {
+                return quoteIndex - 2;
+            }
+
+            var i = quoteIndex - 1;
+            while (i >= 0 && (char.IsLetterOrDigit(sql[i]) || sql[i] == '_'))
+            {
+                i--;
+            }
+
+            var candidateLength = quoteIndex - (i + 1);
+            if (candidateLength <= 0)
+            {
+                return start;
+            }
+
+            // Only treat the run as a prefix when it is not preceded by something that would make it
+            // an identifier, e.g. `col='x'` has no prefix but `WHERE N'x'` does.
+            if (i >= 0 && (char.IsLetterOrDigit(sql[i]) || sql[i] == '_'))
+            {
+                return start;
+            }
+
+            var candidate = sql.Substring(i + 1, candidateLength);
+            return IsKnownLiteralPrefix(candidate) ? i + 1 : start;
+        }
+
+        private static bool IsKnownLiteralPrefix(string candidate)
+        {
+            if (candidate.Length == 0)
+            {
+                return false;
+            }
+
+            // MySQL charset introducers: _utf8mb4'...', _latin1'...'
+            if (candidate[0] == '_')
+            {
+                return candidate.Length > 1;
+            }
+
+            switch (candidate.ToUpperInvariant())
+            {
+                case "N":   // national character literal - T-SQL, Oracle, MySQL, standard
+                case "E":   // PostgreSQL escape-string literal
+                case "B":   // bit-string literal
+                case "X":   // hex-string literal
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Finds the index just past the closing quote of a single-quoted literal.
+        /// </summary>
+        /// <remarks>
+        /// Handles both escaping conventions. Doubled quotes (<c>'it''s'</c>) are universal;
+        /// backslash escapes (<c>'it\'s'</c>) are MySQL-only and change where the literal ends,
+        /// which is why <see cref="SqlLiteralSyntax.BackslashEscapes"/> has to be known here rather
+        /// than at parse time.
+        /// </remarks>
+        private static int EndOfSingleQuoted(string sql, int openIndex, SqlLiteralSyntax syntax)
+        {
+            var i = openIndex + 1;
+            while (i < sql.Length)
+            {
+                var c = sql[i];
+
+                if (syntax.BackslashEscapes && c == '\\')
+                {
+                    i += 2;
+                    continue;
+                }
+
+                if (c == '\'')
+                {
+                    if (Peek(sql, i + 1) == '\'')
+                    {
+                        i += 2;
+                        continue;
+                    }
+
+                    return i + 1;
+                }
+
+                i++;
+            }
+
+            return sql.Length;
+        }
+
+        private static int EndOfDoubleQuoted(string sql, int openIndex, SqlLiteralSyntax syntax)
+        {
+            var i = openIndex + 1;
+            while (i < sql.Length)
+            {
+                var c = sql[i];
+
+                if (syntax.BackslashEscapes && c == '\\')
+                {
+                    i += 2;
+                    continue;
+                }
+
+                if (c == '"')
+                {
+                    if (Peek(sql, i + 1) == '"')
+                    {
+                        i += 2;
+                        continue;
+                    }
+
+                    return i + 1;
+                }
+
+                i++;
+            }
+
+            return sql.Length;
+        }
+
+        /// <summary>
+        /// Reads a dollar-quote tag (<c>$$</c> or <c>$tag$</c>) at <paramref name="index"/>.
+        /// </summary>
+        /// <returns>The tag including both dollar signs, or <see langword="null"/> when this is not a tag.</returns>
+        private static string ReadDollarTag(string sql, int index)
+        {
+            var i = index + 1;
+            while (i < sql.Length && (char.IsLetterOrDigit(sql[i]) || sql[i] == '_'))
+            {
+                i++;
+            }
+
+            if (i >= sql.Length || sql[i] != '$')
+            {
+                return null;
+            }
+
+            // A tag must be a valid identifier, so it cannot start with a digit. `$1$` is a
+            // positional parameter followed by other syntax, not a dollar quote.
+            var tagBody = sql.Substring(index + 1, i - index - 1);
+            if (tagBody.Length > 0 && char.IsDigit(tagBody[0]))
+            {
+                return null;
+            }
+
+            return sql.Substring(index, i - index + 1);
+        }
+
+        private static char MatchingDelimiter(char opener)
+        {
+            switch (opener)
+            {
+                case '[': return ']';
+                case '{': return '}';
+                case '(': return ')';
+                case '<': return '>';
+                default: return opener;
+            }
+        }
+
+        private static int IndexOfAlternativeClose(string sql, int from, char closer)
+        {
+            for (var i = from; i < sql.Length - 1; i++)
+            {
+                if (sql[i] == closer && sql[i + 1] == '\'')
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+    }
+}

--- a/src/FluentMigrator.Analyzers/Analysis/SqlLiteralSyntax.cs
+++ b/src/FluentMigrator.Analyzers/Analysis/SqlLiteralSyntax.cs
@@ -1,0 +1,158 @@
+#region License
+// Copyright (c) 2024, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace FluentMigrator.Analyzers.Analysis
+{
+    /// <summary>
+    /// The string-literal lexing rules of a <see cref="SqlDialect"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These are deliberately modelled as <em>lexer modes</em> rather than as parse-time concerns.
+    /// Backslash handling in particular cannot be deferred, because it changes where a literal
+    /// <em>ends</em>: <c>'\''</c> is one complete literal in MySQL's default mode and an unterminated
+    /// literal in PostgreSQL with <c>standard_conforming_strings</c> on.
+    /// </para>
+    /// <para>
+    /// Session-level settings that flip these modes (<c>NO_BACKSLASH_ESCAPES</c>, <c>ANSI_QUOTES</c>,
+    /// <c>QUOTED_IDENTIFIER</c>, <c>standard_conforming_strings</c>, <c>SQLITE_DQS</c>) are not
+    /// visible to a compile-time analyzer. Each mode below therefore encodes the <em>default</em> for
+    /// the dialect, and any diagnostic that depends on a flippable mode is reported conservatively.
+    /// </para>
+    /// </remarks>
+    internal sealed class SqlLiteralSyntax
+    {
+        private SqlLiteralSyntax(
+            SqlDialect dialect,
+            bool backslashEscapes,
+            bool doubleQuoteIsStringLiteral,
+            bool doubleQuoteIsAmbiguous,
+            bool dollarQuoting,
+            bool alternativeQuoting)
+        {
+            Dialect = dialect;
+            BackslashEscapes = backslashEscapes;
+            DoubleQuoteIsStringLiteral = doubleQuoteIsStringLiteral;
+            DoubleQuoteIsAmbiguous = doubleQuoteIsAmbiguous;
+            DollarQuoting = dollarQuoting;
+            AlternativeQuoting = alternativeQuoting;
+        }
+
+        /// <summary>
+        /// Gets the dialect these rules describe.
+        /// </summary>
+        public SqlDialect Dialect { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether a backslash escapes the next character inside a
+        /// single-quoted literal. MySQL only, and only without <c>NO_BACKSLASH_ESCAPES</c>.
+        /// </summary>
+        public bool BackslashEscapes { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether a double-quoted run is a string literal rather than a
+        /// quoted identifier. MySQL only, and only without <c>ANSI_QUOTES</c>.
+        /// </summary>
+        public bool DoubleQuoteIsStringLiteral { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether a double-quoted run may be either an identifier or a
+        /// string literal depending on whether it resolves to an identifier.
+        /// </summary>
+        /// <remarks>
+        /// SQLite's documented misfeature: <c>"foo"</c> is an identifier unless no such identifier
+        /// exists, in which case it silently degrades to a string literal. Optionally disabled with
+        /// <c>SQLITE_DQS</c>. Because the outcome depends on the schema rather than on the text, a
+        /// double-quoted run is never reported for SQLite.
+        /// </remarks>
+        public bool DoubleQuoteIsAmbiguous { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether <c>$$text$$</c> / <c>$tag$text$tag$</c> dollar quoting is
+        /// supported. PostgreSQL only.
+        /// </summary>
+        public bool DollarQuoting { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether Oracle's alternative quoting mechanism
+        /// (<c>q'[text]'</c>, <c>q'!text!'</c>) is supported.
+        /// </summary>
+        public bool AlternativeQuoting { get; }
+
+        /// <summary>
+        /// Gets the literal rules for a dialect.
+        /// </summary>
+        /// <param name="dialect">The dialect</param>
+        /// <returns>The rules</returns>
+        /// <remarks>
+        /// <see cref="SqlDialect.Unknown"/> maps to the conservative intersection: single quotes
+        /// only, doubled-quote escaping, no backslash escapes, and no dialect-specific forms. Every
+        /// dialect agrees on that core, so diagnostics derived from it need no dialect signal.
+        /// </remarks>
+        public static SqlLiteralSyntax For(SqlDialect dialect)
+        {
+            switch (dialect)
+            {
+                case SqlDialect.MySql:
+                    return new SqlLiteralSyntax(
+                        dialect,
+                        backslashEscapes: true,
+                        doubleQuoteIsStringLiteral: true,
+                        doubleQuoteIsAmbiguous: false,
+                        dollarQuoting: false,
+                        alternativeQuoting: false);
+
+                case SqlDialect.Postgres:
+                    return new SqlLiteralSyntax(
+                        dialect,
+                        backslashEscapes: false,
+                        doubleQuoteIsStringLiteral: false,
+                        doubleQuoteIsAmbiguous: false,
+                        dollarQuoting: true,
+                        alternativeQuoting: false);
+
+                case SqlDialect.Oracle:
+                    return new SqlLiteralSyntax(
+                        dialect,
+                        backslashEscapes: false,
+                        doubleQuoteIsStringLiteral: false,
+                        doubleQuoteIsAmbiguous: false,
+                        dollarQuoting: false,
+                        alternativeQuoting: true);
+
+                case SqlDialect.SQLite:
+                    return new SqlLiteralSyntax(
+                        dialect,
+                        backslashEscapes: false,
+                        doubleQuoteIsStringLiteral: false,
+                        doubleQuoteIsAmbiguous: true,
+                        dollarQuoting: false,
+                        alternativeQuoting: false);
+
+                default:
+                    // SqlServer, Redshift, Firebird, Db2, Hana, Snowflake and Unknown all share the
+                    // standard-SQL core: single quotes, doubled-quote escaping, no backslash escapes.
+                    return new SqlLiteralSyntax(
+                        dialect,
+                        backslashEscapes: false,
+                        doubleQuoteIsStringLiteral: false,
+                        doubleQuoteIsAmbiguous: false,
+                        dollarQuoting: false,
+                        alternativeQuoting: false);
+            }
+        }
+    }
+}

--- a/src/FluentMigrator.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/FluentMigrator.Analyzers/AnalyzerReleases.Unshipped.md
@@ -2,4 +2,5 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
+FM0003 | FluentMigrator | Warning | Automatically quoted token is inside a string literal
 FMUP0001 | FluentMigrator | Warning | Prefer IDictionary<string, object> over IDictionary<string, string> for Execute parameters

--- a/src/FluentMigrator.Analyzers/QuotedSqlTokenAnalyzer.cs
+++ b/src/FluentMigrator.Analyzers/QuotedSqlTokenAnalyzer.cs
@@ -1,0 +1,175 @@
+#region License
+// Copyright (c) 2024, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System.Collections.Immutable;
+using System.Text.RegularExpressions;
+
+using FluentMigrator.Analyzers.Analysis;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+namespace FluentMigrator.Analyzers
+{
+    /// <summary>
+    /// Analyzer that warns when the automatically quoted <c>$[name]</c> token appears inside a SQL
+    /// string literal, which quotes the value twice.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>$[name]</c> expands to a complete SQL literal - <c>'O''Brien'</c>, <c>NULL</c>, <c>1</c>,
+    /// <c>0xdead</c>. Wrapping it in quotes therefore produces <c>''O''Brien''</c> rather than a
+    /// string, and only the string case fails loudly:
+    /// </para>
+    /// <list type="table">
+    /// <item><description><c>"O'Brien"</c> becomes <c>''O''Brien''</c> - a syntax error</description></item>
+    /// <item><description><c>1234.5678</c> becomes <c>'1234.5678'</c> - silently a string, not a number</description></item>
+    /// <item><description><see langword="null"/> becomes <c>'NULL'</c> - silently the four-character text</description></item>
+    /// <item><description><c>RawSql</c> becomes <c>'CURRENT_TIMESTAMP'</c> - silently text, the function never runs</description></item>
+    /// </list>
+    /// <para>
+    /// The raw <c>$(name)</c> style is the opposite: wrapping it in quotes is the correct and
+    /// intended way to substitute a value into a string literal, so it is never reported here.
+    /// </para>
+    /// </remarks>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class QuotedSqlTokenAnalyzer : FluentMigratorAnalyzer
+    {
+        /// <summary>
+        /// The diagnostic ID for double-quoted SQL token warnings.
+        /// </summary>
+        public const string DiagnosticId = "FM0003";
+        private const string Category = "FluentMigrator";
+
+        /// <summary>
+        /// Matches the automatically quoted token form <c>$[name]</c>.
+        /// </summary>
+        internal static readonly Regex QuotedTokenPattern = new Regex(@"\$\[(?<token>\w+)\]", RegexOptions.Compiled);
+
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.QuotedSqlTokenAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.QuotedSqlTokenAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.QuotedSqlTokenAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
+
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
+
+        /// <summary>
+        /// Gets the set of diagnostic descriptors supported by this analyzer.
+        /// </summary>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, FluentMigratorContext fluentMigratorContext)
+        {
+            compilationStartContext.RegisterSyntaxNodeAction(
+                syntaxContext => AnalyzeInvocation(syntaxContext, fluentMigratorContext),
+                SyntaxKind.InvocationExpression);
+        }
+
+        private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context, FluentMigratorContext fluentMigratorContext)
+        {
+            var invocation = (InvocationExpressionSyntax)context.Node;
+
+            if (!ExecuteSqlLiteral.TryGetSqlLiteral(
+                    invocation,
+                    context.SemanticModel,
+                    fluentMigratorContext.ExecuteExpressionRootType,
+                    context.CancellationToken,
+                    out var literal))
+            {
+                return;
+            }
+
+            var token = literal.Token;
+            var matches = ExecuteSqlLiteral.MatchTokens(token, QuotedTokenPattern);
+            if (matches.Count == 0)
+            {
+                return;
+            }
+
+            var dialect = SqlDialectResolver.Resolve(invocation, context.Options);
+            var syntax = SqlLiteralSyntax.For(dialect);
+            var sql = token.ValueText;
+
+            foreach (var match in matches)
+            {
+                var region = SqlLiteralScanner.GetRegionAt(sql, match.SqlIndex, syntax);
+
+                if (!ShouldReport(region, syntax))
+                {
+                    continue;
+                }
+
+                var location = Location.Create(token.SyntaxTree, new TextSpan(match.SourceStart, match.SourceLength));
+                var unquoted = ToRawTokenText(match.Text);
+
+                context.ReportDiagnostic(Diagnostic.Create(Rule, location, match.Text, region.Opener, unquoted));
+            }
+        }
+
+        /// <summary>
+        /// Decides whether a token in <paramref name="region"/> is worth reporting.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately conservative in three places:
+        /// <list type="bullet">
+        /// <item>
+        /// <description>
+        /// PostgreSQL dollar-quoted blocks normally hold SQL or PL/pgSQL source rather than data, so
+        /// a quoted literal inside one is usually correct.
+        /// </description>
+        /// </item>
+        /// <item>
+        /// <description>
+        /// SQLite double quotes resolve to an identifier or a string depending on the schema, not on
+        /// the text, so the outcome is not knowable at compile time.
+        /// </description>
+        /// </item>
+        /// <item>
+        /// <description>
+        /// A double-quoted run is only a string literal in MySQL, and only without
+        /// <c>ANSI_QUOTES</c>. It is therefore reported only when the dialect is known to be MySQL.
+        /// </description>
+        /// </item>
+        /// </list>
+        /// </remarks>
+        private static bool ShouldReport(SqlRegion region, SqlLiteralSyntax syntax)
+        {
+            switch (region.Kind)
+            {
+                case SqlRegionKind.StringLiteral:
+                case SqlRegionKind.AlternativeQuoted:
+                    return true;
+
+                case SqlRegionKind.DoubleQuotedStringLiteral:
+                    return syntax.DoubleQuoteIsStringLiteral && !syntax.DoubleQuoteIsAmbiguous;
+
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Converts an automatically quoted token (<c>$[name]</c>) into its raw equivalent
+        /// (<c>$(name)</c>), which is what belongs inside a string literal.
+        /// </summary>
+        internal static string ToRawTokenText(string quotedTokenText)
+        {
+            return quotedTokenText.Replace('[', '(').Replace(']', ')');
+        }
+    }
+}

--- a/src/FluentMigrator.Analyzers/QuotedSqlTokenCodeFixProvider.cs
+++ b/src/FluentMigrator.Analyzers/QuotedSqlTokenCodeFixProvider.cs
@@ -1,0 +1,79 @@
+#region License
+// Copyright (c) 2024, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Text;
+
+namespace FluentMigrator.Analyzers
+{
+    /// <summary>
+    /// Replaces an automatically quoted token that sits inside a SQL string literal with the raw
+    /// token style, which is what belongs there.
+    /// </summary>
+    /// <remarks>
+    /// The alternative repair - deleting the surrounding quotes and keeping <c>$[name]</c> - is not
+    /// offered automatically. Both produce valid SQL but they mean different things, and only the
+    /// author knows whether the surrounding literal was intentional. Substituting into the existing
+    /// literal is the change that preserves the statement as written.
+    /// </remarks>
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(QuotedSqlTokenCodeFixProvider)), Shared]
+    public class QuotedSqlTokenCodeFixProvider : CodeFixProvider
+    {
+        /// <inheritdoc />
+        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(QuotedSqlTokenAnalyzer.DiagnosticId);
+
+        /// <inheritdoc />
+        public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        /// <inheritdoc />
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            if (root == null)
+            {
+                return;
+            }
+
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        title: Resources.QuotedSqlTokenCodeFixTitle,
+                        createChangedDocument: cancellationToken => ReplaceWithRawTokenAsync(context.Document, diagnosticSpan, cancellationToken),
+                        equivalenceKey: nameof(QuotedSqlTokenCodeFixProvider)),
+                    diagnostic);
+            }
+        }
+
+        private static async Task<Document> ReplaceWithRawTokenAsync(Document document, TextSpan diagnosticSpan, CancellationToken cancellationToken)
+        {
+            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            var quotedTokenText = text.ToString(diagnosticSpan);
+            var rawTokenText = QuotedSqlTokenAnalyzer.ToRawTokenText(quotedTokenText);
+
+            return document.WithText(text.Replace(diagnosticSpan, rawTokenText));
+        }
+    }
+}

--- a/src/FluentMigrator.Analyzers/README.md
+++ b/src/FluentMigrator.Analyzers/README.md
@@ -1,0 +1,77 @@
+# FluentMigrator analyzers
+
+Roslyn analyzers for FluentMigrator migrations.
+
+| Rule | Severity | Summary |
+|---|---|---|
+| `FM0001` | Warning | Migration version should be unique |
+| `FM0002` | Warning | Prefer `$[name]` over `$(name)` for SQL token substitution |
+| `FM0003` | Warning | Automatically quoted token is inside a string literal |
+| `FMUP0001` | Warning | Prefer `IDictionary<string, object>` over `IDictionary<string, string>` for `Execute` parameters |
+
+## Token substitution rules
+
+The two token styles are complements, not alternatives:
+
+- `$(name)` substitutes the value **verbatim**. It supplies content; anything around it in the script
+  supplies the syntax. `WHERE name = '$(userName)'` is the idiomatic use.
+- `$[name]` substitutes a **complete SQL literal**, already quoted: `'O''Brien'`, `NULL`, `1`,
+  `0xdead`. It stands alone: `WHERE name = $[userName]`.
+
+`FM0002` steers you from the first to the second, and `FM0003` catches the failure mode of applying
+that advice mechanically: `'$[userName]'` quotes the value twice. Only the string case fails loudly —
+numbers silently become string literals, `null` silently becomes the four-character text `'NULL'`,
+and a `RawSql` value silently becomes text so its SQL never runs.
+
+`FM0002` does not report the escaped form `$$((name))`, which performs no substitution and so carries
+no injection risk, nor tokens inside comments, which are never executed.
+
+## Configuring the SQL dialect
+
+Most of `FM0003` needs no dialect: every supported database opens a string literal with `'`, so a
+token wrapped in single quotes is wrong everywhere. A few cases do depend on the dialect, and stay
+silent unless it is known:
+
+| Construct | Needs a dialect because |
+|---|---|
+| `"$[name]"` | A string literal in MySQL without `ANSI_QUOTES`, a quoted identifier elsewhere |
+| `$tag$ ... $tag$` | PostgreSQL dollar quoting; the body is scanned as SQL rather than as data |
+| `'a\'$[name]'` | A backslash escapes the quote in MySQL, so the literal has not ended |
+| `q'[$[name]]'` | Oracle's alternative quoting |
+
+Two signals resolve the dialect, in precedence order.
+
+**`IfDatabase(...)`** — the most specific, and needs no configuration:
+
+```csharp
+IfDatabase("MySql").Execute.Sql("SELECT \"$[name]\"");   // FM0003 reports
+```
+
+Naming several databases only resolves when they share a family: `IfDatabase("MySql5", "MySql8")`
+resolves, `IfDatabase("MySql", "Postgres")` does not.
+
+**`.editorconfig`** — applies to a file, directory or project:
+
+```ini
+[*.cs]
+fluent_migrator_sql_dialect = postgres
+```
+
+Accepted values are the `ProcessorIdConstants` spellings, matched by family and case-insensitively:
+`sqlserver`, `postgres`, `redshift`, `mysql`, `mariadb`, `oracle`, `sqlite`, `firebird`, `db2`,
+`hana`, `snowflake`. Version suffixes are accepted and ignored, since no supported version changes
+how a string literal is delimited.
+
+Referenced runner packages are deliberately not used as a signal — projects routinely reference
+several providers, so the inference would be wrong more often than useful.
+
+## Limitations
+
+Session-level settings that change literal lexing are not visible at compile time:
+`NO_BACKSLASH_ESCAPES`, `ANSI_QUOTES`, `QUOTED_IDENTIFIER OFF`, `standard_conforming_strings`,
+`SQLITE_DQS`. Each dialect's **default** is assumed, and any diagnostic that would depend on a
+flipped mode is not reported. SQLite double quotes are never reported for this reason: whether
+`"foo"` is an identifier or a string depends on the schema, not on the text.
+
+Only string *literal* arguments to `Execute.Sql(...)` are analyzed. SQL built at runtime, read from a
+file, or passed through `Execute.Script`/`Execute.EmbeddedScript` is out of reach.

--- a/src/FluentMigrator.Analyzers/RawSqlTokenInterpolationAnalyzer.cs
+++ b/src/FluentMigrator.Analyzers/RawSqlTokenInterpolationAnalyzer.cs
@@ -15,7 +15,6 @@
 #endregion
 
 using System.Collections.Immutable;
-using System.Linq;
 using System.Text.RegularExpressions;
 
 using FluentMigrator.Analyzers.Analysis;
@@ -24,14 +23,26 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
 
 namespace FluentMigrator.Analyzers
 {
     /// <summary>
     /// Analyzer that warns when a call to <c>Execute.Sql(...)</c> uses the raw, unquoted
-    /// <c>$(name)</c>/<c>$$((name))</c> variable interpolation token style, and recommends the
-    /// automatically quoted <c>$[name]</c>/<c>$$[[name]]</c> token style instead.
+    /// <c>$(name)</c> variable interpolation token style, and recommends the automatically quoted
+    /// <c>$[name]</c> token style instead.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The escaped form <c>$$((name))</c> is deliberately <em>not</em> reported. It performs no
+    /// substitution - it renders as the literal text <c>$(name)</c> - so it carries no injection
+    /// risk, and rewriting it to <c>$$[[name]]</c> would change the emitted SQL from <c>$(name)</c>
+    /// to <c>$[name]</c>.
+    /// </para>
+    /// <para>
+    /// Tokens inside a comment are also not reported, since they are never executed.
+    /// </para>
+    /// </remarks>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class RawSqlTokenInterpolationAnalyzer : FluentMigratorAnalyzer
     {
@@ -42,15 +53,21 @@ namespace FluentMigrator.Analyzers
         private const string Category = "FluentMigrator";
 
         /// <summary>
-        /// Matches the escaped raw token form <c>$$((name))</c>, which is rendered verbatim (without
-        /// substitution) as the literal text <c>$(name)</c>.
-        /// </summary>
-        internal static readonly Regex EscapedRawTokenPattern = new Regex(@"\$\$\(\((?<token>\w+)\)\)", RegexOptions.Compiled);
-
-        /// <summary>
         /// Matches the raw, unquoted token form <c>$(name)</c>.
         /// </summary>
         internal static readonly Regex RawTokenPattern = new Regex(@"\$\((?<token>\w+)\)", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Diagnostic property set to <c>"true"</c> when the token is the entire content of a SQL
+        /// string literal, so the code fix must remove the surrounding quotes as it rewrites.
+        /// </summary>
+        internal const string StripEnclosingQuotesProperty = "stripEnclosingQuotes";
+
+        /// <summary>
+        /// Diagnostic property set to <c>"true"</c> when the token is embedded in a larger SQL string
+        /// literal. There is no mechanical rewrite in that case, so no code fix is offered.
+        /// </summary>
+        internal const string EmbeddedInLiteralProperty = "embeddedInLiteral";
 
         // You can change these strings in the Resources.resx file. If you do not want your analyzer to be localize-able, you can use regular strings for Title and MessageFormat.
         private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.RawSqlTokenInterpolationAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
@@ -73,77 +90,110 @@ namespace FluentMigrator.Analyzers
 
         private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context, FluentMigratorContext fluentMigratorContext)
         {
-            var executeExpressionRootType = fluentMigratorContext.ExecuteExpressionRootType;
-            if (executeExpressionRootType == null)
-            {
-                return;
-            }
-
             var invocation = (InvocationExpressionSyntax)context.Node;
 
-            var methodSymbol = context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol as IMethodSymbol;
-            if (methodSymbol == null || methodSymbol.Name != "Sql")
-            {
-                return;
-            }
-
-            if (!IsSqlExecuteMethod(methodSymbol, executeExpressionRootType))
-            {
-                return;
-            }
-
-            // The SQL statement is always the first argument of the `Sql(...)` overloads.
-            var sqlArgument = invocation.ArgumentList?.Arguments.FirstOrDefault();
-            if (!(sqlArgument?.Expression is LiteralExpressionSyntax literal) || !literal.IsKind(SyntaxKind.StringLiteralExpression))
+            if (!ExecuteSqlLiteral.TryGetSqlLiteral(
+                    invocation,
+                    context.SemanticModel,
+                    fluentMigratorContext.ExecuteExpressionRootType,
+                    context.CancellationToken,
+                    out var literal))
             {
                 return;
             }
 
             var token = literal.Token;
-            var tokenText = token.Text;
-
-            foreach (Match match in EscapedRawTokenPattern.Matches(tokenText))
+            var matches = ExecuteSqlLiteral.MatchTokens(token, RawTokenPattern);
+            if (matches.Count == 0)
             {
-                ReportDiagnostic(context, token, match);
+                return;
             }
 
-            foreach (Match match in RawTokenPattern.Matches(tokenText))
+            var dialect = SqlDialectResolver.Resolve(invocation, context.Options);
+            var syntax = SqlLiteralSyntax.For(dialect);
+            var sql = token.ValueText;
+
+            foreach (var match in matches)
             {
-                ReportDiagnostic(context, token, match);
+                var region = SqlLiteralScanner.GetRegionAt(sql, match.SqlIndex, syntax);
+
+                // Tokens in comments are never executed, so there is nothing to warn about.
+                if (region.Kind == SqlRegionKind.Comment)
+                {
+                    continue;
+                }
+
+                ReportDiagnostic(context, token, match, region, sql);
             }
         }
 
-        private static void ReportDiagnostic(SyntaxNodeAnalysisContext context, SyntaxToken token, Match match)
+        private static void ReportDiagnostic(
+            SyntaxNodeAnalysisContext context,
+            SyntaxToken token,
+            SqlTokenMatch match,
+            SqlRegion region,
+            string sql)
         {
-            var location = Location.Create(token.SyntaxTree, new Microsoft.CodeAnalysis.Text.TextSpan(token.SpanStart + match.Index, match.Length));
-            var quotedTokenText = ToQuotedTokenText(match.Value);
+            var location = Location.Create(token.SyntaxTree, new TextSpan(match.SourceStart, match.SourceLength));
+            var quotedTokenText = ToQuotedTokenText(match.Text);
+            var properties = ImmutableDictionary<string, string>.Empty;
 
-            context.ReportDiagnostic(Diagnostic.Create(Rule, location, match.Value, quotedTokenText));
+            if (IsStringLiteral(region.Kind))
+            {
+                // `'$(name)'` becomes `$[name]`: the token supplies the whole value, so the quotes
+                // have to go with it. Rewriting the token alone would double-quote the value, which
+                // is exactly what FM0003 reports.
+                var contentStart = region.ContentStart;
+                var contentEnd = FindContentEnd(sql, region);
+                var tokenIsWholeLiteral = match.SqlIndex == contentStart &&
+                                          match.SqlIndex + match.Text.Length == contentEnd;
+
+                // Only single-quoted literals are safe to rewrite automatically. A SQL double quote
+                // is written as `\"` or `""` in C# source, and Oracle's `q'[...]'` has a two-
+                // character closer, so deleting delimiters by source offset would corrupt either.
+                var canStripQuotes = tokenIsWholeLiteral && region.Kind == SqlRegionKind.StringLiteral;
+
+                properties = canStripQuotes
+                    ? properties.Add(StripEnclosingQuotesProperty, "true")
+                    : properties.Add(EmbeddedInLiteralProperty, "true");
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(Rule, location, properties, match.Text, quotedTokenText));
+        }
+
+        private static bool IsStringLiteral(SqlRegionKind kind)
+        {
+            return kind == SqlRegionKind.StringLiteral ||
+                   kind == SqlRegionKind.DoubleQuotedStringLiteral ||
+                   kind == SqlRegionKind.AlternativeQuoted;
         }
 
         /// <summary>
-        /// Converts a raw token (<c>$(name)</c>) or escaped raw token (<c>$$((name))</c>) into its
-        /// automatically quoted equivalent (<c>$[name]</c> or <c>$$[[name]]</c>, respectively).
+        /// Finds the index just past the last content character of a literal region, i.e. the index
+        /// of its closing delimiter.
+        /// </summary>
+        private static int FindContentEnd(string sql, SqlRegion region)
+        {
+            var end = region.End;
+            if (end <= region.ContentStart)
+            {
+                return region.ContentStart;
+            }
+
+            // Closing delimiters are one character for quoted forms and two for Oracle's q'[ ]'.
+            var closerLength = region.Kind == SqlRegionKind.AlternativeQuoted ? 2 : 1;
+            var contentEnd = end - closerLength;
+
+            return contentEnd < region.ContentStart ? region.ContentStart : contentEnd;
+        }
+
+        /// <summary>
+        /// Converts a raw token (<c>$(name)</c>) into its automatically quoted equivalent
+        /// (<c>$[name]</c>).
         /// </summary>
         internal static string ToQuotedTokenText(string rawTokenText)
         {
             return rawTokenText.Replace('(', '[').Replace(')', ']');
-        }
-
-        private static bool IsSqlExecuteMethod(IMethodSymbol methodSymbol, INamedTypeSymbol executeExpressionRootType)
-        {
-            var containingType = methodSymbol.ContainingType;
-            if (containingType == null)
-            {
-                return false;
-            }
-
-            if (SymbolEqualityComparer.Default.Equals(containingType, executeExpressionRootType))
-            {
-                return true;
-            }
-
-            return containingType.AllInterfaces.Contains(executeExpressionRootType, SymbolEqualityComparer.Default);
         }
     }
 }

--- a/src/FluentMigrator.Analyzers/RawSqlTokenInterpolationCodeFixProvider.cs
+++ b/src/FluentMigrator.Analyzers/RawSqlTokenInterpolationCodeFixProvider.cs
@@ -55,25 +55,90 @@ namespace FluentMigrator.Analyzers
 
             foreach (var diagnostic in context.Diagnostics)
             {
+                // `'prefix$(name)suffix'` has no mechanical rewrite. Swapping in `$[name]` would
+                // nest a quoted literal inside a quoted literal, which is the defect FM0003
+                // reports, and deleting the surrounding quotes would change the statement. Report
+                // only; the author has to decide.
+                if (diagnostic.Properties.ContainsKey(RawSqlTokenInterpolationAnalyzer.EmbeddedInLiteralProperty))
+                {
+                    continue;
+                }
+
                 var diagnosticSpan = diagnostic.Location.SourceSpan;
+                var stripEnclosingQuotes = diagnostic.Properties.ContainsKey(
+                    RawSqlTokenInterpolationAnalyzer.StripEnclosingQuotesProperty);
 
                 context.RegisterCodeFix(
                     CodeAction.Create(
                         title: Resources.RawSqlTokenInterpolationCodeFixTitle,
-                        createChangedDocument: cancellationToken => ReplaceWithQuotedTokenAsync(context.Document, diagnosticSpan, cancellationToken),
+                        createChangedDocument: cancellationToken => ReplaceWithQuotedTokenAsync(
+                            context.Document,
+                            diagnosticSpan,
+                            stripEnclosingQuotes,
+                            cancellationToken),
                         equivalenceKey: nameof(RawSqlTokenInterpolationCodeFixProvider)),
                     diagnostic);
             }
         }
 
-        private static async Task<Document> ReplaceWithQuotedTokenAsync(Document document, TextSpan diagnosticSpan, CancellationToken cancellationToken)
+        private static async Task<Document> ReplaceWithQuotedTokenAsync(
+            Document document,
+            TextSpan diagnosticSpan,
+            bool stripEnclosingQuotes,
+            CancellationToken cancellationToken)
         {
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
             var rawTokenText = text.ToString(diagnosticSpan);
             var quotedTokenText = RawSqlTokenInterpolationAnalyzer.ToQuotedTokenText(rawTokenText);
 
-            var newText = text.Replace(diagnosticSpan, quotedTokenText);
-            return document.WithText(newText);
+            var replacementSpan = stripEnclosingQuotes
+                ? ExpandOverEnclosingQuotes(text, diagnosticSpan)
+                : diagnosticSpan;
+
+            return document.WithText(text.Replace(replacementSpan, quotedTokenText));
+        }
+
+        /// <summary>
+        /// Grows a token span to cover the SQL string literal that encloses it, including any
+        /// literal prefix such as <c>N</c>, <c>E</c> or <c>_utf8mb4</c>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <c>$[name]</c> already expands to a complete, quoted SQL literal, so converting
+        /// <c>'$(name)'</c> has to delete the quotes as well. Rewriting the token alone produced
+        /// <c>'$[name]'</c>, which double-quotes the value: numbers silently became strings,
+        /// <see langword="null"/> silently became the text <c>'NULL'</c>, and only the string case
+        /// failed loudly.
+        /// </para>
+        /// <para>
+        /// The analyzer has already established that the token is the entire content of the literal,
+        /// so this only has to find the delimiters on either side. If the surrounding text is not
+        /// what was expected the original span is returned unchanged, leaving the previous - still
+        /// conservative - behaviour.
+        /// </para>
+        /// </remarks>
+        private static TextSpan ExpandOverEnclosingQuotes(SourceText text, TextSpan tokenSpan)
+        {
+            var start = tokenSpan.Start - 1;
+            if (start < 0 || text[start] != '\'')
+            {
+                return tokenSpan;
+            }
+
+            var end = tokenSpan.End;
+            if (end >= text.Length || text[end] != '\'')
+            {
+                return tokenSpan;
+            }
+
+            // Walk back over a literal prefix: N'...', E'...', U&'...', _utf8mb4'...'.
+            var prefixStart = start;
+            while (prefixStart > 0 && (char.IsLetterOrDigit(text[prefixStart - 1]) || text[prefixStart - 1] == '_' || text[prefixStart - 1] == '&'))
+            {
+                prefixStart--;
+            }
+
+            return TextSpan.FromBounds(prefixStart, end + 1);
         }
     }
 }

--- a/src/FluentMigrator.Analyzers/Resources.Designer.cs
+++ b/src/FluentMigrator.Analyzers/Resources.Designer.cs
@@ -157,5 +157,29 @@ namespace FluentMigrator.Analyzers {
                 return ResourceManager.GetString("LegacyStringDictionaryParameterCodeFixTitle", resourceCulture);
             }
         }
+
+        internal static string QuotedSqlTokenAnalyzerDescription {
+            get {
+                return ResourceManager.GetString("QuotedSqlTokenAnalyzerDescription", resourceCulture);
+            }
+        }
+
+        internal static string QuotedSqlTokenAnalyzerMessageFormat {
+            get {
+                return ResourceManager.GetString("QuotedSqlTokenAnalyzerMessageFormat", resourceCulture);
+            }
+        }
+
+        internal static string QuotedSqlTokenAnalyzerTitle {
+            get {
+                return ResourceManager.GetString("QuotedSqlTokenAnalyzerTitle", resourceCulture);
+            }
+        }
+
+        internal static string QuotedSqlTokenCodeFixTitle {
+            get {
+                return ResourceManager.GetString("QuotedSqlTokenCodeFixTitle", resourceCulture);
+            }
+        }
     }
 }

--- a/src/FluentMigrator.Analyzers/Resources.resx
+++ b/src/FluentMigrator.Analyzers/Resources.resx
@@ -150,4 +150,16 @@
   <data name="LegacyStringDictionaryParameterCodeFixTitle" xml:space="preserve">
     <value>Use IDictionary&lt;string, object&gt; parameter values</value>
   </data>
+  <data name="QuotedSqlTokenAnalyzerDescription" xml:space="preserve">
+    <value>The $[name] token style expands to a complete SQL literal, already quoted - 'O''Brien', NULL, 1, 0xdead. Placing it inside a string literal therefore quotes the value twice, and only the string case fails loudly: a number silently becomes a string literal, null silently becomes the four-character text 'NULL', and a RawSql value silently becomes text so its SQL never runs. Inside a string literal, use the raw $(name) style, which is designed to supply the content while the surrounding quotes supply the literal.</value>
+  </data>
+  <data name="QuotedSqlTokenAnalyzerMessageFormat" xml:space="preserve">
+    <value>Token '{0}' is inside a {1} string literal and will be quoted twice; use '{2}' instead, or remove the surrounding quotes</value>
+  </data>
+  <data name="QuotedSqlTokenAnalyzerTitle" xml:space="preserve">
+    <value>Automatically quoted token is inside a string literal</value>
+  </data>
+  <data name="QuotedSqlTokenCodeFixTitle" xml:space="preserve">
+    <value>Replace with raw token to substitute inside the string literal</value>
+  </data>
 </root>

--- a/test/FluentMigrator.Analyzers.Tests/QuotedSqlTokenUnitTests.cs
+++ b/test/FluentMigrator.Analyzers.Tests/QuotedSqlTokenUnitTests.cs
@@ -1,0 +1,322 @@
+#region License
+// Copyright (c) 2024, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis.Testing;
+
+using NUnit.Framework;
+
+using VerifyTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixTest<
+    FluentMigrator.Analyzers.QuotedSqlTokenAnalyzer,
+    FluentMigrator.Analyzers.QuotedSqlTokenCodeFixProvider,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier
+>;
+
+namespace FluentMigrator.Analyzers.Tests
+{
+    /// <summary>
+    /// Coverage for FM0003, which reports a <c>$[name]</c> token sitting inside a SQL string literal.
+    /// </summary>
+    /// <remarks>
+    /// The dialect axis is exercised through <c>IfDatabase("...")</c> rather than
+    /// <c>.editorconfig</c>, because it scopes to a single statement and keeps each case readable.
+    /// <see cref="Dialect_Comes_From_EditorConfig"/> covers the other signal.
+    /// </remarks>
+    public class QuotedSqlTokenUnitTests
+    {
+        private const string StubDefinitions = @"
+    namespace FluentMigrator.Builders.Execute
+    {
+        public interface IExecuteExpressionRoot
+        {
+            void Sql(string sqlStatement);
+        }
+    }
+
+    namespace ConsoleApplication1
+    {
+        using FluentMigrator.Builders.Execute;
+
+        public class FakeExecuteExpressionRoot : IExecuteExpressionRoot
+        {
+            public void Sql(string sqlStatement)
+            {
+            }
+        }
+
+        public class FakeIfDatabase
+        {
+            public IExecuteExpressionRoot Execute { get { return null; } }
+        }
+
+        public class FakeMigration
+        {
+            public FakeIfDatabase IfDatabase(params string[] databaseType) { return null; }
+        }
+    }
+";
+
+        private static string Source(string body) => @"
+    using ConsoleApplication1;
+
+    namespace ConsoleApplication1
+    {
+        public class TypeName
+        {
+            public void Up()
+            {
+" + body + @"
+            }
+        }
+    }";
+
+        private static VerifyTest CreateTest(string source, string fixedSource = null)
+        {
+            var test = new VerifyTest
+            {
+                TestState =
+                {
+                    Sources = { source, StubDefinitions },
+                },
+            };
+
+            if (fixedSource != null)
+            {
+                test.FixedState.Sources.Add(fixedSource);
+                test.FixedState.Sources.Add(StubDefinitions);
+            }
+
+#if NET
+            test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+#endif
+
+            return test;
+        }
+
+        // ---------------------------------------------------------------- dialect-independent
+
+        [Test]
+        public async Task Warns_When_Token_Is_Wrapped_In_Single_Quotes()
+        {
+            var source = Source(@"                new FakeExecuteExpressionRoot().Sql(""SELECT * FROM Foo WHERE Name = '{|FM0003:$[name]|}'"");");
+            var fixedSource = Source(@"                new FakeExecuteExpressionRoot().Sql(""SELECT * FROM Foo WHERE Name = '$(name)'"");");
+
+            await CreateTest(source, fixedSource).RunAsync();
+        }
+
+        [Test]
+        public async Task Warns_When_Token_Is_Embedded_In_A_Larger_Literal()
+        {
+            var source = Source(@"                new FakeExecuteExpressionRoot().Sql(""SELECT * FROM Foo WHERE Name LIKE '%{|FM0003:$[name]|}%'"");");
+            var fixedSource = Source(@"                new FakeExecuteExpressionRoot().Sql(""SELECT * FROM Foo WHERE Name LIKE '%$(name)%'"");");
+
+            await CreateTest(source, fixedSource).RunAsync();
+        }
+
+        [TestCase("N")]
+        [TestCase("E")]
+        [TestCase("B")]
+        [TestCase("X")]
+        [TestCase("_utf8mb4")]
+        public async Task Warns_For_Prefixed_String_Literals(string prefix)
+        {
+            var source = Source(@"                new FakeExecuteExpressionRoot().Sql(""SELECT " + prefix + @"'{|FM0003:$[name]|}'"");");
+            var fixedSource = Source(@"                new FakeExecuteExpressionRoot().Sql(""SELECT " + prefix + @"'$(name)'"");");
+
+            await CreateTest(source, fixedSource).RunAsync();
+        }
+
+        [Test]
+        public async Task Warns_For_Unicode_Escape_Literals()
+        {
+            var source = Source(@"                new FakeExecuteExpressionRoot().Sql(""SELECT U&'{|FM0003:$[name]|}'"");");
+            var fixedSource = Source(@"                new FakeExecuteExpressionRoot().Sql(""SELECT U&'$(name)'"");");
+
+            await CreateTest(source, fixedSource).RunAsync();
+        }
+
+        [Test]
+        public async Task Doesnt_Warn_When_Token_Is_Not_In_A_Literal()
+        {
+            var source = Source(@"                new FakeExecuteExpressionRoot().Sql(""SELECT * FROM Foo WHERE Name = $[name]"");");
+
+            await CreateTest(source).RunAsync();
+        }
+
+        [Test]
+        public async Task Doesnt_Warn_For_Raw_Token_In_A_Literal()
+        {
+            // '$(name)' is the correct way to substitute a value into a string literal.
+            var source = Source(@"                new FakeExecuteExpressionRoot().Sql(""SELECT * FROM Foo WHERE Name = '$(name)'"");");
+
+            await CreateTest(source).RunAsync();
+        }
+
+        [Test]
+        public async Task Doesnt_Warn_Inside_A_Line_Comment()
+        {
+            var source = Source(@"                new FakeExecuteExpressionRoot().Sql(""SELECT 1 -- '$[name]'"");");
+
+            await CreateTest(source).RunAsync();
+        }
+
+        [Test]
+        public async Task Doesnt_Warn_Inside_A_Block_Comment()
+        {
+            var source = Source(@"                new FakeExecuteExpressionRoot().Sql(""SELECT /* '$[name]' */ 1"");");
+
+            await CreateTest(source).RunAsync();
+        }
+
+        [Test]
+        public async Task Doesnt_Warn_When_A_Preceding_Literal_Is_Already_Closed()
+        {
+            // The token follows a complete literal, so it is in code, not inside it.
+            var source = Source(@"                new FakeExecuteExpressionRoot().Sql(""SELECT 'a', $[name]"");");
+
+            await CreateTest(source).RunAsync();
+        }
+
+        [Test]
+        public async Task Doesnt_Warn_When_Doubled_Quotes_Close_The_Literal()
+        {
+            // 'it''s' is a complete literal; the token after it is in code.
+            var source = Source(@"                new FakeExecuteExpressionRoot().Sql(""SELECT 'it''''s', $[name]"");");
+
+            await CreateTest(source).RunAsync();
+        }
+
+        // ---------------------------------------------------------------- dialect-gated
+
+        [Test]
+        public async Task Warns_For_Double_Quoted_Literal_On_MySql()
+        {
+            // Without ANSI_QUOTES a double-quoted run is a string literal in MySQL.
+            var source = Source(@"                new FakeMigration().IfDatabase(""MySql"").Execute.Sql(""SELECT \""{|FM0003:$[name]|}\"""");");
+            var fixedSource = Source(@"                new FakeMigration().IfDatabase(""MySql"").Execute.Sql(""SELECT \""$(name)\"""");");
+
+            await CreateTest(source, fixedSource).RunAsync();
+        }
+
+        [Test]
+        public async Task Doesnt_Warn_For_Double_Quoted_Identifier_On_SqlServer()
+        {
+            var source = Source(@"                new FakeMigration().IfDatabase(""SqlServer2016"").Execute.Sql(""SELECT \""$[name]\"""");");
+
+            await CreateTest(source).RunAsync();
+        }
+
+        [Test]
+        public async Task Doesnt_Warn_For_Double_Quoted_Run_When_Dialect_Is_Unknown()
+        {
+            var source = Source(@"                new FakeExecuteExpressionRoot().Sql(""SELECT \""$[name]\"""");");
+
+            await CreateTest(source).RunAsync();
+        }
+
+        [Test]
+        public async Task Doesnt_Warn_For_Double_Quoted_Run_On_SQLite()
+        {
+            // SQLite resolves "x" to an identifier or a string depending on the schema, so the
+            // outcome is not knowable at compile time.
+            var source = Source(@"                new FakeMigration().IfDatabase(""SQLite"").Execute.Sql(""SELECT \""$[name]\"""");");
+
+            await CreateTest(source).RunAsync();
+        }
+
+        [Test]
+        public async Task Doesnt_Warn_Inside_Postgres_Dollar_Quoting()
+        {
+            // A dollar-quoted block holds SQL source, so a quoted literal inside it is expected.
+            var source = Source(@"                new FakeMigration().IfDatabase(""Postgres"").Execute.Sql(""CREATE FUNCTION f() AS $body$ SELECT $[name]; $body$"");");
+
+            await CreateTest(source).RunAsync();
+        }
+
+        [Test]
+        public async Task Warns_Inside_A_Literal_Nested_In_Postgres_Dollar_Quoting()
+        {
+            var source = Source(@"                new FakeMigration().IfDatabase(""Postgres"").Execute.Sql(""CREATE FUNCTION f() AS $body$ SELECT '{|FM0003:$[name]|}'; $body$"");");
+            var fixedSource = Source(@"                new FakeMigration().IfDatabase(""Postgres"").Execute.Sql(""CREATE FUNCTION f() AS $body$ SELECT '$(name)'; $body$"");");
+
+            await CreateTest(source, fixedSource).RunAsync();
+        }
+
+        [Test]
+        public async Task Warns_For_Oracle_Alternative_Quoting()
+        {
+            var source = Source(@"                new FakeMigration().IfDatabase(""Oracle"").Execute.Sql(""SELECT q'[{|FM0003:$[name]|}]' FROM dual"");");
+            var fixedSource = Source(@"                new FakeMigration().IfDatabase(""Oracle"").Execute.Sql(""SELECT q'[$(name)]' FROM dual"");");
+
+            await CreateTest(source, fixedSource).RunAsync();
+        }
+
+        [Test]
+        public async Task Backslash_Does_Not_Close_A_Literal_On_MySql()
+        {
+            // In MySQL's default mode '\'' is a complete literal, so the token is still inside it.
+            var source = Source(@"                new FakeMigration().IfDatabase(""MySql"").Execute.Sql(""SELECT 'a\\'{|FM0003:$[name]|}'"");");
+            var fixedSource = Source(@"                new FakeMigration().IfDatabase(""MySql"").Execute.Sql(""SELECT 'a\\'$(name)'"");");
+
+            await CreateTest(source, fixedSource).RunAsync();
+        }
+
+        [Test]
+        public async Task Backslash_Closes_A_Literal_On_Postgres()
+        {
+            // With standard_conforming_strings the backslash is literal, so 'a\' is complete and
+            // the token that follows is in code.
+            var source = Source(@"                new FakeMigration().IfDatabase(""Postgres"").Execute.Sql(""SELECT 'a\\', $[name]"");");
+
+            await CreateTest(source).RunAsync();
+        }
+
+        [Test]
+        public async Task Doesnt_Resolve_Dialect_When_IfDatabase_Names_Several_Families()
+        {
+            // Guarded for two dialects at once: nothing dialect-specific is safe, so the
+            // double-quote case stays silent.
+            var source = Source(@"                new FakeMigration().IfDatabase(""MySql"", ""Postgres"").Execute.Sql(""SELECT \""$[name]\"""");");
+
+            await CreateTest(source).RunAsync();
+        }
+
+        [Test]
+        public async Task Resolves_Dialect_When_IfDatabase_Names_One_Family()
+        {
+            var source = Source(@"                new FakeMigration().IfDatabase(""MySql5"", ""MySql8"").Execute.Sql(""SELECT \""{|FM0003:$[name]|}\"""");");
+            var fixedSource = Source(@"                new FakeMigration().IfDatabase(""MySql5"", ""MySql8"").Execute.Sql(""SELECT \""$(name)\"""");");
+
+            await CreateTest(source, fixedSource).RunAsync();
+        }
+
+        [Test]
+        public async Task Dialect_Comes_From_EditorConfig()
+        {
+            var source = Source(@"                new FakeExecuteExpressionRoot().Sql(""SELECT \""{|FM0003:$[name]|}\"""");");
+            var fixedSource = Source(@"                new FakeExecuteExpressionRoot().Sql(""SELECT \""$(name)\"""");");
+
+            var test = CreateTest(source, fixedSource);
+            test.TestState.AnalyzerConfigFiles.Add(
+                ("/.editorconfig", "root = true\n\n[*.cs]\nfluent_migrator_sql_dialect = mysql\n"));
+            test.FixedState.AnalyzerConfigFiles.Add(
+                ("/.editorconfig", "root = true\n\n[*.cs]\nfluent_migrator_sql_dialect = mysql\n"));
+
+            await test.RunAsync();
+        }
+    }
+}

--- a/test/FluentMigrator.Analyzers.Tests/RawSqlTokenInterpolationUnitTests.cs
+++ b/test/FluentMigrator.Analyzers.Tests/RawSqlTokenInterpolationUnitTests.cs
@@ -158,8 +158,14 @@ namespace FluentMigrator.Analyzers.Tests
             await ut.RunAsync();
         }
 
+        /// <summary>
+        /// The escaped form performs no substitution - it renders as the literal text
+        /// <c>$(name)</c> - so it carries no injection risk. Reporting it also invited a code fix
+        /// that changed the emitted SQL from <c>$(name)</c> to <c>$[name]</c>, corrupting output for
+        /// anyone deliberately emitting token syntax.
+        /// </summary>
         [Test]
-        public async Task Warns_On_Escaped_Raw_Token()
+        public async Task Doesnt_Warn_On_Escaped_Raw_Token()
         {
             //language=csharp
             const string source = @"
@@ -176,6 +182,49 @@ namespace FluentMigrator.Analyzers.Tests
         }
     }";
 
+            var ut = new VerifyTest
+            {
+                TestState =
+                {
+                    Sources = { source, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                    ExpectedDiagnostics =
+                    {
+                        Capacity = 0
+                    },
+                },
+            };
+
+#if NET
+            ut.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+#endif
+
+            await ut.RunAsync();
+        }
+
+        /// <summary>
+        /// The code fix has to remove the surrounding quotes: <c>$[name]</c> already expands to a
+        /// complete, quoted literal, so rewriting the token alone produced <c>'$[name]'</c> and
+        /// quoted the value twice.
+        /// </summary>
+        [Test]
+        public async Task Fix_Removes_Enclosing_Quotes_When_Token_Is_The_Whole_Literal()
+        {
+            //language=csharp
+            const string source = @"
+    using ConsoleApplication1;
+
+    namespace ConsoleApplication1
+    {
+        public class TypeName
+        {
+            public void Up()
+            {
+                new FakeExecuteExpressionRoot().Sql(""UPDATE Foo SET Name = '$(name)'"");
+            }
+        }
+    }";
+
             //language=csharp
             const string fixedSource = @"
     using ConsoleApplication1;
@@ -186,14 +235,14 @@ namespace FluentMigrator.Analyzers.Tests
         {
             public void Up()
             {
-                new FakeExecuteExpressionRoot().Sql(""SELECT '$$[[name]]' AS Literal"");
+                new FakeExecuteExpressionRoot().Sql(""UPDATE Foo SET Name = $[name]"");
             }
         }
     }";
 
             var expected = Verify.Diagnostic(RawSqlTokenInterpolationAnalyzer.DiagnosticId)
-                .WithSpan(10, 62, 10, 72)
-                .WithArguments("$$((name))", "$$[[name]]");
+                .WithSpan(10, 77, 10, 84)
+                .WithArguments("$(name)", "$[name]");
 
             var ut = new VerifyTest
             {
@@ -210,6 +259,97 @@ namespace FluentMigrator.Analyzers.Tests
             };
 
             ut.TestState.ExpectedDiagnostics.Add(expected);
+#if NET
+            ut.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+#endif
+
+            await ut.RunAsync();
+        }
+
+        /// <summary>
+        /// When the token is only part of a literal there is no mechanical rewrite, so the
+        /// diagnostic is still reported but no code fix is offered.
+        /// </summary>
+        [Test]
+        public async Task Offers_No_Fix_When_Token_Is_Embedded_In_A_Literal()
+        {
+            //language=csharp
+            const string source = @"
+    using ConsoleApplication1;
+
+    namespace ConsoleApplication1
+    {
+        public class TypeName
+        {
+            public void Up()
+            {
+                new FakeExecuteExpressionRoot().Sql(""SELECT * FROM Foo WHERE Name LIKE '%$(name)%'"");
+            }
+        }
+    }";
+
+            var expected = Verify.Diagnostic(RawSqlTokenInterpolationAnalyzer.DiagnosticId)
+                .WithSpan(10, 90, 10, 97)
+                .WithArguments("$(name)", "$[name]");
+
+            var ut = new VerifyTest
+            {
+                TestState =
+                {
+                    Sources = { source, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+                FixedState =
+                {
+                    // Unchanged: the analyzer reports, but the fix provider declines to rewrite.
+                    Sources = { source, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+            };
+
+            ut.TestState.ExpectedDiagnostics.Add(expected);
+            ut.FixedState.ExpectedDiagnostics.Add(expected);
+#if NET
+            ut.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+#endif
+
+            await ut.RunAsync();
+        }
+
+        /// <summary>
+        /// A token in a comment is never executed, so there is nothing to warn about.
+        /// </summary>
+        [Test]
+        public async Task Doesnt_Warn_Inside_A_Comment()
+        {
+            //language=csharp
+            const string source = @"
+    using ConsoleApplication1;
+
+    namespace ConsoleApplication1
+    {
+        public class TypeName
+        {
+            public void Up()
+            {
+                new FakeExecuteExpressionRoot().Sql(""SELECT 1 -- $(name)"");
+            }
+        }
+    }";
+
+            var ut = new VerifyTest
+            {
+                TestState =
+                {
+                    Sources = { source, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                    ExpectedDiagnostics =
+                    {
+                        Capacity = 0
+                    },
+                },
+            };
+
 #if NET
             ut.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
 #endif


### PR DESCRIPTION
Claude `claude-opus-5[1m]` opening on behalf of @jzabroski.

Enriches the token interpolation analyzer to understand SQL string literals, per-dialect. Branches off `main`. Independent of #2337 — the branch was initially cut from that PR by mistake and has been rebased onto `main`; it now contains a single commit touching only analyzer files.

## The bug that motivated this

FM0002's code fix could produce broken SQL. `ReplaceWithQuotedTokenAsync` replaced only the diagnostic span — the token — and never looked at what surrounded it. So the most idiomatic use of a raw token was silently corrupted by the offered fix:

```csharp
Execute.Sql("UPDATE t SET name = '$(userName)'");   // correct
Execute.Sql("UPDATE t SET name = '$[userName]'");   // after FM0002's code fix
```

`$[name]` already expands to a complete quoted literal, so this quotes the value twice. Only the string case fails loudly:

| Value | `$[x]` expands to | `'$[x]'` yields |
|---|---|---|
| `"O'Brien"` | `'O''Brien'` | `''O''Brien''` — syntax error, loud |
| `1234.5678` | `1234.5678` | `'1234.5678'` — silently a string literal |
| `null` | `NULL` | `'NULL'` — silently the 4-character text |
| `RawSql.Insert("CURRENT_TIMESTAMP")` | `CURRENT_TIMESTAMP` | `'CURRENT_TIMESTAMP'` — silently text, function never runs |

No test covered a quoted `$(name)`.

## What changed

**FM0003 (new).** Reports `$[name]` inside a SQL string literal, with a fix that swaps in `$(name)` — what belongs inside a literal.

**FM0002 (changed).**
- The code fix now removes the enclosing quotes when the token is the whole literal, and **declines to offer a fix** when the token is embedded in a larger literal (`'%$(name)%'`), where no mechanical rewrite exists. It still reports — the injection concern is real — but won't silently corrupt.
- The escaped form `$$((name))` is no longer reported. It performs *no substitution*, so there is no injection risk, and the fix changed the emitted SQL from `$(name)` to `$[name]` — corrupting output for anyone deliberately emitting token syntax, under a fix labelled as a security improvement.
- Tokens inside comments are no longer reported.

## On dialects

One thing worth pushing back on from the design discussion: **the core rule needs no dialect knowledge at all.** Every supported database opens a string literal with `'`, and `$[name]` is self-quoting by contract, so `'$[x]'` is wrong in T-SQL, PostgreSQL, MySQL, Oracle and SQLite alike. The prefix zoo and escape divergence change *how* a literal is written, not whether the expansion already brought its own quotes.

The cases that genuinely need a dialect are gated behind a resolved one and stay silent without it:

| Construct | Why it needs a dialect |
|---|---|
| `"$[name]"` | String literal in MySQL without `ANSI_QUOTES`, quoted identifier elsewhere |
| `$tag$ … $tag$` | PostgreSQL dollar quoting |
| `'a\'$[name]'` | Backslash escapes the quote in MySQL, so the literal has not ended |
| `q'[$[name]]'` | Oracle alternative quoting |

Two signals, in precedence order: `IfDatabase("...")` in the receiver chain, then the `fluent_migrator_sql_dialect` `.editorconfig` key. Multi-database `IfDatabase` resolves only when the names share a family. Referenced runner packages are deliberately **not** used — projects routinely reference several providers, so the inference would be wrong more often than useful.

## On lexer modes

Escape behaviour is modelled as lexer state, not a parse-time concern, for exactly the reason raised in review: it changes where a literal *ends*. `'\''` is one complete literal in MySQL's default mode and an unterminated one in PostgreSQL with `standard_conforming_strings` on. Both are covered by tests.

`SqlLiteralSyntax` carries the modes; `SqlLiteralScanner` is a single-pass scanner that answers one question — which region encloses this index. It is deliberately not a SQL parser.

One result worth calling out: **dollar-quoted bodies are scanned recursively.** They hold SQL or PL/pgSQL source rather than data, so a token directly inside one is legitimate and is not reported, but a token inside a literal *nested* in one still is. Modelling dollar quoting turned out to be necessary for correctness of the scan rather than to produce a diagnostic.

## Limitations, stated in the analyzer README

Session settings that flip these modes — `NO_BACKSLASH_ESCAPES`, `ANSI_QUOTES`, `QUOTED_IDENTIFIER OFF`, `standard_conforming_strings`, `SQLITE_DQS` — are invisible at compile time. Each dialect's default is assumed and anything depending on a flipped mode is not reported. SQLite double quotes are never reported: whether `"foo"` is an identifier or a string depends on the schema, not the text.

Only string *literal* arguments to `Execute.Sql(...)` are analyzed. SQL built at runtime, or passed through `Execute.Script`/`Execute.EmbeddedScript`, is out of reach.

## Note on span mapping

Matching now runs against `SyntaxToken.ValueText` so the scanner sees the SQL the runtime will, rather than C# source with its own quoting. Spans are recovered by matching the same pattern against `Text` and pairing positionally — sound because substitution tokens contain no character C# escaping can introduce or remove. If the counts ever disagree (needs something like `"$[name]"`), no matches are reported rather than risk pointing a diagnostic at the wrong span.

## Results

```
Analyzers:   40 passed,   0 failed
Full suite: 5406 passed, 940 skipped, 0 failed   (net48)
```

New tests cover: single quotes, embedded-in-literal, the `N`/`E`/`B`/`X`/`_utf8mb4`/`U&` prefixes, Oracle `q'[…]'`, MySQL vs Postgres backslash termination, MySQL vs SQL Server vs SQLite double quotes, dollar quoting and literals nested inside it, both dialect signals, multi-database `IfDatabase`, comments, and doubled-quote termination.

## Reviewer notes

- **FM0002 now reports fewer things** (no escaped form, no comments) and **offers fewer fixes** (none when embedded). Both are deliberate; the escaped-form change is the one most likely to surprise.
- `Verify.NUnit` is not involved here — this branch does not depend on #2337.
- **Only `net48` was executed locally**; the repo lives on a WSL share. CI covers net8.0.
- `Resources.Designer.cs` was hand-extended, since `ResXFileCodeGenerator` runs in VS rather than on build.

Refs #2332, #2336

🤖 Generated with [Claude Code](https://claude.com/claude-code)

