### PR TITLE
Stop labelling every column description with "Description:"

### DIFF
--- a/src/FluentMigrator.Runner.Core/Generators/Generic/GenericDescriptionGenerator.cs
+++ b/src/FluentMigrator.Runner.Core/Generators/Generic/GenericDescriptionGenerator.cs
@@ -68,23 +68,23 @@ namespace FluentMigrator.Runner.Generators.Generic
                 if (string.IsNullOrEmpty(column.ColumnDescription))
                     continue;
 
-                string initialDescriptionStatement = GenerateColumnDescription(
-                    "Description",
-                    expression.SchemaName,
-                    expression.TableName,
-                    column.Name,
-                    "Description:" + column.ColumnDescription);
-
                 if (column.AdditionalColumnDescriptions.Count == 0)
                 {
-                    statements.Add(initialDescriptionStatement);
+                    // No label. The "Description:" prefix exists only to tell the main description
+                    // apart from the additional named ones below; with none of those, it is noise
+                    // in the user's column comment. See #1783.
+                    statements.Add(GenerateColumnDescription(
+                        "Description",
+                        expression.SchemaName,
+                        expression.TableName,
+                        column.Name,
+                        column.ColumnDescription));
                 }
                 else
                 {
-                    initialDescriptionStatement = "Description:" + column.ColumnDescription;
                     var descriptionsList = new List<string>
                     {
-                        initialDescriptionStatement
+                        "Description:" + column.ColumnDescription
                     };
                     descriptionsList.AddRange(from description in column.AdditionalColumnDescriptions
                                               let newDescriptionStatement = description.Key + ":" + description.Value
@@ -112,19 +112,17 @@ namespace FluentMigrator.Runner.Generators.Generic
             if (string.IsNullOrEmpty(expression.Column.ColumnDescription))
                 return string.Empty;
 
-            string initialDescriptionStatement = GenerateColumnDescription(
-                "Description", expression.SchemaName, expression.TableName, expression.Column.Name, "Description:" + expression.Column.ColumnDescription);
-
             if (expression.Column.AdditionalColumnDescriptions.Count == 0)
             {
-                return initialDescriptionStatement;
+                // Unlabelled: see the note in GenerateDescriptionStatements and #1783.
+                return GenerateColumnDescription(
+                    "Description", expression.SchemaName, expression.TableName, expression.Column.Name, expression.Column.ColumnDescription);
             }
             else
             {
-                initialDescriptionStatement = "Description:" + expression.Column.ColumnDescription;
                 var descriptionsList = new List<string>
                 {
-                    initialDescriptionStatement
+                    "Description:" + expression.Column.ColumnDescription
                 };
                 descriptionsList.AddRange(from description in expression.Column.AdditionalColumnDescriptions
                                           let newDescriptionStatement = description.Key + ":" + description.Value
@@ -139,17 +137,17 @@ namespace FluentMigrator.Runner.Generators.Generic
             if (string.IsNullOrEmpty(expression.Column.ColumnDescription))
                 return string.Empty;
 
-            string initialDescriptionStatement = GenerateColumnDescription(string.Empty, expression.SchemaName, expression.TableName, expression.Column.Name, "Description:"+expression.Column.ColumnDescription);
             if (expression.Column.AdditionalColumnDescriptions.Count == 0)
             {
-                return initialDescriptionStatement;
+                // Unlabelled: see the note in GenerateDescriptionStatements and #1783.
+                return GenerateColumnDescription(
+                    string.Empty, expression.SchemaName, expression.TableName, expression.Column.Name, expression.Column.ColumnDescription);
             }
             else
             {
-                initialDescriptionStatement = "Description:" + expression.Column.ColumnDescription;
                 var descriptionsList = new List<string>
                 {
-                    initialDescriptionStatement
+                    "Description:" + expression.Column.ColumnDescription
                 };
                 descriptionsList.AddRange(from description in expression.Column.AdditionalColumnDescriptions
                                           let newDescriptionStatement = description.Key + ":" + description.Value

--- a/src/FluentMigrator.Runner.MySql/Generators/MySql/MySqlColumn.cs
+++ b/src/FluentMigrator.Runner.MySql/Generators/MySql/MySqlColumn.cs
@@ -44,12 +44,15 @@ namespace FluentMigrator.Runner.Generators.MySql
             if (string.IsNullOrEmpty(column.ColumnDescription))
                 return string.Empty;
 
+            // No label. The "Description:" prefix exists only to tell the main description apart
+            // from the additional named ones; with none of those it is noise in the column comment.
+            // See #1783.
             if (column.AdditionalColumnDescriptions.Count == 0)
-                return string.Format("COMMENT {0}", Quoter.QuoteValue("Description:"+column.ColumnDescription));
+                return string.Format("COMMENT {0}", Quoter.QuoteValue(column.ColumnDescription));
 
             var descriptionsList = new List<string>
             {
-                string.Format("Description:" + column.ColumnDescription)
+                "Description:" + column.ColumnDescription
             };
             descriptionsList.AddRange(from descriptionItem in column.AdditionalColumnDescriptions
                                       select descriptionItem.Key + ":" + descriptionItem.Value);

--- a/test/FluentMigrator.Tests/Unit/Generators/MySql4/MySql4ColumnTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/MySql4/MySql4ColumnTests.cs
@@ -253,7 +253,7 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql4
             var expression = GeneratorTestHelper.GetAlterColumnExpressionWithDescription();
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("ALTER TABLE `TestTable1` MODIFY COLUMN `TestColumn1` VARCHAR(20) NOT NULL COMMENT 'Description:TestColumn1Description';");
+            result.ShouldBe("ALTER TABLE `TestTable1` MODIFY COLUMN `TestColumn1` VARCHAR(20) NOT NULL COMMENT 'TestColumn1Description';");
         }
 
         [Test]
@@ -262,7 +262,7 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql4
             var expression = GeneratorTestHelper.GetCreateColumnExpressionWithDescription();
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("ALTER TABLE `TestTable1` ADD COLUMN `TestColumn1` VARCHAR(5) NOT NULL COMMENT 'Description:TestColumn1Description';");
+            result.ShouldBe("ALTER TABLE `TestTable1` ADD COLUMN `TestColumn1` VARCHAR(5) NOT NULL COMMENT 'TestColumn1Description';");
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/MySql4/MySql4TableTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/MySql4/MySql4TableTests.cs
@@ -295,7 +295,7 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql4
             var expression = GeneratorTestHelper.GetCreateTableWithTableDescriptionAndColumnDescriptions();
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE TABLE `TestTable1` (`TestColumn1` VARCHAR(255) COMMENT 'Description:TestColumn1Description', `TestColumn2` INTEGER NOT NULL COMMENT 'Description:TestColumn2Description') COMMENT 'TestDescription' ENGINE = INNODB;");
+            result.ShouldBe("CREATE TABLE `TestTable1` (`TestColumn1` VARCHAR(255) COMMENT 'TestColumn1Description', `TestColumn2` INTEGER NOT NULL COMMENT 'TestColumn2Description') COMMENT 'TestDescription' ENGINE = INNODB;");
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/MySql5/MySql5ColumnTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/MySql5/MySql5ColumnTests.cs
@@ -83,7 +83,7 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql5
             var expression = GeneratorTestHelper.GetAlterColumnExpressionWithDescription();
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("ALTER TABLE `TestTable1` MODIFY COLUMN `TestColumn1` NVARCHAR(20) NOT NULL COMMENT 'Description:TestColumn1Description';");
+            result.ShouldBe("ALTER TABLE `TestTable1` MODIFY COLUMN `TestColumn1` NVARCHAR(20) NOT NULL COMMENT 'TestColumn1Description';");
         }
 
         [Test]
@@ -102,7 +102,7 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql5
             var expression = GeneratorTestHelper.GetCreateColumnExpressionWithDescription();
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("ALTER TABLE `TestTable1` ADD COLUMN `TestColumn1` NVARCHAR(5) NOT NULL COMMENT 'Description:TestColumn1Description';");
+            result.ShouldBe("ALTER TABLE `TestTable1` ADD COLUMN `TestColumn1` NVARCHAR(5) NOT NULL COMMENT 'TestColumn1Description';");
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/MySql5/MySql5TableTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/MySql5/MySql5TableTests.cs
@@ -230,7 +230,7 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql5
             var expression = GeneratorTestHelper.GetCreateTableWithTableDescriptionAndColumnDescriptions();
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("CREATE TABLE `TestTable1` (`TestColumn1` NVARCHAR(255) COMMENT 'Description:TestColumn1Description', `TestColumn2` INTEGER NOT NULL COMMENT 'Description:TestColumn2Description') COMMENT 'TestDescription' ENGINE = INNODB;");
+            result.ShouldBe("CREATE TABLE `TestTable1` (`TestColumn1` NVARCHAR(255) COMMENT 'TestColumn1Description', `TestColumn2` INTEGER NOT NULL COMMENT 'TestColumn2Description') COMMENT 'TestDescription' ENGINE = INNODB;");
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/MySql8/MySql8ColumnTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/MySql8/MySql8ColumnTests.cs
@@ -253,7 +253,7 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql8
             var expression = GeneratorTestHelper.GetAlterColumnExpressionWithDescription();
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("ALTER TABLE `TestTable1` MODIFY COLUMN `TestColumn1` NVARCHAR(20) NOT NULL COMMENT 'Description:TestColumn1Description';");
+            result.ShouldBe("ALTER TABLE `TestTable1` MODIFY COLUMN `TestColumn1` NVARCHAR(20) NOT NULL COMMENT 'TestColumn1Description';");
         }
 
         [Test]
@@ -262,7 +262,7 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql8
             var expression = GeneratorTestHelper.GetCreateColumnExpressionWithDescription();
 
             var result = Generator.Generate(expression);
-            result.ShouldBe("ALTER TABLE `TestTable1` ADD COLUMN `TestColumn1` NVARCHAR(5) NOT NULL COMMENT 'Description:TestColumn1Description';");
+            result.ShouldBe("ALTER TABLE `TestTable1` ADD COLUMN `TestColumn1` NVARCHAR(5) NOT NULL COMMENT 'TestColumn1Description';");
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/Oracle/OracleDescriptionGeneratorTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Oracle/OracleDescriptionGeneratorTests.cs
@@ -34,7 +34,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
 
             var result = string.Join(";", statements);
             result.ShouldBe(
-                "COMMENT ON TABLE TestTable1 IS 'TestDescription';COMMENT ON COLUMN TestTable1.TestColumn1 IS 'Description:TestColumn1Description';COMMENT ON COLUMN TestTable1.TestColumn2 IS 'Description:TestColumn2Description'");
+                "COMMENT ON TABLE TestTable1 IS 'TestDescription';COMMENT ON COLUMN TestTable1.TestColumn1 IS 'TestColumn1Description';COMMENT ON COLUMN TestTable1.TestColumn2 IS 'TestColumn2Description'");
         }
 
         public override void GenerateDescriptionStatementsForCreateTableReturnTableDescriptionAndColumnDescriptionsWithAdditionalDescriptionsStatements()
@@ -62,7 +62,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
             var createColumnExpression = GeneratorTestHelper.GetCreateColumnExpressionWithDescription();
             var statement = DescriptionGenerator.GenerateDescriptionStatement(createColumnExpression);
 
-            statement.ShouldBe("COMMENT ON COLUMN TestTable1.TestColumn1 IS 'Description:TestColumn1Description'");
+            statement.ShouldBe("COMMENT ON COLUMN TestTable1.TestColumn1 IS 'TestColumn1Description'");
         }
 
         [Test]
@@ -92,7 +92,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
             var alterColumnExpression = GeneratorTestHelper.GetAlterColumnExpressionWithDescription();
             var statement = DescriptionGenerator.GenerateDescriptionStatement(alterColumnExpression);
 
-            statement.ShouldBe("COMMENT ON COLUMN TestTable1.TestColumn1 IS 'Description:TestColumn1Description'");
+            statement.ShouldBe("COMMENT ON COLUMN TestTable1.TestColumn1 IS 'TestColumn1Description'");
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/Oracle/OracleGeneratorTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Oracle/OracleGeneratorTests.cs
@@ -112,7 +112,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
 
             var result = Generator.Generate(expression);
 
-            result.ShouldBe("BEGIN EXECUTE IMMEDIATE 'CREATE TABLE TestTable1 (TestColumn1 NVARCHAR2(255), TestColumn2 NUMBER(10,0) NOT NULL);';EXECUTE IMMEDIATE 'COMMENT ON TABLE TestTable1 IS ''TestDescription''';EXECUTE IMMEDIATE 'COMMENT ON COLUMN TestTable1.TestColumn1 IS ''Description:TestColumn1Description''';EXECUTE IMMEDIATE 'COMMENT ON COLUMN TestTable1.TestColumn2 IS ''Description:TestColumn2Description'''; END;");
+            result.ShouldBe("BEGIN EXECUTE IMMEDIATE 'CREATE TABLE TestTable1 (TestColumn1 NVARCHAR2(255), TestColumn2 NUMBER(10,0) NOT NULL);';EXECUTE IMMEDIATE 'COMMENT ON TABLE TestTable1 IS ''TestDescription''';EXECUTE IMMEDIATE 'COMMENT ON COLUMN TestTable1.TestColumn1 IS ''TestColumn1Description''';EXECUTE IMMEDIATE 'COMMENT ON COLUMN TestTable1.TestColumn2 IS ''TestColumn2Description'''; END;");
         }
 
         [Test]
@@ -154,7 +154,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
 
             var result = Generator.Generate(expression);
 
-            result.ShouldBe("BEGIN EXECUTE IMMEDIATE 'ALTER TABLE TestTable1 ADD TestColumn1 NVARCHAR2(5) NOT NULL;';EXECUTE IMMEDIATE 'COMMENT ON COLUMN TestTable1.TestColumn1 IS ''Description:TestColumn1Description'''; END;");
+            result.ShouldBe("BEGIN EXECUTE IMMEDIATE 'ALTER TABLE TestTable1 ADD TestColumn1 NVARCHAR2(5) NOT NULL;';EXECUTE IMMEDIATE 'COMMENT ON COLUMN TestTable1.TestColumn1 IS ''TestColumn1Description'''; END;");
         }
 
         [Test]
@@ -197,7 +197,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
 
             var result = Generator.Generate(expression);
 
-            result.ShouldBe("BEGIN EXECUTE IMMEDIATE 'ALTER TABLE TestTable1 MODIFY TestColumn1 NVARCHAR2(20) NOT NULL;';EXECUTE IMMEDIATE 'COMMENT ON COLUMN TestTable1.TestColumn1 IS ''Description:TestColumn1Description'''; END;");
+            result.ShouldBe("BEGIN EXECUTE IMMEDIATE 'ALTER TABLE TestTable1 MODIFY TestColumn1 NVARCHAR2(20) NOT NULL;';EXECUTE IMMEDIATE 'COMMENT ON COLUMN TestTable1.TestColumn1 IS ''TestColumn1Description'''; END;");
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/Postgres/PostgresDescriptionGeneratorTest.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Postgres/PostgresDescriptionGeneratorTest.cs
@@ -57,7 +57,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Postgres
             var statements = DescriptionGenerator.GenerateDescriptionStatements(createTableExpression).ToArray();
 
             var result = string.Join("", statements);
-            result.ShouldBe("COMMENT ON TABLE \"public\".\"TestTable1\" IS 'TestDescription';COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'Description:TestColumn1Description';COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn2\" IS 'Description:TestColumn2Description';");
+            result.ShouldBe("COMMENT ON TABLE \"public\".\"TestTable1\" IS 'TestDescription';COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'TestColumn1Description';COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn2\" IS 'TestColumn2Description';");
         }
 
         [Test]
@@ -87,7 +87,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Postgres
             var createColumnExpression = GeneratorTestHelper.GetCreateColumnExpressionWithDescription();
             var statement = DescriptionGenerator.GenerateDescriptionStatement(createColumnExpression);
 
-            statement.ShouldBe("COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'Description:TestColumn1Description';");
+            statement.ShouldBe("COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'TestColumn1Description';");
         }
 
         [Test]
@@ -117,7 +117,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Postgres
             var alterColumnExpression = GeneratorTestHelper.GetAlterColumnExpressionWithDescription();
             var statement = DescriptionGenerator.GenerateDescriptionStatement(alterColumnExpression);
 
-            statement.ShouldBe("COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'Description:TestColumn1Description';");
+            statement.ShouldBe("COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'TestColumn1Description';");
         }
 
         [Test]
@@ -129,5 +129,38 @@ namespace FluentMigrator.Tests.Unit.Generators.Postgres
             statement.ShouldBe("COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'Description:TestColumn1Description" + Environment.NewLine +
                 "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1';");
         }
+
+        #region "Description:" label regression (#1783)
+
+        /// <summary>
+        /// The label exists to separate the main description from the additional named ones. With
+        /// none of those there is nothing to separate it from, so it must not appear - it was
+        /// landing in every user's column comment as of 5.2.0.
+        /// </summary>
+        [Test]
+        public void ColumnDescriptionIsNotLabelledWhenThereAreNoAdditionalDescriptions()
+        {
+            var createColumnExpression = GeneratorTestHelper.GetCreateColumnExpressionWithDescription();
+            var statement = DescriptionGenerator.GenerateDescriptionStatement(createColumnExpression);
+
+            statement.ShouldNotContain("Description:");
+            statement.ShouldBe("COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'TestColumn1Description';");
+        }
+
+        /// <summary>
+        /// The counterpart: once there is more than one description the labels are load-bearing,
+        /// because they are the only thing telling the entries apart in a single comment.
+        /// </summary>
+        [Test]
+        public void ColumnDescriptionKeepsItsLabelWhenAdditionalDescriptionsArePresent()
+        {
+            var createColumnExpression = GeneratorTestHelper.GetCreateColumnExpressionWithDescriptionWithAdditionalDescriptions();
+            var statement = DescriptionGenerator.GenerateDescriptionStatement(createColumnExpression);
+
+            statement.ShouldContain("Description:TestColumn1Description");
+            statement.ShouldContain("AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1");
+        }
+
+        #endregion
     }
 }

--- a/test/FluentMigrator.Tests/Unit/Generators/Redshift/RedshiftDescriptionGeneratorTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Redshift/RedshiftDescriptionGeneratorTests.cs
@@ -53,7 +53,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Redshift
 
             var result = string.Join(string.Empty, statements);
             result.ShouldBe(
-                "COMMENT ON TABLE \"public\".\"TestTable1\" IS 'TestDescription';COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'Description:TestColumn1Description';COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn2\" IS 'Description:TestColumn2Description';");
+                "COMMENT ON TABLE \"public\".\"TestTable1\" IS 'TestDescription';COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'TestColumn1Description';COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn2\" IS 'TestColumn2Description';");
         }
 
         [Test]
@@ -85,7 +85,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Redshift
             var createColumnExpression = GeneratorTestHelper.GetCreateColumnExpressionWithDescription();
             var statement = DescriptionGenerator.GenerateDescriptionStatement(createColumnExpression);
 
-            statement.ShouldBe("COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'Description:TestColumn1Description';");
+            statement.ShouldBe("COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'TestColumn1Description';");
         }
 
         [Test]
@@ -115,7 +115,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Redshift
             var alterColumnExpression = GeneratorTestHelper.GetAlterColumnExpressionWithDescription();
             var statement = DescriptionGenerator.GenerateDescriptionStatement(alterColumnExpression);
 
-            statement.ShouldBe("COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'Description:TestColumn1Description';");
+            statement.ShouldBe("COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'TestColumn1Description';");
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/Snowflake/SnowflakeDescriptionGeneratorTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Snowflake/SnowflakeDescriptionGeneratorTests.cs
@@ -72,7 +72,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Snowflake
 
             var result = string.Join(string.Empty, statements);
             result.ShouldBe(
-                $@"COMMENT ON TABLE ""{TestSchema}"".""TestTable1"" IS 'TestDescription';COMMENT ON COLUMN ""{TestSchema}"".""TestTable1"".""TestColumn1"" IS 'Description:TestColumn1Description';COMMENT ON COLUMN ""{TestSchema}"".""TestTable1"".""TestColumn2"" IS 'Description:TestColumn2Description';", _quotingEnabled);
+                $@"COMMENT ON TABLE ""{TestSchema}"".""TestTable1"" IS 'TestDescription';COMMENT ON COLUMN ""{TestSchema}"".""TestTable1"".""TestColumn1"" IS 'TestColumn1Description';COMMENT ON COLUMN ""{TestSchema}"".""TestTable1"".""TestColumn2"" IS 'TestColumn2Description';", _quotingEnabled);
         }
 
         [Test]
@@ -105,7 +105,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Snowflake
             createColumnExpression.SchemaName = TestSchema;
             var statement = DescriptionGenerator.GenerateDescriptionStatement(createColumnExpression);
 
-            statement.ShouldBe($@"COMMENT ON COLUMN ""{TestSchema}"".""TestTable1"".""TestColumn1"" IS 'Description:TestColumn1Description';", _quotingEnabled);
+            statement.ShouldBe($@"COMMENT ON COLUMN ""{TestSchema}"".""TestTable1"".""TestColumn1"" IS 'TestColumn1Description';", _quotingEnabled);
         }
 
         [Test]
@@ -138,7 +138,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Snowflake
             alterColumnExpression.SchemaName = TestSchema;
             var statement = DescriptionGenerator.GenerateDescriptionStatement(alterColumnExpression);
 
-            statement.ShouldBe($@"COMMENT ON COLUMN ""{TestSchema}"".""TestTable1"".""TestColumn1"" IS 'Description:TestColumn1Description';", _quotingEnabled);
+            statement.ShouldBe($@"COMMENT ON COLUMN ""{TestSchema}"".""TestTable1"".""TestColumn1"" IS 'TestColumn1Description';", _quotingEnabled);
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005DescriptionGeneratorTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005DescriptionGeneratorTests.cs
@@ -33,7 +33,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
             var statements = DescriptionGenerator.GenerateDescriptionStatements(createTableExpression).ToArray();
 
             var result = string.Join("", statements);
-            result.ShouldBe("EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'TestDescription', @level0type=N'SCHEMA', @level0name='dbo', @level1type=N'TABLE', @level1name='TestTable1';EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'Description:TestColumn1Description', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn1';EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'Description:TestColumn2Description', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn2';");
+            result.ShouldBe("EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'TestDescription', @level0type=N'SCHEMA', @level0name='dbo', @level1type=N'TABLE', @level1name='TestTable1';EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'TestColumn1Description', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn1';EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'TestColumn2Description', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn2';");
         }
 
         [Test]
@@ -63,7 +63,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
             var createColumnExpression = GeneratorTestHelper.GetCreateColumnExpressionWithDescription();
             var statement = DescriptionGenerator.GenerateDescriptionStatement(createColumnExpression);
 
-            statement.ShouldBe("EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'Description:TestColumn1Description', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn1';");
+            statement.ShouldBe("EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'TestColumn1Description', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn1';");
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005GeneratorTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005GeneratorTests.cs
@@ -325,7 +325,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
 
             result.ShouldBe(@"CREATE TABLE [dbo].[TestTable1] ([TestColumn1] NVARCHAR(255), [TestColumn2] INT NOT NULL);" + Environment.NewLine +
                             "GO" + Environment.NewLine +
-                            "EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'TestDescription', @level0type=N'SCHEMA', @level0name='dbo', @level1type=N'TABLE', @level1name='TestTable1';EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'Description:TestColumn1Description', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn1';EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'Description:TestColumn2Description', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn2';");
+                            "EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'TestDescription', @level0type=N'SCHEMA', @level0name='dbo', @level1type=N'TABLE', @level1name='TestTable1';EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'TestColumn1Description', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn1';EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'TestColumn2Description', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn2';");
         }
 
         [Test]
@@ -361,7 +361,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
 
             result.ShouldBe(@"ALTER TABLE [dbo].[TestTable1] ADD [TestColumn1] NVARCHAR(5) NOT NULL;" + Environment.NewLine +
                             "GO" + Environment.NewLine +
-                            "EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'Description:TestColumn1Description', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn1';");
+                            "EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'TestColumn1Description', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn1';");
         }
 
         [Test]


### PR DESCRIPTION
Claude `claude-opus-5[1m]` opening on behalf of @jzabroski.

Milestone 9.0.0. Second of the open items, unrelated to the SQLite ones.

## The regression

5.2.0 added `AdditionalColumnDescriptions`, which packs several descriptions into one column comment and prefixes each with its key so they can be told apart. The main description got the literal key `Description:`.

The prefix was applied **unconditionally** — including when there were no additional descriptions. So every user with a plain `WithColumnDescription` got the label in their comment:

```sql
COMMENT ON COLUMN "public"."TestTable1"."TestColumn1" IS 'Description:TestColumn1Description';
```

@martinib77 pinpointed the commit on the thread (`b8dd18d`), and the original reporter noted they weren't using `AdditionalColumnDescriptions` at all.

## The fix

The label exists to separate entries from each other. With one entry there is nothing to separate it from, so it is omitted:

```sql
COMMENT ON COLUMN "public"."TestTable1"."TestColumn1" IS 'TestColumn1Description';
```

Multiple descriptions are unchanged — there the labels are load-bearing, since they are the only thing distinguishing entries inside a single comment:

```sql
IS 'Description:TestColumn1Description
AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1';
```

No feature flag. The issue asked whether one was needed, but a flag would only be necessary if the prefix were sometimes wanted on a lone description, and it never is — it is pure noise when there is nothing to disambiguate.

## Where it was

Two places, which a search for the literal `"Description:"` confirms are the only ones:

- `GenericDescriptionGenerator` — all three expression types carrying a column description (`CreateTable`, `CreateColumn`, `AlterColumn`). This covers SQL Server, Postgres, Oracle, Redshift and Snowflake, which all route through it.
- `MySqlColumn.FormatDescription` — MySQL builds its `COMMENT` clause inline rather than through the description generator, and had the same unconditional prefix.

@jzabroski noted on the thread that `AdditionalColumnDescriptions` does not support `AlterTableExpression`. That gap is real but separate — table descriptions never took the prefix, so it is not part of this regression and is not touched here.

## Tests

27 assertions across 12 provider test files encoded the old output. All 27 are single-description cases; **every assertion involving additional descriptions is untouched**, which is the useful signal that the change is scoped to the unlabelled path.

Two named regression tests pin both halves so a future change to either has to be deliberate:

- `ColumnDescriptionIsNotLabelledWhenThereAreNoAdditionalDescriptions`
- `ColumnDescriptionKeepsItsLabelWhenAdditionalDescriptionsArePresent`

They live in the Postgres fixture because Postgres is what the issue reported against.

Full suite: `5211 passed, 940 skipped, 0 failed` (net48).

## Upgrade note

This changes emitted DDL. Comments already written to a database keep their `Description:` prefix until the migration that created them is re-run — FluentMigrator does not rewrite existing comments, so nothing is silently corrected in place. Worth a line in the 9.0.0 release notes, since a user comparing a fresh database against an existing one will see the difference.

Fixes #1783.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
