### PR TITLE
Preserve token lookup semantics for SortedDictionary parameters

### DIFF
--- a/src/FluentMigrator.Abstractions/SqlScriptTokenReplacer.cs
+++ b/src/FluentMigrator.Abstractions/SqlScriptTokenReplacer.cs
@@ -67,6 +67,11 @@ namespace FluentMigrator
         /// </remarks>
         public static string ReplaceSqlScriptTokens([StringSyntax("sql")] string sqlText, IDictionary<string, object> parameters, IQuoter quoter = null)
         {
+            return ReplaceSqlScriptTokensCore(sqlText, parameters, quoter);
+        }
+
+        private static string ReplaceSqlScriptTokensCore<TValue>([StringSyntax("sql")] string sqlText, IDictionary<string, TValue> parameters, IQuoter quoter)
+        {
             // Are parameters set?
             if (parameters != null && parameters.Count != 0)
             {
@@ -80,9 +85,10 @@ namespace FluentMigrator
                         var key = m.Groups["token"].Value;
                         if (parameters.TryGetValue(key, out var keyValue))
                         {
+                            object value = keyValue;
                             return quoter != null
-                                ? quoter.QuoteValue(keyValue)
-                                : QuoteSqlStringLiteral(keyValue?.ToString());
+                                ? quoter.QuoteValue(value)
+                                : QuoteSqlStringLiteral(value?.ToString());
                         }
 
                         // Return the whole match value when the key
@@ -145,27 +151,13 @@ namespace FluentMigrator
         /// which supports non-string parameter values and safe SQL literal quoting via an
         /// <see cref="IQuoter"/>.
         /// <para>
-        /// The key comparer of <paramref name="parameters"/> is carried over when it is a
-        /// <see cref="Dictionary{TKey,TValue}"/>, so that callers passing e.g. a
-        /// <see cref="StringComparer.OrdinalIgnoreCase"/> dictionary keep the token lookup
-        /// semantics they had before the conversion.
+        /// The supplied dictionary is queried directly, preserving its key lookup semantics.
         /// </para>
         /// </remarks>
         [Obsolete("Use the IDictionary<string, object> overload instead. The IDictionary<string, string> overload is kept for backwards compatibility and will be removed in a future major version.")]
         public static string ReplaceSqlScriptTokens([StringSyntax("sql")] string sqlText, IDictionary<string, string> parameters)
         {
-            IDictionary<string, object> objectParameters = null;
-            if (parameters != null)
-            {
-                var comparer = (parameters as Dictionary<string, string>)?.Comparer;
-                objectParameters = new Dictionary<string, object>(parameters.Count, comparer);
-                foreach (var parameter in parameters)
-                {
-                    objectParameters[parameter.Key] = parameter.Value;
-                }
-            }
-
-            return ReplaceSqlScriptTokens(sqlText, objectParameters);
+            return ReplaceSqlScriptTokensCore(sqlText, parameters, null);
         }
 
         /// <summary>

--- a/src/FluentMigrator/Builders/Execute/ExecuteExpressionRoot.cs
+++ b/src/FluentMigrator/Builders/Execute/ExecuteExpressionRoot.cs
@@ -220,10 +220,10 @@ namespace FluentMigrator.Builders.Execute
         /// <returns>An object-valued copy of <paramref name="parameters"/>, or <c>null</c> when
         /// <paramref name="parameters"/> is <c>null</c></returns>
         /// <remarks>
-        /// The key comparer of <paramref name="parameters"/> is carried over when it is a
-        /// <see cref="Dictionary{TKey,TValue}"/>, so that callers passing e.g. a
-        /// <see cref="StringComparer.OrdinalIgnoreCase"/> dictionary keep the token lookup
-        /// semantics they had before the conversion.
+        /// The key comparer of <paramref name="parameters"/> is carried over for the built-in
+        /// dictionary implementations that expose an <see cref="IEqualityComparer{T}"/>, so
+        /// that callers passing e.g. a <see cref="StringComparer.OrdinalIgnoreCase"/> dictionary
+        /// keep the token lookup semantics they had before the conversion.
         /// </remarks>
         private static IDictionary<string, object> ToObjectParameters(IDictionary<string, string> parameters)
         {
@@ -232,7 +232,7 @@ namespace FluentMigrator.Builders.Execute
                 return null;
             }
 
-            var comparer = (parameters as Dictionary<string, string>)?.Comparer;
+            var comparer = GetKeyComparer(parameters);
             var converted = new Dictionary<string, object>(parameters.Count, comparer);
             foreach (var parameter in parameters)
             {
@@ -240,6 +240,16 @@ namespace FluentMigrator.Builders.Execute
             }
 
             return converted;
+        }
+
+        private static IEqualityComparer<string> GetKeyComparer(IDictionary<string, string> parameters)
+        {
+            return parameters switch
+            {
+                Dictionary<string, string> dictionary => dictionary.Comparer,
+                SortedDictionary<string, string> dictionary => dictionary.Comparer as IEqualityComparer<string>,
+                _ => null,
+            };
         }
 
         /// <summary>

--- a/test/FluentMigrator.Tests/Unit/Builders/Execute/ExecuteExpressionRootTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Builders/Execute/ExecuteExpressionRootTests.cs
@@ -372,6 +372,22 @@ namespace FluentMigrator.Tests.Unit.Builders.Execute
         }
 
         [Test]
+        public void SqlWithLegacySortedStringParametersPreservesKeyComparer()
+        {
+            _contextMock.SetupGet(x => x.ServiceProvider).Returns(new Mock<IServiceProvider>().Object);
+
+            var parameters = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { "Name", "value" } };
+
+            _root.Sql("SELECT $(name)", parameters);
+
+            _expressions.Count.ShouldBe(1);
+            var expression = _expressions.First() as ExecuteSqlStatementExpression;
+            expression.ShouldNotBeNull();
+            expression.Parameters.ShouldNotBeNull();
+            expression.Parameters.ShouldContainKeyAndValue("name", "value");
+        }
+
+        [Test]
         public void ScriptWithLegacyStringParametersPreservesKeyComparer()
         {
             _contextMock.SetupGet(x => x.ServiceProvider).Returns(new Mock<IServiceProvider>().Object);

--- a/test/FluentMigrator.Tests/Unit/SqlScriptTokenReplacerTests.cs
+++ b/test/FluentMigrator.Tests/Unit/SqlScriptTokenReplacerTests.cs
@@ -249,6 +249,18 @@ namespace FluentMigrator.Tests.Unit
             SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT * FROM $(tableprefix)Users", parameters)
                 .ShouldBe("SELECT * FROM $(tableprefix)Users");
         }
+
+        [Test]
+        public void LegacyStringSortedDictionaryOverloadPreservesCaseInsensitiveLookup()
+        {
+            IDictionary<string, string> parameters = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["TablePrefix"] = "App_",
+            };
+
+            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT * FROM $(tableprefix)Users", parameters)
+                .ShouldBe("SELECT * FROM App_Users");
+        }
 #pragma warning restore CS0618 // Type or member is obsolete
     }
 }


### PR DESCRIPTION
Fixes #2342.

## Summary
- query legacy string parameter maps directly in SqlScriptTokenReplacer so their lookup semantics are retained
- preserve the comparer from SortedDictionary when legacy Execute overloads convert string parameters
- add regression coverage for case-insensitive sorted parameter maps