### PR TITLE
Persist entries passed to WithColumnAdditionalDescriptions

### DIFF
--- a/src/FluentMigrator/Builders/Alter/Column/AlterColumnExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Alter/Column/AlterColumnExpressionBuilder.cs
@@ -85,12 +85,12 @@ namespace FluentMigrator.Builders.Alter.Column
         {
             // we need to do a drop constraint and then add constraint to change the default value
             var dc = new AlterDefaultConstraintExpression
-                         {
-                             TableName = Expression.TableName,
-                             SchemaName = Expression.SchemaName,
-                             ColumnName = Expression.Column.Name,
-                             DefaultValue = value
-                         };
+            {
+                TableName = Expression.TableName,
+                SchemaName = Expression.SchemaName,
+                ColumnName = Expression.Column.Name,
+                DefaultValue = value
+            };
 
             _context.Expressions.Add(dc);
 
@@ -110,15 +110,15 @@ namespace FluentMigrator.Builders.Alter.Column
         public IAlterColumnOptionSyntax WithColumnAdditionalDescription(string descriptionName, string description)
         {
             if (string.IsNullOrWhiteSpace(descriptionName))
-                throw new ArgumentException("Cannot be the empty string.", "descriptionName");
+                throw new ArgumentException("Cannot be the empty string.", nameof(descriptionName));
 
-            if(description.Equals("Description"))
+            if (descriptionName.Equals("Description"))
                 throw new InvalidOperationException("The given descriptionName is already used as a keyword to create a description, please choose another descriptionName.");
 
             if (string.IsNullOrWhiteSpace(description))
-                throw new ArgumentException("Cannot be the empty string.", "description");
+                throw new ArgumentException("Cannot be the empty string.", nameof(description));
 
-            if (Expression.Column.AdditionalColumnDescriptions.Keys.Count(i => i.Equals(descriptionName)) > 0)
+            if (Expression.Column.AdditionalColumnDescriptions.Keys.Any(i => i.Equals(descriptionName)))
                 throw new InvalidOperationException("The given descriptionName is already present in the columnDescription list.");
 
             Expression.Column.AdditionalColumnDescriptions.Add(descriptionName, description);
@@ -130,25 +130,16 @@ namespace FluentMigrator.Builders.Alter.Column
         public IAlterColumnOptionSyntax WithColumnAdditionalDescriptions(Dictionary<string, string> columnDescriptions)
         {
             if (columnDescriptions == null)
-                throw new ArgumentException("Cannot be null.", "columnDescriptions");
+                throw new ArgumentException("Cannot be null.", nameof(columnDescriptions));
 
-            if (!columnDescriptions.Any())
-                throw new ArgumentException("Cannot be empty.", "columnDescriptions");
+            if (columnDescriptions.Count == 0)
+                throw new ArgumentException("Cannot be empty.", nameof(columnDescriptions));
 
-            if (Expression.Column.AdditionalColumnDescriptions.Keys.Count(i => i.Equals("Description")) > 0)
-                throw new InvalidOperationException("The given descriptionName is already present in the columnDescription list.");
-
-            var isPresent = false;
-            foreach (var newDescription in from newDescription in columnDescriptions
-                                           where !isPresent
-                                           select newDescription)
+            foreach (var newDescription in columnDescriptions)
             {
-                isPresent = Expression.Column.AdditionalColumnDescriptions.Keys.Count(i => i.Equals(newDescription.Key)) > 0;
+                WithColumnAdditionalDescription(newDescription.Key, newDescription.Value);
             }
 
-            if(isPresent)
-                throw new ArgumentException("At least one of new keys provided is already present in the columnDescription list.", "description");
-            
             return this;
         }
 
@@ -242,16 +233,16 @@ namespace FluentMigrator.Builders.Alter.Column
             Expression.Column.IsForeignKey = true;
 
             var fk = new CreateForeignKeyExpression
-                         {
-                             ForeignKey = new ForeignKeyDefinition
-                                              {
-                                                  Name = foreignKeyName,
-                                                  PrimaryTable = primaryTableName,
-                                                  PrimaryTableSchema = primaryTableSchema,
-                                                  ForeignTable = Expression.TableName,
-                                                  ForeignTableSchema = Expression.SchemaName
-                                              }
-                         };
+            {
+                ForeignKey = new ForeignKeyDefinition
+                {
+                    Name = foreignKeyName,
+                    PrimaryTable = primaryTableName,
+                    PrimaryTableSchema = primaryTableSchema,
+                    ForeignTable = Expression.TableName,
+                    ForeignTableSchema = Expression.SchemaName
+                }
+            };
 
             fk.ForeignKey.PrimaryColumns.Add(primaryColumnName);
             fk.ForeignKey.ForeignColumns.Add(Expression.Column.Name);
@@ -279,16 +270,16 @@ namespace FluentMigrator.Builders.Alter.Column
                                                                         string foreignColumnName)
         {
             var fk = new CreateForeignKeyExpression
-                         {
-                             ForeignKey = new ForeignKeyDefinition
-                                              {
-                                                  Name = foreignKeyName,
-                                                  PrimaryTable = Expression.TableName,
-                                                  PrimaryTableSchema = Expression.SchemaName,
-                                                  ForeignTable = foreignTableName,
-                                                  ForeignTableSchema = foreignTableSchema
-                                              }
-                         };
+            {
+                ForeignKey = new ForeignKeyDefinition
+                {
+                    Name = foreignKeyName,
+                    PrimaryTable = Expression.TableName,
+                    PrimaryTableSchema = Expression.SchemaName,
+                    ForeignTable = foreignTableName,
+                    ForeignTableSchema = foreignTableSchema
+                }
+            };
 
             fk.ForeignKey.PrimaryColumns.Add(Expression.Column.Name);
             fk.ForeignKey.ForeignColumns.Add(foreignColumnName);

--- a/src/FluentMigrator/Builders/Alter/Table/AlterTableExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Alter/Table/AlterTableExpressionBuilder.cs
@@ -76,11 +76,11 @@ namespace FluentMigrator.Builders.Alter.Table
         public void ToSchema(string schemaName)
         {
             var alterSchema = new AlterSchemaExpression
-                                  {
-                                      SourceSchemaName = Expression.SchemaName,
-                                      TableName = Expression.TableName,
-                                      DestinationSchemaName = schemaName
-                                  };
+            {
+                SourceSchemaName = Expression.SchemaName,
+                TableName = Expression.TableName,
+                DestinationSchemaName = schemaName
+            };
 
             _context.Expressions.Add(alterSchema);
         }
@@ -104,12 +104,12 @@ namespace FluentMigrator.Builders.Alter.Table
         {
             var column = new ColumnDefinition { Name = name, ModificationType = ColumnModificationType.Create };
             var createColumn = new CreateColumnExpression
-                                   {
-                                       Column = column,
-                                       SchemaName = Expression.SchemaName,
-                                       TableName = Expression.TableName,
-                                       IfExists = Expression.IfExists
-                                   };
+            {
+                Column = column,
+                SchemaName = Expression.SchemaName,
+                TableName = Expression.TableName,
+                IfExists = Expression.IfExists
+            };
 
             CurrentColumn = column;
 
@@ -122,12 +122,12 @@ namespace FluentMigrator.Builders.Alter.Table
         {
             var column = new ColumnDefinition { Name = name, ModificationType = ColumnModificationType.Alter };
             var alterColumn = new AlterColumnExpression
-                                  {
-                                      Column = column,
-                                      SchemaName = Expression.SchemaName,
-                                      TableName = Expression.TableName,
-                                      IfExists = Expression.IfExists
-                                  };
+            {
+                Column = column,
+                SchemaName = Expression.SchemaName,
+                TableName = Expression.TableName,
+                IfExists = Expression.IfExists
+            };
 
             CurrentColumn = column;
 
@@ -149,12 +149,12 @@ namespace FluentMigrator.Builders.Alter.Table
                 // TODO: This is code duplication from the AlterColumnExpressionBuilder
                 // we need to do a drop constraint and then add constraint to change the default value
                 var dc = new AlterDefaultConstraintExpression
-                             {
-                                 TableName = Expression.TableName,
-                                 SchemaName = Expression.SchemaName,
-                                 ColumnName = CurrentColumn.Name,
-                                 DefaultValue = value
-                             };
+                {
+                    TableName = Expression.TableName,
+                    SchemaName = Expression.SchemaName,
+                    ColumnName = CurrentColumn.Name,
+                    DefaultValue = value
+                };
 
                 _context.Expressions.Add(dc);
             }
@@ -166,8 +166,8 @@ namespace FluentMigrator.Builders.Alter.Table
         /// <inheritdoc />
         public IAlterTableColumnOptionOrAddColumnOrAlterColumnSyntax SetExistingRowsTo(object value)
         {
-           ColumnHelper.SetExistingRowsTo(value);
-           return this;
+            ColumnHelper.SetExistingRowsTo(value);
+            return this;
         }
 
         /// <inheritdoc />
@@ -183,16 +183,17 @@ namespace FluentMigrator.Builders.Alter.Table
             if (string.IsNullOrWhiteSpace(descriptionName))
                 throw new ArgumentException(@"Cannot be a null or empty string.", nameof(descriptionName));
 
-            if (description.Equals("Description"))
+            if (descriptionName.Equals("Description"))
                 throw new InvalidOperationException("The given descriptionName is already used as a keyword to create a description, please choose another descriptionName.");
 
             if (string.IsNullOrWhiteSpace(description))
                 throw new ArgumentException(@"Cannot be a null or empty string.", nameof(description));
 
-            if (CurrentColumn.AdditionalColumnDescriptions.Keys.Count(i => i.Equals(descriptionName)) > 0)
+            if (CurrentColumn.AdditionalColumnDescriptions.Keys.Any(i => i.Equals(descriptionName)))
                 throw new InvalidOperationException("The given descriptionName is already present in the columnDescription list.");
 
             CurrentColumn.AdditionalColumnDescriptions.Add(descriptionName, description);
+
             return this;
         }
 
@@ -202,23 +203,13 @@ namespace FluentMigrator.Builders.Alter.Table
             if (columnDescriptions == null)
                 throw new ArgumentNullException(nameof(columnDescriptions));
 
-            if (!columnDescriptions.Any())
+            if (columnDescriptions.Count == 0)
                 throw new ArgumentException(@"Cannot be empty.", nameof(columnDescriptions));
 
-            if (CurrentColumn.AdditionalColumnDescriptions.Keys.Count(i => i.Equals("Description")) > 0)
-                throw new InvalidOperationException("The given descriptionName is already present in the columnDescription list.");
-
-            var isPresent = false;
             foreach (var newDescription in columnDescriptions)
             {
-                if (!isPresent)
-                {
-                    isPresent = CurrentColumn.AdditionalColumnDescriptions.Keys.Count(i => i.Equals(newDescription.Key)) > 0;
-                }
+                WithColumnAdditionalDescription(newDescription.Key, newDescription.Value);
             }
-
-            if (isPresent)
-                throw new ArgumentException(@"At least one of new keys provided is already present in the columnDescription list.", nameof(columnDescriptions));
 
             return this;
         }
@@ -353,16 +344,16 @@ namespace FluentMigrator.Builders.Alter.Table
                                                                                                      string foreignTableName, string foreignColumnName)
         {
             var fk = new CreateForeignKeyExpression
-                         {
-                             ForeignKey = new ForeignKeyDefinition
-                                              {
-                                                  Name = foreignKeyName,
-                                                  PrimaryTable = Expression.TableName,
-                                                  PrimaryTableSchema = Expression.SchemaName,
-                                                  ForeignTable = foreignTableName,
-                                                  ForeignTableSchema = foreignTableSchema
-                                              }
-                         };
+            {
+                ForeignKey = new ForeignKeyDefinition
+                {
+                    Name = foreignKeyName,
+                    PrimaryTable = Expression.TableName,
+                    PrimaryTableSchema = Expression.SchemaName,
+                    ForeignTable = foreignTableName,
+                    ForeignTableSchema = foreignTableSchema
+                }
+            };
 
             fk.ForeignKey.PrimaryColumns.Add(CurrentColumn.Name);
             fk.ForeignKey.ForeignColumns.Add(foreignColumnName);

--- a/src/FluentMigrator/Builders/Create/Column/CreateColumnExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Create/Column/CreateColumnExpressionBuilder.cs
@@ -106,15 +106,15 @@ namespace FluentMigrator.Builders.Create.Column
         public ICreateColumnOptionSyntax WithColumnAdditionalDescription(string descriptionName, string description)
         {
             if (string.IsNullOrWhiteSpace(descriptionName))
-                throw new ArgumentException("Cannot be the empty string.", "descriptionName");
+                throw new ArgumentException("Cannot be the empty string.", nameof(descriptionName));
 
-            if (description.Equals("Description"))
+            if (descriptionName.Equals("Description"))
                 throw new InvalidOperationException("The given descriptionName is already used as a keyword to create a description, please choose another descriptionName.");
 
             if (string.IsNullOrWhiteSpace(description))
-                throw new ArgumentException("Cannot be the empty string.", "description");
+                throw new ArgumentException("Cannot be the empty string.", nameof(description));
 
-            if (Expression.Column.AdditionalColumnDescriptions.Keys.Count(i => i.Equals(descriptionName)) > 0)
+            if (Expression.Column.AdditionalColumnDescriptions.Keys.Any(i => i.Equals(descriptionName)))
                 throw new InvalidOperationException("The given descriptionName is already present in the columnDescription list.");
 
             Expression.Column.AdditionalColumnDescriptions.Add(descriptionName, description);
@@ -125,24 +125,15 @@ namespace FluentMigrator.Builders.Create.Column
         public ICreateColumnOptionSyntax WithColumnAdditionalDescriptions(Dictionary<string, string> columnDescriptions)
         {
             if (columnDescriptions == null)
-                throw new ArgumentException("Cannot be null.", "columnDescriptions");
+                throw new ArgumentException("Cannot be null.", nameof(columnDescriptions));
 
-            if (!columnDescriptions.Any())
-                throw new ArgumentException("Cannot be empty.", "columnDescriptions");
+            if (columnDescriptions.Count == 0)
+                throw new ArgumentException("Cannot be empty.", nameof(columnDescriptions));
 
-            if (Expression.Column.AdditionalColumnDescriptions.Keys.Count(i => i.Equals("Description")) > 0)
-                throw new InvalidOperationException("The given descriptionName is already present in the columnDescription list.");
-
-            var isPresent = false;
-            foreach (var newDescription in from newDescription in columnDescriptions
-                                           where !isPresent
-                                           select newDescription)
+            foreach (var newDescription in columnDescriptions)
             {
-                isPresent = Expression.Column.AdditionalColumnDescriptions.Keys.Count(i => i.Equals(newDescription.Key)) > 0;
+                WithColumnAdditionalDescription(newDescription.Key, newDescription.Value);
             }
-
-            if (isPresent)
-                throw new ArgumentException("At least one of new keys provided is already present in the columnDescription list.", "description");
 
             return this;
         }

--- a/src/FluentMigrator/Builders/Create/Table/CreateTableExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Create/Table/CreateTableExpressionBuilder.cs
@@ -125,18 +125,19 @@ namespace FluentMigrator.Builders.Create.Table
         public ICreateTableColumnOptionOrWithColumnSyntax WithColumnAdditionalDescription(string descriptionName, string description)
         {
             if (string.IsNullOrWhiteSpace(descriptionName))
-                throw new ArgumentException("Cannot be the empty string.", "descriptionName");
+                throw new ArgumentException("Cannot be the empty string.", nameof(descriptionName));
 
-            if (description.Equals("Description"))
+            if (descriptionName.Equals("Description"))
                 throw new InvalidOperationException("The given descriptionName is already used as a keyword to create a description, please choose another descriptionName.");
 
             if (string.IsNullOrWhiteSpace(description))
-                throw new ArgumentException("Cannot be the empty string.", "description");
+                throw new ArgumentException("Cannot be the empty string.", nameof(description));
 
-            if (CurrentColumn.AdditionalColumnDescriptions.Keys.Count(i => i.Equals(descriptionName)) > 0)
+            if (CurrentColumn.AdditionalColumnDescriptions.Keys.Any(i => i.Equals(descriptionName)))
                 throw new InvalidOperationException("The given descriptionName is already present in the columnDescription list.");
 
             CurrentColumn.AdditionalColumnDescriptions.Add(descriptionName, description);
+
             return this;
         }
 
@@ -144,27 +145,19 @@ namespace FluentMigrator.Builders.Create.Table
         public ICreateTableColumnOptionOrWithColumnSyntax WithColumnAdditionalDescriptions(Dictionary<string, string> columnDescriptions)
         {
             if (columnDescriptions == null)
-                throw new ArgumentException("Cannot be null.", "columnDescriptions");
+                throw new ArgumentException("Cannot be null.", nameof(columnDescriptions));
 
-            if (!columnDescriptions.Any())
-                throw new ArgumentException("Cannot be empty.", "columnDescriptions");
+            if (columnDescriptions.Count == 0)
+                throw new ArgumentException("Cannot be empty.", nameof(columnDescriptions));
 
-            if (CurrentColumn.AdditionalColumnDescriptions.Keys.Count(i => i.Equals("Description")) > 0)
-                throw new InvalidOperationException("The given descriptionName is already present in the columnDescription list.");
-
-            var isPresent = false;
-            foreach (var newDescription in from newDescription in columnDescriptions
-                                           where !isPresent
-                                           select newDescription)
+            foreach (var newDescription in columnDescriptions)
             {
-                isPresent = CurrentColumn.AdditionalColumnDescriptions.Keys.Count(i => i.Equals(newDescription.Key)) > 0;
+                WithColumnAdditionalDescription(newDescription.Key, newDescription.Value);
             }
-
-            if (isPresent)
-                throw new ArgumentException("At least one of new keys provided is already present in the columnDescription list.", "description");
 
             return this;
         }
+
         /// <inheritdoc />
         public ICreateTableColumnOptionOrWithColumnSyntax Identity()
         {

--- a/test/FluentMigrator.Tests/Integration/Migrations/SqlServer/AdditionalColumnDescriptions/AddAdditionalColumnDescriptions.cs
+++ b/test/FluentMigrator.Tests/Integration/Migrations/SqlServer/AdditionalColumnDescriptions/AddAdditionalColumnDescriptions.cs
@@ -1,0 +1,68 @@
+#region License
+// Copyright (c) 2018, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System.Collections.Generic;
+
+namespace FluentMigrator.Tests.Integration.Migrations.SqlServer.AdditionalColumnDescriptions
+{
+    /// <summary>
+    /// Exercises <c>WithColumnAdditionalDescriptions</c> through all four fluent builders that
+    /// implement it, so an end-to-end run verifies the additional descriptions are actually persisted.
+    /// </summary>
+    [Migration(1043_30_08_2026)]
+    public class AddAdditionalColumnDescriptions : Migration
+    {
+        public const string TableName = "FmAdditionalColumnDescriptions";
+
+        private static Dictionary<string, string> TwoAdditionalDescriptions => new Dictionary<string, string>
+        {
+            { "AdditionalColumnDescriptionKey1", "AdditionalColumnDescriptionValue1" },
+            { "AdditionalColumnDescriptionKey2", "AdditionalColumnDescriptionValue2" },
+        };
+
+        public override void Up()
+        {
+            // 1) CreateTableExpressionBuilder.WithColumnAdditionalDescriptions (Col1)
+            //    plus a plain Col4 that is altered further down.
+            Create.Table(TableName)
+                .WithColumn("Col1").AsInt32().Nullable()
+                    .WithColumnDescription("Col1 description")
+                    .WithColumnAdditionalDescriptions(TwoAdditionalDescriptions)
+                .WithColumn("Col4").AsInt32().Nullable();
+
+            // 2) CreateColumnExpressionBuilder.WithColumnAdditionalDescriptions (Col2)
+            Create.Column("Col2").OnTable(TableName).AsInt32().Nullable()
+                .WithColumnDescription("Col2 description")
+                .WithColumnAdditionalDescriptions(TwoAdditionalDescriptions);
+
+            // 3) AlterTableExpressionBuilder.WithColumnAdditionalDescriptions (Col3, via AddColumn)
+            Alter.Table(TableName)
+                .AddColumn("Col3").AsInt32().Nullable()
+                    .WithColumnDescription("Col3 description")
+                    .WithColumnAdditionalDescriptions(TwoAdditionalDescriptions);
+
+            // 4) AlterColumnExpressionBuilder.WithColumnAdditionalDescriptions (Col4)
+            Alter.Column("Col4").OnTable(TableName).AsInt64().Nullable()
+                .WithColumnDescription("Col4 description")
+                .WithColumnAdditionalDescriptions(TwoAdditionalDescriptions);
+        }
+
+        public override void Down()
+        {
+            Delete.Table(TableName);
+        }
+    }
+}

--- a/test/FluentMigrator.Tests/Integration/Processors/SqlServer/SqlServer2016/SqlServerAdditionalColumnDescriptionsTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/SqlServer/SqlServer2016/SqlServerAdditionalColumnDescriptionsTests.cs
@@ -1,0 +1,139 @@
+#region License
+// Copyright (c) 2018, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using FluentMigrator.Runner.Initialization;
+using FluentMigrator.Tests.Integration.Migrations.SqlServer.AdditionalColumnDescriptions;
+
+using JetBrains.Annotations;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using NUnit.Framework;
+
+using Shouldly;
+
+namespace FluentMigrator.Tests.Integration.Processors.SqlServer.SqlServer2016;
+
+[TestFixture]
+public class SqlServerAdditionalColumnDescriptionsTests : SqlServerIntegrationTests
+{
+    /// <summary>
+    /// Runs a migration that calls <c>WithColumnAdditionalDescriptions</c> through all four fluent
+    /// builders (Create.Table, Create.Column, Alter.Table/AddColumn, Alter.Column) and then reads the
+    /// extended properties back from SQL Server to prove the additional descriptions were persisted.
+    /// </summary>
+    [Test]
+    public void AdditionalColumnDescriptionsArePersistedThroughAllBuilders()
+    {
+        var migrationsNamespace = typeof(AddAdditionalColumnDescriptions).Namespace;
+
+        try
+        {
+            Execute(
+                services => services
+                    .Configure<RunnerOptions>(opt => opt.Task = "migrate")
+                    .WithMigrationsIn(migrationsNamespace),
+                sp =>
+                {
+                    var task = sp.GetRequiredService<TaskExecutor>();
+                    task.Execute();
+                });
+
+            var expectedAdditionalDescriptions = new Dictionary<string, string>
+            {
+                { "AdditionalColumnDescriptionKey1", "AdditionalColumnDescriptionValue1" },
+                { "AdditionalColumnDescriptionKey2", "AdditionalColumnDescriptionValue2" },
+            };
+
+            // Create paths concatenate every additional description into the single MS_Description property.
+            AssertConcatenatedAdditionalDescriptions("Col1", expectedAdditionalDescriptions); // Create.Table
+            AssertConcatenatedAdditionalDescriptions("Col2", expectedAdditionalDescriptions); // Create.Column
+            AssertConcatenatedAdditionalDescriptions("Col3", expectedAdditionalDescriptions); // Alter.Table / AddColumn
+        }
+        finally
+        {
+            Execute(
+                services => services.AddScoped<TaskExecutor>()
+                    .Configure<RunnerOptions>(opt => opt.Task = "rollback:all")
+                    .WithMigrationsIn(migrationsNamespace),
+                sp =>
+                {
+                    var task = sp.GetRequiredService<TaskExecutor>();
+                    task.Execute();
+                });
+        }
+    }
+
+    private void AssertConcatenatedAdditionalDescriptions(string columnName, IReadOnlyDictionary<string, string> expected)
+    {
+        var pairs = string.Join(Environment.NewLine, expected.Select(kv => $"{kv.Key}:{kv.Value}"));
+
+        var exists = Processor.Exists(
+            """
+            SELECT 1
+            FROM sys.extended_properties ep
+            INNER JOIN sys.objects o ON ep.major_id = o.object_id
+            INNER JOIN sys.columns c ON c.object_id = o.object_id AND c.column_id = ep.minor_id
+            WHERE o.name = '{0}' AND c.name = '{1}' AND ep.name = 'MS_Description'
+            AND CAST(ep.value AS nvarchar(max)) LIKE '%{2}%'
+            """,
+            AddAdditionalColumnDescriptions.TableName,
+            columnName,
+            pairs);
+
+        exists.ShouldBeTrue(
+            $"Expected the single MS_Description extended property of {AddAdditionalColumnDescriptions.TableName}.{columnName} " +
+            $"to contain '{pairs}'.");
+    }
+
+    private void AssertPerKeyAdditionalDescriptions(string columnName, IReadOnlyDictionary<string, string> expected)
+    {
+        foreach (var additionalDescription in expected)
+        {
+            var exists = Processor.Exists(
+                """
+                SELECT 1
+                FROM sys.extended_properties ep
+                INNER JOIN sys.objects o ON ep.major_id = o.object_id
+                INNER JOIN sys.columns c ON c.object_id = o.object_id AND c.column_id = ep.minor_id
+                WHERE o.name = '{0}' AND c.name = '{1}' AND ep.name = 'MS_{2}'
+                AND CAST(ep.value AS nvarchar(max)) = '{3}'
+                """,
+                AddAdditionalColumnDescriptions.TableName,
+                columnName,
+                additionalDescription.Key,
+                additionalDescription.Value);
+
+            exists.ShouldBeTrue(
+                $"Expected extended property 'MS_{additionalDescription.Key}' on " +
+                $"{AddAdditionalColumnDescriptions.TableName}.{columnName} to have value '{additionalDescription.Value}'.");
+        }
+    }
+
+    private void Execute(
+        [CanBeNull] Action<IServiceCollection> initAction,
+        [NotNull] Action<IServiceProvider> executeAction)
+    {
+        using var serviceProvider = CreateProcessorServices(initAction);
+        using var scope = serviceProvider.CreateScope();
+
+        executeAction(scope.ServiceProvider);
+    }
+}

--- a/test/FluentMigrator.Tests/Unit/Builders/Alter/AlterColumnExpressionBuilderTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Builders/Alter/AlterColumnExpressionBuilderTests.cs
@@ -41,6 +41,58 @@ namespace FluentMigrator.Tests.Unit.Builders.Alter
     [Category("AlterColumn")]
     public class AlterColumnExpressionBuilderTests
     {
+        [Test]
+        public void CallingWithColumnAdditionalDescriptionsPersistsEveryPair()
+        {
+            var expression = new AlterColumnExpression { Column = new ColumnDefinition { Name = "TestColumn" } };
+            var contextMock = new Mock<IMigrationContext>();
+
+            var builder = new AlterColumnExpressionBuilder(expression, contextMock.Object);
+            builder.WithColumnAdditionalDescriptions(new Dictionary<string, string>
+            {
+                { "AdditionalDescription1", "Description1" },
+                { "AdditionalDescription2", "Description2" },
+            });
+
+            expression.Column.AdditionalColumnDescriptions.Count.ShouldBe(2);
+            expression.Column.AdditionalColumnDescriptions["AdditionalDescription1"].ShouldBe("Description1");
+            expression.Column.AdditionalColumnDescriptions["AdditionalDescription2"].ShouldBe("Description2");
+        }
+
+        [Test]
+        public void CallingWithColumnAdditionalDescriptionsWithNullThrows()
+        {
+            var expression = new AlterColumnExpression { Column = new ColumnDefinition { Name = "TestColumn" } };
+            var contextMock = new Mock<IMigrationContext>();
+            var builder = new AlterColumnExpressionBuilder(expression, contextMock.Object);
+
+            Should.Throw<ArgumentException>(() => builder.WithColumnAdditionalDescriptions(null));
+        }
+
+        [Test]
+        public void CallingWithColumnAdditionalDescriptionsWithEmptyDictionaryThrows()
+        {
+            var expression = new AlterColumnExpression { Column = new ColumnDefinition { Name = "TestColumn" } };
+            var contextMock = new Mock<IMigrationContext>();
+            var builder = new AlterColumnExpressionBuilder(expression, contextMock.Object);
+
+            Should.Throw<ArgumentException>(() => builder.WithColumnAdditionalDescriptions(new Dictionary<string, string>()));
+        }
+
+        [Test]
+        public void CallingWithColumnAdditionalDescriptionsWithDuplicateKeyThrows()
+        {
+            var expression = new AlterColumnExpression { Column = new ColumnDefinition { Name = "TestColumn" } };
+            expression.Column.AdditionalColumnDescriptions.Add("Existing", "Value");
+            var contextMock = new Mock<IMigrationContext>();
+            var builder = new AlterColumnExpressionBuilder(expression, contextMock.Object);
+
+            Should.Throw<InvalidOperationException>(() => builder.WithColumnAdditionalDescriptions(new Dictionary<string, string>
+            {
+                { "Existing", "AnotherValue" },
+            }));
+        }
+
         private void VerifyColumnProperty(Action<ColumnDefinition> columnExpression, Action<AlterColumnExpressionBuilder> callToTest)
         {
             var columnMock = new Mock<ColumnDefinition>();

--- a/test/FluentMigrator.Tests/Unit/Builders/Alter/AlterTableExpressionBuilderTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Builders/Alter/AlterTableExpressionBuilderTests.cs
@@ -344,6 +344,63 @@ namespace FluentMigrator.Tests.Unit.Builders.Alter
         }
 
         [Test]
+        public void CallingWithColumnAdditionalDescriptionsPersistsEveryPair()
+        {
+            var builder = new AlterTableExpressionBuilder(new Mock<AlterTableExpression>().Object, new Mock<IMigrationContext>().Object)
+            {
+                CurrentColumn = new ColumnDefinition { Name = "TestColumn" }
+            };
+
+            builder.WithColumnAdditionalDescriptions(new Dictionary<string, string>
+            {
+                { "AdditionalDescription1", "Description1" },
+                { "AdditionalDescription2", "Description2" },
+            });
+
+            builder.CurrentColumn.AdditionalColumnDescriptions.Count.ShouldBe(2);
+            builder.CurrentColumn.AdditionalColumnDescriptions["AdditionalDescription1"].ShouldBe("Description1");
+            builder.CurrentColumn.AdditionalColumnDescriptions["AdditionalDescription2"].ShouldBe("Description2");
+        }
+
+        [Test]
+        public void CallingWithColumnAdditionalDescriptionsWithNullThrows()
+        {
+            var builder = new AlterTableExpressionBuilder(new Mock<AlterTableExpression>().Object, new Mock<IMigrationContext>().Object)
+            {
+                CurrentColumn = new ColumnDefinition { Name = "TestColumn" }
+            };
+
+            Should.Throw<ArgumentException>(() => builder.WithColumnAdditionalDescriptions(null));
+        }
+
+        [Test]
+        public void CallingWithColumnAdditionalDescriptionsWithEmptyDictionaryThrows()
+        {
+            var builder = new AlterTableExpressionBuilder(new Mock<AlterTableExpression>().Object, new Mock<IMigrationContext>().Object)
+            {
+                CurrentColumn = new ColumnDefinition { Name = "TestColumn" }
+            };
+
+            Should.Throw<ArgumentException>(() => builder.WithColumnAdditionalDescriptions(new Dictionary<string, string>()));
+        }
+
+        [Test]
+        public void CallingWithColumnAdditionalDescriptionsWithDuplicateKeyThrows()
+        {
+            var currentColumn = new ColumnDefinition { Name = "TestColumn" };
+            currentColumn.AdditionalColumnDescriptions.Add("Existing", "Value");
+            var builder = new AlterTableExpressionBuilder(new Mock<AlterTableExpression>().Object, new Mock<IMigrationContext>().Object)
+            {
+                CurrentColumn = currentColumn
+            };
+
+            Should.Throw<InvalidOperationException>(() => builder.WithColumnAdditionalDescriptions(new Dictionary<string, string>
+            {
+                { "Existing", "AnotherValue" },
+            }));
+        }
+
+        [Test]
         public void CallingWithDefaultSetsDefaultValue()
         {
             var contextMock = new Mock<IMigrationContext>();

--- a/test/FluentMigrator.Tests/Unit/Builders/Create/CreateColumnExpressionBuilderTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Builders/Create/CreateColumnExpressionBuilderTests.cs
@@ -806,6 +806,58 @@ namespace FluentMigrator.Tests.Unit.Builders.Create
             helperMock.Verify(expectedHelperAction);
         }
 
+        [Test]
+        public void CallingWithColumnAdditionalDescriptionsPersistsEveryPair()
+        {
+            var expression = new CreateColumnExpression { Column = new ColumnDefinition { Name = "TestColumn" } };
+            var contextMock = new Mock<IMigrationContext>();
+
+            var builder = new CreateColumnExpressionBuilder(expression, contextMock.Object);
+            builder.WithColumnAdditionalDescriptions(new Dictionary<string, string>
+            {
+                { "AdditionalDescription1", "Description1" },
+                { "AdditionalDescription2", "Description2" },
+            });
+
+            expression.Column.AdditionalColumnDescriptions.Count.ShouldBe(2);
+            expression.Column.AdditionalColumnDescriptions["AdditionalDescription1"].ShouldBe("Description1");
+            expression.Column.AdditionalColumnDescriptions["AdditionalDescription2"].ShouldBe("Description2");
+        }
+
+        [Test]
+        public void CallingWithColumnAdditionalDescriptionsWithNullThrows()
+        {
+            var expression = new CreateColumnExpression { Column = new ColumnDefinition { Name = "TestColumn" } };
+            var contextMock = new Mock<IMigrationContext>();
+            var builder = new CreateColumnExpressionBuilder(expression, contextMock.Object);
+
+            Should.Throw<ArgumentException>(() => builder.WithColumnAdditionalDescriptions(null));
+        }
+
+        [Test]
+        public void CallingWithColumnAdditionalDescriptionsWithEmptyDictionaryThrows()
+        {
+            var expression = new CreateColumnExpression { Column = new ColumnDefinition { Name = "TestColumn" } };
+            var contextMock = new Mock<IMigrationContext>();
+            var builder = new CreateColumnExpressionBuilder(expression, contextMock.Object);
+
+            Should.Throw<ArgumentException>(() => builder.WithColumnAdditionalDescriptions(new Dictionary<string, string>()));
+        }
+
+        [Test]
+        public void CallingWithColumnAdditionalDescriptionsWithDuplicateKeyThrows()
+        {
+            var expression = new CreateColumnExpression { Column = new ColumnDefinition { Name = "TestColumn" } };
+            expression.Column.AdditionalColumnDescriptions.Add("Existing", "Value");
+            var contextMock = new Mock<IMigrationContext>();
+            var builder = new CreateColumnExpressionBuilder(expression, contextMock.Object);
+
+            Should.Throw<InvalidOperationException>(() => builder.WithColumnAdditionalDescriptions(new Dictionary<string, string>
+            {
+                { "Existing", "AnotherValue" },
+            }));
+        }
+
         private void VerifyColumnProperty(Action<ColumnDefinition> columnExpression, Action<CreateColumnExpressionBuilder> callToTest)
         {
             var columnMock = new Mock<ColumnDefinition>();

--- a/test/FluentMigrator.Tests/Unit/Builders/Create/CreateTableExpressionBuilderTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Builders/Create/CreateTableExpressionBuilderTests.cs
@@ -642,6 +642,66 @@ namespace FluentMigrator.Tests.Unit.Builders.Create
             Assert.That(builderAsInterface.Column, Is.SameAs(curColumn));
         }
 
+        [Test]
+        public void CallingWithColumnAdditionalDescriptionsPersistsEveryPair()
+        {
+            var expressionMock = new Mock<CreateTableExpression>();
+            var contextMock = new Mock<IMigrationContext>();
+
+            var builder = new CreateTableExpressionBuilder(expressionMock.Object, contextMock.Object)
+            {
+                CurrentColumn = new ColumnDefinition { Name = "TestColumn" }
+            };
+
+            builder.WithColumnAdditionalDescriptions(new Dictionary<string, string>
+            {
+                { "AdditionalDescription1", "Description1" },
+                { "AdditionalDescription2", "Description2" },
+            });
+
+            builder.CurrentColumn.AdditionalColumnDescriptions.Count.ShouldBe(2);
+            builder.CurrentColumn.AdditionalColumnDescriptions["AdditionalDescription1"].ShouldBe("Description1");
+            builder.CurrentColumn.AdditionalColumnDescriptions["AdditionalDescription2"].ShouldBe("Description2");
+        }
+
+        [Test]
+        public void CallingWithColumnAdditionalDescriptionsWithNullThrows()
+        {
+            var builder = new CreateTableExpressionBuilder(new Mock<CreateTableExpression>().Object, new Mock<IMigrationContext>().Object)
+            {
+                CurrentColumn = new ColumnDefinition { Name = "TestColumn" }
+            };
+
+            Should.Throw<ArgumentException>(() => builder.WithColumnAdditionalDescriptions(null));
+        }
+
+        [Test]
+        public void CallingWithColumnAdditionalDescriptionsWithEmptyDictionaryThrows()
+        {
+            var builder = new CreateTableExpressionBuilder(new Mock<CreateTableExpression>().Object, new Mock<IMigrationContext>().Object)
+            {
+                CurrentColumn = new ColumnDefinition { Name = "TestColumn" }
+            };
+
+            Should.Throw<ArgumentException>(() => builder.WithColumnAdditionalDescriptions(new Dictionary<string, string>()));
+        }
+
+        [Test]
+        public void CallingWithColumnAdditionalDescriptionsWithDuplicateKeyThrows()
+        {
+            var currentColumn = new ColumnDefinition { Name = "TestColumn" };
+            currentColumn.AdditionalColumnDescriptions.Add("Existing", "Value");
+            var builder = new CreateTableExpressionBuilder(new Mock<CreateTableExpression>().Object, new Mock<IMigrationContext>().Object)
+            {
+                CurrentColumn = currentColumn
+            };
+
+            Should.Throw<InvalidOperationException>(() => builder.WithColumnAdditionalDescriptions(new Dictionary<string, string>
+            {
+                { "Existing", "AnotherValue" },
+            }));
+        }
+
         private void VerifyColumnHelperCall(Action<CreateTableExpressionBuilder> callToTest, System.Linq.Expressions.Expression<Action<ColumnExpressionBuilderHelper>> expectedHelperAction)
         {
             var expressionMock = new Mock<CreateTableExpression>();

--- a/test/FluentMigrator.Tests/Unit/Generators/GeneratorTestHelper.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/GeneratorTestHelper.cs
@@ -54,6 +54,11 @@ namespace FluentMigrator.Tests.Unit.Generators
         {
             {"AdditionalColumnDescriptionKey2", "AdditionalColumnDescriptionValue2" }
         };
+        public static Dictionary<string, string> TestMultipleAdditionalColumnDescriptions = new Dictionary<string, string>()
+        {
+            {"AdditionalColumnDescriptionKey1", "AdditionalColumnDescriptionValue1" },
+            {"AdditionalColumnDescriptionKey2", "AdditionalColumnDescriptionValue2" }
+        };
 
         public static Guid TestGuid = Guid.NewGuid();
 
@@ -540,6 +545,14 @@ namespace FluentMigrator.Tests.Unit.Generators
             CreateColumnExpression columnExpression = GetCreateColumnExpression();
             columnExpression.Column.ColumnDescription = TestColumn1Description;
             columnExpression.Column.AdditionalColumnDescriptions = TestAdditionalColumnDescriptions1;
+            return columnExpression;
+        }
+
+        public static CreateColumnExpression GetCreateColumnExpressionWithDescriptionWithMultipleAdditionalDescriptions()
+        {
+            CreateColumnExpression columnExpression = GetCreateColumnExpression();
+            columnExpression.Column.ColumnDescription = TestColumn1Description;
+            columnExpression.Column.AdditionalColumnDescriptions = TestMultipleAdditionalColumnDescriptions;
             return columnExpression;
         }
 

--- a/test/FluentMigrator.Tests/Unit/Generators/MySql4/MySql4ColumnTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/MySql4/MySql4ColumnTests.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using FluentMigrator.Expressions;
 using FluentMigrator.Model;
 using FluentMigrator.Runner.Generators.MySql;
+
 using NUnit.Framework;
 
 using Shouldly;
@@ -284,6 +285,17 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql4
         }
 
         [Test]
+        public void CanCreateColumnWithDescriptionWithMultipleAdditionalDescriptions()
+        {
+            var expression = GeneratorTestHelper.GetCreateColumnExpressionWithDescriptionWithMultipleAdditionalDescriptions();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE `TestTable1` ADD COLUMN `TestColumn1` VARCHAR(5) NOT NULL COMMENT 'Description:TestColumn1Description" + Environment.NewLine +
+                            "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1" + Environment.NewLine +
+                            "AdditionalColumnDescriptionKey2:AdditionalColumnDescriptionValue2';");
+        }
+
+        [Test]
         public void CanCreateColumnWithBinaryIntMax()
         {
             var column = new ColumnDefinition { Name = GeneratorTestHelper.TestColumnName1, Type = DbType.Binary, Size = int.MaxValue };
@@ -296,7 +308,7 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql4
         public override void CanCreateColumnWithComputedExpression()
         {
             var expression = GeneratorTestHelper.GetCreateColumnExpressionWithComputed();
-            
+
             var result = Generator.Generate(expression);
             result.ShouldBe("ALTER TABLE `TestTable1` ADD COLUMN `TestColumn1` GENERATED ALWAYS AS (Price * Quantity) VIRTUAL NOT NULL;");
         }
@@ -305,7 +317,7 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql4
         public override void CanCreateColumnWithStoredComputedExpression()
         {
             var expression = GeneratorTestHelper.GetCreateColumnExpressionWithStoredComputed();
-            
+
             var result = Generator.Generate(expression);
             result.ShouldBe("ALTER TABLE `TestTable1` ADD COLUMN `TestColumn1` GENERATED ALWAYS AS (Price * Quantity) STORED NOT NULL;");
         }
@@ -314,7 +326,7 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql4
         public override void CanAlterColumnToAddComputedExpression()
         {
             var expression = GeneratorTestHelper.GetAlterColumnExpressionWithComputed();
-            
+
             var result = Generator.Generate(expression);
             result.ShouldBe("ALTER TABLE `TestTable1` MODIFY COLUMN `TestColumn1` GENERATED ALWAYS AS (Price * Quantity) VIRTUAL NOT NULL;");
         }
@@ -323,7 +335,7 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql4
         public override void CanAlterColumnToAddStoredComputedExpression()
         {
             var expression = GeneratorTestHelper.GetAlterColumnExpressionWithStoredComputed();
-            
+
             var result = Generator.Generate(expression);
             result.ShouldBe("ALTER TABLE `TestTable1` MODIFY COLUMN `TestColumn1` GENERATED ALWAYS AS (Price * Quantity) STORED NOT NULL;");
         }

--- a/test/FluentMigrator.Tests/Unit/Generators/MySql5/MySql5ColumnTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/MySql5/MySql5ColumnTests.cs
@@ -114,5 +114,16 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql5
             result.ShouldBe("ALTER TABLE `TestTable1` ADD COLUMN `TestColumn1` NVARCHAR(5) NOT NULL COMMENT 'Description:TestColumn1Description" + Environment.NewLine +
                             "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1';");
         }
+
+        [Test]
+        public void CanCreateColumnWithDescriptionWithMultipleAdditionalDescriptions()
+        {
+            var expression = GeneratorTestHelper.GetCreateColumnExpressionWithDescriptionWithMultipleAdditionalDescriptions();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE `TestTable1` ADD COLUMN `TestColumn1` NVARCHAR(5) NOT NULL COMMENT 'Description:TestColumn1Description" + Environment.NewLine +
+                            "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1" + Environment.NewLine +
+                            "AdditionalColumnDescriptionKey2:AdditionalColumnDescriptionValue2';");
+        }
     }
 }

--- a/test/FluentMigrator.Tests/Unit/Generators/MySql8/MySql8ColumnTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/MySql8/MySql8ColumnTests.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using FluentMigrator.Expressions;
 using FluentMigrator.Model;
 using FluentMigrator.Runner.Generators.MySql;
+
 using NUnit.Framework;
 
 using Shouldly;
@@ -281,6 +282,17 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql8
             var result = Generator.Generate(expression);
             result.ShouldBe("ALTER TABLE `TestTable1` ADD COLUMN `TestColumn1` NVARCHAR(5) NOT NULL COMMENT 'Description:TestColumn1Description" + Environment.NewLine +
                             "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1';");
+        }
+
+        [Test]
+        public void CanCreateColumnWithDescriptionWithMultipleAdditionalDescriptions()
+        {
+            var expression = GeneratorTestHelper.GetCreateColumnExpressionWithDescriptionWithMultipleAdditionalDescriptions();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("ALTER TABLE `TestTable1` ADD COLUMN `TestColumn1` NVARCHAR(5) NOT NULL COMMENT 'Description:TestColumn1Description" + Environment.NewLine +
+                            "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1" + Environment.NewLine +
+                            "AdditionalColumnDescriptionKey2:AdditionalColumnDescriptionValue2';");
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/Oracle/OracleDescriptionGeneratorTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Oracle/OracleDescriptionGeneratorTests.cs
@@ -71,10 +71,21 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
             var createColumnExpression = GeneratorTestHelper.GetCreateColumnExpressionWithDescriptionWithAdditionalDescriptions();
             var statement = DescriptionGenerator.GenerateDescriptionStatement(createColumnExpression);
 
-            statement.ShouldBe("COMMENT ON COLUMN TestTable1.TestColumn1 IS 'Description:TestColumn1Description"+Environment.NewLine+
+            statement.ShouldBe("COMMENT ON COLUMN TestTable1.TestColumn1 IS 'Description:TestColumn1Description" + Environment.NewLine +
                 "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1'");
         }
-        
+
+        [Test]
+        public void GenerateDescriptionStatementForCreateColumnReturnColumnDescriptionStatementWithMultipleAdditionalDescriptions()
+        {
+            var createColumnExpression = GeneratorTestHelper.GetCreateColumnExpressionWithDescriptionWithMultipleAdditionalDescriptions();
+            var statement = DescriptionGenerator.GenerateDescriptionStatement(createColumnExpression);
+
+            statement.ShouldBe("COMMENT ON COLUMN TestTable1.TestColumn1 IS 'Description:TestColumn1Description" + Environment.NewLine +
+                "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1" + Environment.NewLine +
+                "AdditionalColumnDescriptionKey2:AdditionalColumnDescriptionValue2'");
+        }
+
         [Test]
         public override void GenerateDescriptionStatementForAlterColumnReturnColumnDescriptionStatement()
         {
@@ -90,7 +101,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
             var alterColumnExpression = GeneratorTestHelper.GetAlterColumnExpressionWithDescriptionWithAdditionalDescriptions();
             var statement = DescriptionGenerator.GenerateDescriptionStatement(alterColumnExpression);
 
-            statement.ShouldBe("COMMENT ON COLUMN TestTable1.TestColumn1 IS 'Description:TestColumn1Description"+ Environment.NewLine +
+            statement.ShouldBe("COMMENT ON COLUMN TestTable1.TestColumn1 IS 'Description:TestColumn1Description" + Environment.NewLine +
                 "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1'");
         }
 

--- a/test/FluentMigrator.Tests/Unit/Generators/Oracle/OracleGeneratorTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Oracle/OracleGeneratorTests.cs
@@ -164,8 +164,20 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
 
             var result = Generator.Generate(expression);
 
-            result.ShouldBe("BEGIN EXECUTE IMMEDIATE 'ALTER TABLE TestTable1 ADD TestColumn1 NVARCHAR2(5) NOT NULL;';EXECUTE IMMEDIATE 'COMMENT ON COLUMN TestTable1.TestColumn1 IS ''Description:TestColumn1Description"+Environment.NewLine+
+            result.ShouldBe("BEGIN EXECUTE IMMEDIATE 'ALTER TABLE TestTable1 ADD TestColumn1 NVARCHAR2(5) NOT NULL;';EXECUTE IMMEDIATE 'COMMENT ON COLUMN TestTable1.TestColumn1 IS ''Description:TestColumn1Description" + Environment.NewLine +
                 "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1'''; END;");
+        }
+
+        [Test]
+        public void CanCreateColumnWithDescriptionWithMultipleAdditionalDescriptions()
+        {
+            var expression = GeneratorTestHelper.GetCreateColumnExpressionWithDescriptionWithMultipleAdditionalDescriptions();
+
+            var result = Generator.Generate(expression);
+
+            result.ShouldBe("BEGIN EXECUTE IMMEDIATE 'ALTER TABLE TestTable1 ADD TestColumn1 NVARCHAR2(5) NOT NULL;';EXECUTE IMMEDIATE 'COMMENT ON COLUMN TestTable1.TestColumn1 IS ''Description:TestColumn1Description" + Environment.NewLine +
+                "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1" + Environment.NewLine +
+                "AdditionalColumnDescriptionKey2:AdditionalColumnDescriptionValue2'''; END;");
         }
 
         [Test]
@@ -195,7 +207,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Oracle
 
             var result = Generator.Generate(expression);
 
-            result.ShouldBe("BEGIN EXECUTE IMMEDIATE 'ALTER TABLE TestTable1 MODIFY TestColumn1 NVARCHAR2(20) NOT NULL;';EXECUTE IMMEDIATE 'COMMENT ON COLUMN TestTable1.TestColumn1 IS ''Description:TestColumn1Description"+Environment.NewLine+
+            result.ShouldBe("BEGIN EXECUTE IMMEDIATE 'ALTER TABLE TestTable1 MODIFY TestColumn1 NVARCHAR2(20) NOT NULL;';EXECUTE IMMEDIATE 'COMMENT ON COLUMN TestTable1.TestColumn1 IS ''Description:TestColumn1Description" + Environment.NewLine +
                 "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1'''; END;");
         }
 

--- a/test/FluentMigrator.Tests/Unit/Generators/Postgres/PostgresDescriptionGeneratorTest.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Postgres/PostgresDescriptionGeneratorTest.cs
@@ -67,7 +67,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Postgres
             var statements = DescriptionGenerator.GenerateDescriptionStatements(createTableExpression).ToArray();
 
             var result = string.Join("", statements);
-            result.ShouldBe("COMMENT ON TABLE \"public\".\"TestTable1\" IS 'TestDescription';COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'Description:TestColumn1Description"+Environment.NewLine+
+            result.ShouldBe("COMMENT ON TABLE \"public\".\"TestTable1\" IS 'TestDescription';COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'Description:TestColumn1Description" + Environment.NewLine +
                 "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1';COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn2\" IS 'Description:TestColumn2Description" + Environment.NewLine +
                 "AdditionalColumnDescriptionKey2:AdditionalColumnDescriptionValue2';");
         }
@@ -96,8 +96,19 @@ namespace FluentMigrator.Tests.Unit.Generators.Postgres
             var createColumnExpression = GeneratorTestHelper.GetCreateColumnExpressionWithDescriptionWithAdditionalDescriptions();
             var statement = DescriptionGenerator.GenerateDescriptionStatement(createColumnExpression);
 
-            statement.ShouldBe("COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'Description:TestColumn1Description"+Environment.NewLine +
+            statement.ShouldBe("COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'Description:TestColumn1Description" + Environment.NewLine +
                 "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1';");
+        }
+
+        [Test]
+        public void GenerateDescriptionStatementForCreateColumnReturnColumnDescriptionStatementWithMultipleAdditionalDescriptions()
+        {
+            var createColumnExpression = GeneratorTestHelper.GetCreateColumnExpressionWithDescriptionWithMultipleAdditionalDescriptions();
+            var statement = DescriptionGenerator.GenerateDescriptionStatement(createColumnExpression);
+
+            statement.ShouldBe("COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'Description:TestColumn1Description" + Environment.NewLine +
+                "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1" + Environment.NewLine +
+                "AdditionalColumnDescriptionKey2:AdditionalColumnDescriptionValue2';");
         }
 
         [Test]
@@ -115,7 +126,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Postgres
             var alterColumnExpression = GeneratorTestHelper.GetAlterColumnExpressionWithDescriptionWithAdditionalDescriptions();
             var statement = DescriptionGenerator.GenerateDescriptionStatement(alterColumnExpression);
 
-            statement.ShouldBe("COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'Description:TestColumn1Description"+Environment.NewLine+
+            statement.ShouldBe("COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'Description:TestColumn1Description" + Environment.NewLine +
                 "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1';");
         }
     }

--- a/test/FluentMigrator.Tests/Unit/Generators/Redshift/RedshiftDescriptionGeneratorTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Redshift/RedshiftDescriptionGeneratorTests.cs
@@ -65,7 +65,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Redshift
 
             var result = string.Join(string.Empty, statements);
             result.ShouldBe(
-                "COMMENT ON TABLE \"public\".\"TestTable1\" IS 'TestDescription';COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'Description:TestColumn1Description"+Environment.NewLine+
+                "COMMENT ON TABLE \"public\".\"TestTable1\" IS 'TestDescription';COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'Description:TestColumn1Description" + Environment.NewLine +
                 "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1';COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn2\" IS 'Description:TestColumn2Description" + Environment.NewLine +
                 "AdditionalColumnDescriptionKey2:AdditionalColumnDescriptionValue2';");
         }
@@ -94,8 +94,19 @@ namespace FluentMigrator.Tests.Unit.Generators.Redshift
             var createColumnExpression = GeneratorTestHelper.GetCreateColumnExpressionWithDescriptionWithAdditionalDescriptions();
             var statement = DescriptionGenerator.GenerateDescriptionStatement(createColumnExpression);
 
-            statement.ShouldBe("COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'Description:TestColumn1Description"+Environment.NewLine+
+            statement.ShouldBe("COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'Description:TestColumn1Description" + Environment.NewLine +
                 "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1';");
+        }
+
+        [Test]
+        public void GenerateDescriptionStatementForCreateColumnReturnColumnDescriptionStatementWithMultipleAdditionalDescriptions()
+        {
+            var createColumnExpression = GeneratorTestHelper.GetCreateColumnExpressionWithDescriptionWithMultipleAdditionalDescriptions();
+            var statement = DescriptionGenerator.GenerateDescriptionStatement(createColumnExpression);
+
+            statement.ShouldBe("COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'Description:TestColumn1Description" + Environment.NewLine +
+                "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1" + Environment.NewLine +
+                "AdditionalColumnDescriptionKey2:AdditionalColumnDescriptionValue2';");
         }
 
         [Test]
@@ -113,7 +124,7 @@ namespace FluentMigrator.Tests.Unit.Generators.Redshift
             var alterColumnExpression = GeneratorTestHelper.GetAlterColumnExpressionWithDescriptionWithAdditionalDescriptions();
             var statement = DescriptionGenerator.GenerateDescriptionStatement(alterColumnExpression);
 
-            statement.ShouldBe("COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'Description:TestColumn1Description"+Environment.NewLine+
+            statement.ShouldBe("COMMENT ON COLUMN \"public\".\"TestTable1\".\"TestColumn1\" IS 'Description:TestColumn1Description" + Environment.NewLine +
                 "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1';");
         }
     }

--- a/test/FluentMigrator.Tests/Unit/Generators/Snowflake/SnowflakeDescriptionGeneratorTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Snowflake/SnowflakeDescriptionGeneratorTests.cs
@@ -120,6 +120,18 @@ namespace FluentMigrator.Tests.Unit.Generators.Snowflake
         }
 
         [Test]
+        public void GenerateDescriptionStatementForCreateColumnReturnColumnDescriptionStatementWithMultipleAdditionalDescriptions()
+        {
+            var createColumnExpression = GeneratorTestHelper.GetCreateColumnExpressionWithDescriptionWithMultipleAdditionalDescriptions();
+            createColumnExpression.SchemaName = TestSchema;
+            var statement = DescriptionGenerator.GenerateDescriptionStatement(createColumnExpression);
+
+            statement.ShouldBe($@"COMMENT ON COLUMN ""{TestSchema}"".""TestTable1"".""TestColumn1"" IS 'Description:TestColumn1Description" + Environment.NewLine +
+                "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1" + Environment.NewLine +
+                "AdditionalColumnDescriptionKey2:AdditionalColumnDescriptionValue2';", _quotingEnabled);
+        }
+
+        [Test]
         public override void GenerateDescriptionStatementForAlterColumnReturnColumnDescriptionStatement()
         {
             var alterColumnExpression = GeneratorTestHelper.GetAlterColumnExpressionWithDescription();

--- a/test/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005DescriptionGeneratorTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005DescriptionGeneratorTests.cs
@@ -43,7 +43,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
             var statements = DescriptionGenerator.GenerateDescriptionStatements(createTableExpression).ToArray();
 
             var result = string.Join("", statements);
-            result.ShouldBe("EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'TestDescription', @level0type=N'SCHEMA', @level0name='dbo', @level1type=N'TABLE', @level1name='TestTable1';EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'Description:TestColumn1Description" + Environment.NewLine+
+            result.ShouldBe("EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'TestDescription', @level0type=N'SCHEMA', @level0name='dbo', @level1type=N'TABLE', @level1name='TestTable1';EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'Description:TestColumn1Description" + Environment.NewLine +
                 "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn1';EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'Description:TestColumn2Description" + Environment.NewLine +
                 "AdditionalColumnDescriptionKey2:AdditionalColumnDescriptionValue2', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn2';");
         }
@@ -72,8 +72,19 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
             var createColumnExpression = GeneratorTestHelper.GetCreateColumnExpressionWithDescriptionWithAdditionalDescriptions();
             var statement = DescriptionGenerator.GenerateDescriptionStatement(createColumnExpression);
 
-            statement.ShouldBe("EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'Description:TestColumn1Description"+Environment.NewLine+
+            statement.ShouldBe("EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'Description:TestColumn1Description" + Environment.NewLine +
                 "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn1';");
+        }
+
+        [Test]
+        public void GenerateDescriptionStatementForCreateColumnReturnColumnDescriptionStatementWithMultipleAdditionalDescriptions()
+        {
+            var createColumnExpression = GeneratorTestHelper.GetCreateColumnExpressionWithDescriptionWithMultipleAdditionalDescriptions();
+            var statement = DescriptionGenerator.GenerateDescriptionStatement(createColumnExpression);
+
+            statement.ShouldBe("EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'Description:TestColumn1Description" + Environment.NewLine +
+                "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1" + Environment.NewLine +
+                "AdditionalColumnDescriptionKey2:AdditionalColumnDescriptionValue2', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn1';");
         }
 
         [Test]

--- a/test/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005GeneratorTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005GeneratorTests.cs
@@ -185,7 +185,7 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
         [Test]
         public void CanDropDefaultExpression()
         {
-            var expression = new DeleteDefaultConstraintExpression {ColumnName = "Name", SchemaName = "Personalia", TableName = "Person"};
+            var expression = new DeleteDefaultConstraintExpression { ColumnName = "Name", SchemaName = "Personalia", TableName = "Person" };
 
             string expected = "DECLARE @default sysname, @sql nvarchar(max);" + Environment.NewLine + Environment.NewLine +
                                     "-- get name of default constraint" + Environment.NewLine +
@@ -284,14 +284,15 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
         public void CanUseSystemMethodNewGuidAsADefaultValueForAColumn()
         {
             var expression = new CreateColumnExpression
+            {
+                Column = new ColumnDefinition
                 {
-                    Column = new ColumnDefinition
-                        {
-                            Name = "NewColumn",
-                            Type = DbType.Guid,
-                            DefaultValue = SystemMethods.NewGuid
-                        }, TableName = "NewTable"
-                };
+                    Name = "NewColumn",
+                    Type = DbType.Guid,
+                    DefaultValue = SystemMethods.NewGuid
+                },
+                TableName = "NewTable"
+            };
 
             var result = Generator.Generate(expression);
             result.ShouldBe("ALTER TABLE [dbo].[NewTable] ADD [NewColumn] UNIQUEIDENTIFIER NOT NULL CONSTRAINT [DF__NewColumn] DEFAULT NEWID();");
@@ -301,14 +302,15 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
         public void CanUseSystemMethodNewSequentialIdAsADefaultValueForAColumn()
         {
             var expression = new CreateColumnExpression
+            {
+                Column = new ColumnDefinition
                 {
-                    Column = new ColumnDefinition
-                        {
-                            Name = "NewColumn",
-                            Type = DbType.Guid,
-                            DefaultValue = SystemMethods.NewSequentialId
-                        }, TableName = "NewTable"
-                };
+                    Name = "NewColumn",
+                    Type = DbType.Guid,
+                    DefaultValue = SystemMethods.NewSequentialId
+                },
+                TableName = "NewTable"
+            };
 
             var result = Generator.Generate(expression);
             result.ShouldBe("ALTER TABLE [dbo].[NewTable] ADD [NewColumn] UNIQUEIDENTIFIER NOT NULL CONSTRAINT [DF__NewColumn] DEFAULT NEWSEQUENTIALID();");
@@ -371,8 +373,22 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
 
             result.ShouldBe(@"ALTER TABLE [dbo].[TestTable1] ADD [TestColumn1] NVARCHAR(5) NOT NULL;" + Environment.NewLine +
                             "GO" + Environment.NewLine +
-                            "EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'Description:TestColumn1Description"+Environment.NewLine+
+                            "EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'Description:TestColumn1Description" + Environment.NewLine +
                             "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn1';");
+        }
+
+        [Test]
+        public void CanCreateColumnWithDescriptionWithMultipleAdditionalDescriptions()
+        {
+            var expression = GeneratorTestHelper.GetCreateColumnExpressionWithDescriptionWithMultipleAdditionalDescriptions();
+
+            var result = Generator.Generate(expression);
+
+            result.ShouldBe(@"ALTER TABLE [dbo].[TestTable1] ADD [TestColumn1] NVARCHAR(5) NOT NULL;" + Environment.NewLine +
+                            "GO" + Environment.NewLine +
+                            "EXEC sys.sp_addextendedproperty @name = N'MS_Description', @value = N'Description:TestColumn1Description" + Environment.NewLine +
+                            "AdditionalColumnDescriptionKey1:AdditionalColumnDescriptionValue1" + Environment.NewLine +
+                            "AdditionalColumnDescriptionKey2:AdditionalColumnDescriptionValue2', @level0type = N'SCHEMA', @level0name = 'dbo', @level1type = N'Table', @level1name = 'TestTable1', @level2type = N'Column',  @level2name = 'TestColumn1';");
         }
 
         [Test]


### PR DESCRIPTION
Fixes #2348

### Fix

The `Dictionary` overload now persists every pair. Each builder delegates to its singular `WithColumnAdditionalDescription`, which keeps the null/empty/duplicate/reserved-key validation in one place and actually adds the entries to the column.

Reproduction:

```csharp
Create.Table("Users")
    .WithColumn("Email").AsString()
        .WithColumnDescription("Primary email")
        .WithColumnAdditionalDescriptions(new Dictionary<string, string>
        {
            { "PII",         "Contains personal data" },
            { "Sensitivity", "High" },
        });
```

### Tests

- **Builder unit tests** for all four builders.
- **Generator coverage for multiple additional descriptions**
- **SQL Server end-to-end integration test** that runs a migration exercising `Create.Table`, `Create.Column` and `Alter.Table`/`AddColumn`, then reads the extended properties back and asserts the additional descriptions are persisted in the single `MS_Description` property.

### Verification

```bash
dotnet test test/FluentMigrator.Tests --filter "TestCategory=Generator|TestCategory=Builder"
```


### Notes

- The `Dictionary` overload now throws `InvalidOperationException` for a duplicate key (surfaced by the shared singular validation) rather than silently doing nothing.
- The error message previously said the argument exception was for `descriptionName`, but it validates the value (`description` agument).