### PR TITLE
Stop MySqlQuoter corrupting RawSql by escaping its backslashes

### DIFF
--- a/src/FluentMigrator.Runner.MySql/Generators/MySql/MySqlQuoter.cs
+++ b/src/FluentMigrator.Runner.MySql/Generators/MySql/MySqlQuoter.cs
@@ -30,8 +30,21 @@ namespace FluentMigrator.Runner.Generators.MySql
         public override string CloseQuote => "`";
 
         /// <inheritdoc />
+        /// <remarks>
+        /// MySQL treats the backslash as an escape character inside string literals, so backslashes
+        /// in a quoted value have to be doubled. That escaping must not be applied to
+        /// <see cref="RawSql"/>, which <see cref="GenericQuoter.QuoteValue"/> returns verbatim: the
+        /// caller has taken responsibility for that SQL and it has to reach the server unmodified.
+        /// Escaping it corrupted regex predicates, <c>LIKE</c> patterns and JSON paths.
+        /// See https://github.com/fluentmigrator/fluentmigrator/issues/2335.
+        /// </remarks>
         public override string QuoteValue(object value)
         {
+            if (value is RawSql rawSql)
+            {
+                return rawSql.Value;
+            }
+
             return base.QuoteValue(value).Replace(@"\", @"\\");
         }
 

--- a/test/FluentMigrator.Tests/Unit/Generators/MySql4/MySql4DataTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/MySql4/MySql4DataTests.cs
@@ -16,6 +16,10 @@
 //
 #endregion
 
+using System.Collections.Generic;
+
+using FluentMigrator.Expressions;
+using FluentMigrator.Model;
 using FluentMigrator.Runner.Generators.MySql;
 
 using NUnit.Framework;
@@ -191,5 +195,70 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql4
             var result = Generator.Generate(expression);
             result.ShouldBe("UPDATE `TestTable1` SET `Name` = 'Just''in', `Age` = 25 WHERE `Id` = 9 AND `Homepage` IS NULL;");
         }
+
+        #region RawSql backslash regression (#2335)
+
+        // Insert/Update/Delete all render their values through IQuoter.QuoteValue, so the MySQL
+        // string-literal backslash escaping reached RawSql values that were meant to pass through
+        // untouched. These reproduce the defect on the DML path alone - no SQL script token
+        // substitution is involved.
+
+        [Test]
+        public void CanUpdateDataWithRawSqlContainingBackslash()
+        {
+            var expression = new UpdateDataExpression
+            {
+                TableName = "TestTable1",
+                Set = new List<KeyValuePair<string, object>>
+                {
+                    new KeyValuePair<string, object>("Flagged", RawSql.Insert(@"`Code` REGEXP '\\d+'"))
+                },
+                Where = new List<KeyValuePair<string, object>>
+                {
+                    new KeyValuePair<string, object>("Id", 9)
+                }
+            };
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe(@"UPDATE `TestTable1` SET `Flagged` = `Code` REGEXP '\\d+' WHERE `Id` = 9;");
+        }
+
+        [Test]
+        public void CanDeleteDataWithRawSqlContainingBackslash()
+        {
+            var expression = new DeleteDataExpression
+            {
+                TableName = "TestTable1",
+                Rows =
+                {
+                    new DeletionDataDefinition
+                    {
+                        new KeyValuePair<string, object>("Path", RawSql.Insert(@"LIKE 'C:\\Temp\\%'"))
+                    }
+                }
+            };
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe(@"DELETE FROM `TestTable1` WHERE `Path` LIKE 'C:\\Temp\\%';");
+        }
+
+        [Test]
+        public void CanInsertDataWithRawSqlContainingBackslash()
+        {
+            var expression = new InsertDataExpression { TableName = "TestTable1" };
+            expression.Rows.Add(new InsertionDataDefinition
+            {
+                new KeyValuePair<string, object>("Pattern", RawSql.Insert(@"'\\d+'")),
+                new KeyValuePair<string, object>("Literal", @"a\b")
+            });
+
+            var result = Generator.Generate(expression);
+
+            // The RawSql column passes through untouched; the ordinary string column beside it is
+            // still escaped, which is what the escaping was written for.
+            result.ShouldBe(@"INSERT INTO `TestTable1` (`Pattern`, `Literal`) VALUES ('\\d+', 'a\\b');");
+        }
+
+        #endregion
     }
 }

--- a/test/FluentMigrator.Tests/Unit/Generators/MySql4/MySql4QuoterTest.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/MySql4/MySql4QuoterTest.cs
@@ -54,5 +54,33 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql4
             _quoter.QuoteValue(new TimeSpan(1,2, 13, 65))
                 .ShouldBe("'26:14:05'");
         }
+
+        /// <summary>
+        /// MySQL needs backslashes doubled inside a string literal, and that escaping is what
+        /// <see cref="MySqlQuoter.QuoteValue"/> adds on top of the generic quoter.
+        /// </summary>
+        [Test]
+        public void BackslashInStringIsEscaped()
+        {
+            _quoter.QuoteValue(@"a\b")
+                .ShouldBe(@"'a\\b'");
+        }
+
+        /// <summary>
+        /// Regression test for #2335. <see cref="RawSql"/> is an opt-in escape hatch: the caller has
+        /// taken responsibility for the SQL, so it must reach the server byte-for-byte. The
+        /// string-literal backslash escaping was being applied to it as well, which silently
+        /// corrupted regex predicates, LIKE patterns and JSON paths.
+        /// </summary>
+        [TestCase("CURRENT_TIMESTAMP")]
+        [TestCase(@"c REGEXP '\d+'")]
+        [TestCase(@"path LIKE 'C:\Temp\%'")]
+        [TestCase(@"json_col->'$.a\b'")]
+        [TestCase("name = 'O''Brien'")]
+        public void RawSqlIsPassedThroughVerbatim(string sql)
+        {
+            _quoter.QuoteValue(RawSql.Insert(sql))
+                .ShouldBe(sql);
+        }
     }
 }


### PR DESCRIPTION
Claude `claude-opus-5[1m]` opening on behalf of @jzabroski.

Split out of #2337 per @hopkienne's review note: the `MySqlQuoter` backslash behaviour affects the DML quoting path independently of script-token replacement, so it gets its own issue (#2335, filed) and its own focused reproducer here rather than riding along with the matrix work.

One commit, one line of production code.

## The defect

`MySqlQuoter.QuoteValue` applied MySQL's string-literal backslash escaping to whatever the generic quoter returned:

```csharp
public override string QuoteValue(object value)
{
    return base.QuoteValue(value).Replace(@"\", @"\\");
}
```

For a `RawSql` value that return is a verbatim passthrough (`GenericQuoter.QuoteValue` has `case RawSql v: return v.Value;`), so the escaping corrupted SQL the caller had already taken responsibility for:

```
RawSql.Insert(@"c REGEXP '\d+'")   ->   c REGEXP '\\d+'
```

Regex predicates, `LIKE` patterns with escapes, and JSON path expressions are all affected.

## Not a token-substitution problem

`Insert`, `Update` and the `Update`/`Delete` `WHERE` builders all render values through `Quoter.QuoteValue` — `GenericGenerator.GenerateUpdateSet` line 446 and `GenerateWhere` line 480. The `RawSql` branch in `GenerateWhere` only picks the *operator*; the value still goes through the quoter. So this reproduces through ordinary migration code with no script tokens involved:

```csharp
Update.Table("TestTable1")
      .Set(new { Flagged = RawSql.Insert(@"`Code` REGEXP '\d+'") })
      .Where(new { Id = 9 });
// emitted: UPDATE `TestTable1` SET `Flagged` = `Code` REGEXP '\\d+' WHERE `Id` = 9;
```

The reproducers in `MySql4DataTests` exercise `Insert`, `Update` and `Delete` on that path directly. `MySql4QuoterTest` covers `QuoteValue` itself.

## The fix

`RawSql` is returned before the escaping runs. Ordinary strings are untouched and still have their backslashes doubled — `BackslashInStringIsEscaped` pins that, and `CanInsertDataWithRawSqlContainingBackslash` asserts both behaviours in one statement: a `RawSql` column passing through beside an ordinary string column still being escaped.

## Affected versions

Both halves of the defect — the unconditional `Replace` in `MySqlQuoter` and the `case RawSql` passthrough in `GenericQuoter` — are present in every release tag checked: `v3.0.0`, `v3.1.3`, `v3.2.4`, `v3.2.8`, `v3.2.12`, `v3.2.16`, `v3.3.2`, `v6.0.0`, `v6.1.3`, `v7.1.0`, `v8.0.0`, `v8.0.1`.

**This is an escaped defect, not a regression in unreleased work** — worth classifying that way in release notes. The behaviour was executed and confirmed against the released 8.0.1 `FluentMigrator.Runner.MySql` package from nuget.org; the version range across older tags is from code inspection.

`HanaQuoter` is the only other quoter in the tree that overrides `QuoteValue`; it special-cases `bool` and delegates to base without post-processing, so it is unaffected. Those two plus `GenericQuoter` are the complete set of `QuoteValue` implementations.

## Verification

The reproducers were checked against the unfixed quoter rather than assumed. Reverting the one-line change fails 6 of the new tests:

```
Failed CanDeleteDataWithRawSqlContainingBackslash
Failed CanInsertDataWithRawSqlContainingBackslash
Failed CanUpdateDataWithRawSqlContainingBackslash
Failed RawSqlIsPassedThroughVerbatim("c REGEXP '\d+'")
Failed RawSqlIsPassedThroughVerbatim("path LIKE 'C:\Temp\%'")
Failed RawSqlIsPassedThroughVerbatim("json_col->'$.a\b'")
```

The two `RawSqlIsPassedThroughVerbatim` cases without a backslash (`CURRENT_TIMESTAMP`, `name = 'O''Brien'`) pass either way, as expected.

With the fix: `5218 passed, 940 skipped, 0 failed` (net48).

## Relationship to #2337

#2337 is rebased onto this branch, because its `RawSql_RoundTripsVerbatim` assertion cannot be green until this lands. Merging this one first lets #2337 rebase onto `main` with this commit dropping out as already-upstream. Reviewing them in that order also means the one-line fix is not buried in a 2,000-line matrix diff, which was the point of the split.

Note that #2337's matrix would **not** have caught this on its own — `SafeToken_Agrees_With_QuoteValue` compares two paths that both run through the same `MySqlQuoter` and so agree on the corrupted value. Catching a defect inside a shared component needs an absolute assertion, which is what `RawSqlIsPassedThroughVerbatim` here and `RawSql_RoundTripsVerbatim` there both are.

Fixes #2335.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
