### PR TITLE
Preserve sorted parameter comparers when merging tokens

### DIFF
--- a/src/FluentMigrator.Abstractions/Expressions/ExecuteSqlScriptExpressionBase.cs
+++ b/src/FluentMigrator.Abstractions/Expressions/ExecuteSqlScriptExpressionBase.cs
@@ -60,9 +60,9 @@ namespace FluentMigrator.Expressions
         /// <returns>The merged token map, or <see cref="Parameters"/> unchanged when there are no
         /// tokens to merge</returns>
         /// <remarks>
-        /// The merged map reuses the key comparer of <see cref="Parameters"/> when it is a
-        /// <see cref="Dictionary{TKey,TValue}"/>, so that merging in provider tokens does not
-        /// silently change token lookup semantics for callers who supplied e.g. a
+        /// The merged map reuses the key comparer of built-in dictionary implementations that
+        /// expose an <see cref="IEqualityComparer{T}"/>, so that merging in provider tokens does
+        /// not silently change token lookup semantics for callers who supplied e.g. a
         /// <see cref="System.StringComparer.OrdinalIgnoreCase"/> dictionary.
         /// </remarks>
         protected IDictionary<string, object> GetMergedParameters()
@@ -72,7 +72,7 @@ namespace FluentMigrator.Expressions
                 return Parameters;
             }
 
-            var comparer = (Parameters as Dictionary<string, object>)?.Comparer;
+            var comparer = GetKeyComparer(Parameters);
             var mergedParameters = new Dictionary<string, object>(comparer);
             foreach (var provider in SqlScriptTokenProviders)
             {
@@ -102,6 +102,16 @@ namespace FluentMigrator.Expressions
             }
 
             return mergedParameters;
+        }
+
+        private static IEqualityComparer<string> GetKeyComparer(IDictionary<string, object> parameters)
+        {
+            return parameters switch
+            {
+                Dictionary<string, object> dictionary => dictionary.Comparer,
+                SortedDictionary<string, object> dictionary => dictionary.Comparer as IEqualityComparer<string>,
+                _ => null,
+            };
         }
     }
 }

--- a/test/FluentMigrator.Tests/Unit/Expressions/ExecuteSqlStatementExpressionTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Expressions/ExecuteSqlStatementExpressionTests.cs
@@ -147,6 +147,31 @@ namespace FluentMigrator.Tests.Unit.Expressions
         }
 
         [Test]
+        public void MergingWellKnownTokensPreservesSortedParameterKeyComparer()
+        {
+            var tokenProvider = new Mock<ISqlTokenProvider>();
+            tokenProvider
+                .Setup(x => x.GetTokens())
+                .Returns(new Dictionary<string, string> { { "DefaultSchema", "dbo" } });
+
+            var expression = new ExecuteSqlStatementExpression()
+            {
+                SqlStatement = "ALTER TABLE $(defaultschema).$(tableprefix)BLAH ADD COLUMN Foo INT",
+                Parameters = new SortedDictionary<string, object>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { "TablePrefix", "App_" },
+                },
+                SqlScriptTokenProviders = new[] { tokenProvider.Object },
+            };
+
+            var processor = new Mock<IMigrationProcessor>();
+            processor.Setup(x => x.Execute("ALTER TABLE dbo.App_BLAH ADD COLUMN Foo INT")).Verifiable();
+
+            expression.ExecuteWith(processor.Object);
+            processor.Verify();
+        }
+
+        [Test]
         public void ExecutesTheStatementWithWellKnownTokensUsingQuotedTokenSyntax()
         {
             var tokenProvider = new Mock<ISqlTokenProvider>();


### PR DESCRIPTION
Fixes #2358.

## Summary
- retain the equality comparer from `SortedDictionary<string, object>` when SQL token providers are merged
- add regression coverage for case-insensitive object-valued parameters

## Root Cause
The merge copied only the comparer of a concrete `Dictionary`, so a case-insensitive `SortedDictionary` was converted into a case-sensitive merged map.

## Validation
`dotnet test test/FluentMigrator.Tests/FluentMigrator.Tests.csproj --configuration Debug --no-restore --filter "FullyQualifiedName~ExecuteSqlStatementExpressionTests" --verbosity minimal`