### PR TITLE
Explain what to do instead when SQLite rejects a foreign key

### DIFF
--- a/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteGenerator.cs
+++ b/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteGenerator.cs
@@ -211,8 +211,8 @@ namespace FluentMigrator.Runner.Generators.SQLite
         }
 
         /// <summary>
-        /// The trailing sentence pointing at LOOSE compatibility mode, which downgrades these
-        /// failures to a warning.
+        /// The trailing sentence pointing at LOOSE compatibility mode, which skips these statements
+        /// instead of failing.
         /// </summary>
         private const string CompatibilityModeHint =
             "If you would rather these statements be skipped than fail, register SQLite with " +

--- a/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteGenerator.cs
+++ b/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteGenerator.cs
@@ -143,6 +143,11 @@ namespace FluentMigrator.Runner.Generators.SQLite
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// SQLite accepts foreign keys only as part of a <c>CREATE TABLE</c> statement - there is no
+        /// <c>ALTER TABLE ... ADD CONSTRAINT</c>. Declaring the key on the column when the table is
+        /// created does work and is generated inline; see <see cref="SQLiteColumn"/>.
+        /// </remarks>
         public override string Generate(CreateForeignKeyExpression expression)
         {
             // If a FK name starts with $$IGNORE$$_ then it means it was handled by the CREATE TABLE
@@ -150,14 +155,68 @@ namespace FluentMigrator.Runner.Generators.SQLite
             if (expression.ForeignKey.Name.StartsWith("$$IGNORE$$_"))
                 return string.Empty;
 
-            return CompatibilityMode.HandleCompatibility("Foreign keys are not supported in SQLite");
+            return CompatibilityMode.HandleCompatibility(DescribeUnsupportedForeignKey(expression.ForeignKey));
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// SQLite has no <c>ALTER TABLE ... DROP CONSTRAINT</c>, so an existing foreign key can only
+        /// be removed by rebuilding the table without it.
+        /// </remarks>
         public override string Generate(DeleteForeignKeyExpression expression)
         {
-            return CompatibilityMode.HandleCompatibility("Foreign keys are not supported in SQLite");
+            var foreignKey = expression.ForeignKey;
+            var name = string.IsNullOrEmpty(foreignKey?.Name) ? "The foreign key" : $"Foreign key '{foreignKey.Name}'";
+
+            return CompatibilityMode.HandleCompatibility(
+                $"{name} cannot be dropped: SQLite has no ALTER TABLE ... DROP CONSTRAINT. " +
+                "Removing a foreign key requires rebuilding the table without it - create a replacement table, " +
+                "copy the rows across, drop the original and rename. " +
+                CompatibilityModeHint);
         }
+
+        /// <summary>
+        /// Explains why a standalone foreign key cannot be created on SQLite, and what to do instead.
+        /// </summary>
+        /// <param name="foreignKey">The foreign key that could not be generated</param>
+        /// <returns>The message</returns>
+        /// <remarks>
+        /// The original message was just "Foreign keys are not supported in SQLite", which reads as
+        /// though SQLite has no foreign keys at all. It does - they simply have to be declared when
+        /// the table is created. Reporters of #1784 and #2117 both concluded FluentMigrator could not
+        /// do foreign keys on SQLite when the working form was one call away.
+        /// </remarks>
+        private static string DescribeUnsupportedForeignKey(ForeignKeyDefinition foreignKey)
+        {
+            var name = string.IsNullOrEmpty(foreignKey?.Name) ? null : $"'{foreignKey.Name}' ";
+
+            var foreignColumns = foreignKey?.ForeignColumns?.ToList() ?? new List<string>();
+            var primaryColumns = foreignKey?.PrimaryColumns?.ToList() ?? new List<string>();
+
+            // Only a single-column key can be shown as a concrete one-liner. A composite key needs
+            // the table-level syntax, which FluentMigrator has no fluent equivalent for yet (#2090),
+            // so the generic example is used rather than one that would not compile.
+            var example = foreignColumns.Count == 1 && primaryColumns.Count == 1
+                ? $"Create.Table(\"{foreignKey.ForeignTable}\").WithColumn(\"{foreignColumns[0]}\").AsInt32()" +
+                  $".ForeignKey(\"{foreignKey.PrimaryTable}\", \"{primaryColumns[0]}\")"
+                : "Create.Table(\"Child\").WithColumn(\"ParentId\").AsInt32().ForeignKey(\"Parent\", \"Id\")";
+
+            return
+                $"Foreign key {name}cannot be created with Create.ForeignKey on SQLite. SQLite accepts foreign keys " +
+                "only inside a CREATE TABLE statement; it has no ALTER TABLE ... ADD CONSTRAINT. " +
+                $"Declare the key on the column when the table is created - {example} - which FluentMigrator " +
+                "generates inline and SQLite accepts. To add one to a table that already exists, rebuild the table: " +
+                "create a replacement with the key declared, copy the rows across, drop the original and rename. " +
+                CompatibilityModeHint;
+        }
+
+        /// <summary>
+        /// The trailing sentence pointing at LOOSE compatibility mode, which downgrades these
+        /// failures to a warning.
+        /// </summary>
+        private const string CompatibilityModeHint =
+            "If you would rather these statements be skipped than fail, register SQLite with " +
+            "AddSQLite(compatibilityMode: CompatibilityMode.LOOSE).";
 
         /// <inheritdoc />
         public override string Generate(CreateSequenceExpression expression)

--- a/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteConstraintsTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteConstraintsTests.cs
@@ -20,7 +20,11 @@ using System.Data;
 
 using FluentMigrator.Exceptions;
 using FluentMigrator.Runner;
+using FluentMigrator.Runner.Generators;
 using FluentMigrator.Runner.Generators.SQLite;
+
+using Microsoft.Extensions.Options;
+
 using NUnit.Framework;
 
 using Shouldly;
@@ -388,5 +392,85 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
             var result = Generator.Generate(expression);
             result.ShouldBe("DROP INDEX \"TESTUNIQUECONSTRAINT\";");
         }
+
+        #region Foreign key diagnostics (#1784, #2117)
+
+        // SQLite accepts foreign keys only inside CREATE TABLE. The old message - "Foreign keys are
+        // not supported in SQLite" - read as though it had none at all, and reporters of both issues
+        // concluded FluentMigrator could not do foreign keys on SQLite when the working form was one
+        // call away. These pin the parts of the message a user has to act on.
+
+        [Test]
+        public void CreateForeignKeyExplainsWhyAndPointsAtTheInlineForm()
+        {
+            var expression = GeneratorTestHelper.GetCreateNamedForeignKeyExpression();
+
+            var exception = Assert.Throws<DatabaseOperationNotSupportedException>(
+                () => Generator.Generate(expression));
+
+            Assert.Multiple(() =>
+            {
+                // Names the offending key rather than failing anonymously.
+                exception.Message.ShouldContain("FK_Test");
+
+                // Says why, so it does not read as "SQLite has no foreign keys".
+                exception.Message.ShouldContain("only inside a CREATE TABLE statement");
+                exception.Message.ShouldContain("ALTER TABLE");
+
+                // Gives the form that does work, built from this key's own tables and columns.
+                exception.Message.ShouldContain(".ForeignKey(\"TestTable2\", \"TestColumn2\")");
+
+                // And the escape hatch, which is what the 5.0 default change actually took away.
+                exception.Message.ShouldContain("CompatibilityMode.LOOSE");
+            });
+        }
+
+        [Test]
+        public void CreateForeignKeyFallsBackToAGenericExampleForCompositeKeys()
+        {
+            // A composite key has no single-column fluent equivalent to suggest (#2090), so the
+            // message must not offer one that would not compile.
+            var expression = GeneratorTestHelper.GetCreateMultiColumnForeignKeyExpression();
+
+            var exception = Assert.Throws<DatabaseOperationNotSupportedException>(
+                () => Generator.Generate(expression));
+
+            exception.Message.ShouldContain("Create.Table(\"Child\").WithColumn(\"ParentId\")");
+        }
+
+        [Test]
+        public void DeleteForeignKeyExplainsTheTableRebuild()
+        {
+            var expression = GeneratorTestHelper.GetDeleteForeignKeyExpression();
+
+            var exception = Assert.Throws<DatabaseOperationNotSupportedException>(
+                () => Generator.Generate(expression));
+
+            Assert.Multiple(() =>
+            {
+                exception.Message.ShouldContain("DROP CONSTRAINT");
+                exception.Message.ShouldContain("rebuilding the table");
+                exception.Message.ShouldContain("CompatibilityMode.LOOSE");
+            });
+        }
+
+        [Test]
+        public void LooseCompatibilityModeSkipsForeignKeysInsteadOfFailing()
+        {
+            // The behaviour the message now advertises. CompatibilityMode became STRICT by default
+            // in 5.0, which is what turned a silent skip into the exception behind #1784.
+            var looseGenerator = new SQLiteGenerator(
+                new SQLiteQuoter(),
+                new SQLiteTypeMap(),
+                new OptionsWrapper<GeneratorOptions>(
+                    new GeneratorOptions { CompatibilityMode = CompatibilityMode.LOOSE }));
+
+            looseGenerator.Generate(GeneratorTestHelper.GetCreateNamedForeignKeyExpression())
+                .ShouldBe(string.Empty);
+            looseGenerator.Generate(GeneratorTestHelper.GetDeleteForeignKeyExpression())
+                .ShouldBe(string.Empty);
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Claude `claude-opus-5[1m]` opening on behalf of @jzabroski.

Milestone 9.0.0, first of the SQLite items. **#1784 and #2117 are the same root cause** — I'd close one as a duplicate of the other.

## They are not a missing feature

Both issues report "Foreign keys are not supported in SQLite" and conclude FluentMigrator cannot do foreign keys on SQLite. It can. SQLite accepts them only inside `CREATE TABLE` — there is no `ALTER TABLE ... ADD CONSTRAINT` — and FluentMigrator already generates that inline form, marking the follow-up expression with `$$IGNORE$$_` so it is skipped rather than rejected ([SQLiteColumn.cs:43](src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteColumn.cs#L43), [SQLiteGenerator.cs:150](src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteGenerator.cs#L150)).

So the working call was one line away from the failing one, and the message gave no hint of it. #2117's reporter worked this out themselves and said exactly what was needed:

> the exception message could be more clear, specifying that it's not supported because of that method usage, but that it works via `WithColumn(<...>).<...>.ForeignKey`

That is what this PR does.

## The new message

`Create.ForeignKey`, for `FK_Test` on `TestTable1`:

> Foreign key `'FK_Test'` cannot be created with Create.ForeignKey on SQLite. SQLite accepts foreign keys only inside a CREATE TABLE statement; it has no ALTER TABLE ... ADD CONSTRAINT. Declare the key on the column when the table is created — `Create.Table("TestTable1").WithColumn("TestColumn1").AsInt32().ForeignKey("TestTable2", "TestColumn2")` — which FluentMigrator generates inline and SQLite accepts. To add one to a table that already exists, rebuild the table: create a replacement with the key declared, copy the rows across, drop the original and rename. If you would rather these statements be skipped than fail, register SQLite with `AddSQLite(compatibilityMode: CompatibilityMode.LOOSE)`.

The example is built from the key's own tables and columns, so it can be pasted rather than translated.

**Composite keys get a generic example instead.** There is no single-column fluent equivalent to suggest for them — that is #2090 — and printing one that would not compile is worse than being generic. Pinned by a test so a future change to #2090 has to revisit it deliberately.

`Delete.ForeignKey` explains the table rebuild, since dropping a constraint has no `ALTER` form either.

## Why the LOOSE hint earns its place

#1784 is titled "Can no longer create foreign key", and @jzabroski's diagnosis on the thread was:

> I think the issue is CompatibilityMode is now strict by default in 5.0

That is the actual regression: the statement was silently skipped before, and STRICT turned the skip into an exception. `AddSQLite` already takes a `compatibilityMode` parameter — the thread's suggested workaround of copy-pasting the DI extension has since shipped — so the message points at a switch that exists.

## Scope

**No behaviour change.** The same expressions throw under STRICT and are skipped under LOOSE, exactly as before. This is a diagnostics change.

I deliberately did **not** implement `Create.ForeignKey` via the 12-step table rebuild. That would silently recreate a user's table — copying data, dropping and renaming — as a side effect of a call that reads like a constraint addition. If that is wanted it should be an explicit opt-in with its own design discussion, not smuggled in behind an error-message fix.

## Tests

Four tests in `SQLiteConstraintsTests`, pinning the parts of the message a user has to act on rather than the whole string:

- names the offending key
- says *why* (`only inside a CREATE TABLE statement`, `ALTER TABLE`)
- gives the working form built from this key's own tables and columns
- offers the LOOSE escape hatch
- falls back to a generic example for composite keys
- and `LooseCompatibilityModeSkipsForeignKeysInsteadOfFailing` asserts the behaviour the message advertises actually holds

Full suite: `5213 passed, 940 skipped, 0 failed` (net48).

## Remaining milestone items

- **#2090** — genuine feature gap, and per @jzabroski's comment on that thread it is cross-provider, not SQLite-specific. Next up as an ADR rather than an implementation, per the same comment.
- **#1783** — unrelated to SQLite; the `"Description:"` prefix is still hardcoded in `GenericDescriptionGenerator` and `MySqlColumn`. Separate PR.

Fixes #1784.
Fixes #2117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
