### PR TITLE
Validate bulk column descriptions before adding

### DIFF
--- a/src/FluentMigrator/Builders/Alter/Column/AlterColumnExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Alter/Column/AlterColumnExpressionBuilder.cs
@@ -109,6 +109,15 @@ namespace FluentMigrator.Builders.Alter.Column
         /// <inheritdoc />
         public IAlterColumnOptionSyntax WithColumnAdditionalDescription(string descriptionName, string description)
         {
+            ValidateColumnAdditionalDescription(descriptionName, description);
+
+            Expression.Column.AdditionalColumnDescriptions.Add(descriptionName, description);
+
+            return this;
+        }
+
+        private void ValidateColumnAdditionalDescription(string descriptionName, string description)
+        {
             if (string.IsNullOrWhiteSpace(descriptionName))
                 throw new ArgumentException("Cannot be the empty string.", nameof(descriptionName));
 
@@ -120,10 +129,6 @@ namespace FluentMigrator.Builders.Alter.Column
 
             if (Expression.Column.AdditionalColumnDescriptions.Keys.Any(i => i.Equals(descriptionName)))
                 throw new InvalidOperationException("The given descriptionName is already present in the columnDescription list.");
-
-            Expression.Column.AdditionalColumnDescriptions.Add(descriptionName, description);
-
-            return this;
         }
 
         /// <inheritdoc />
@@ -137,7 +142,12 @@ namespace FluentMigrator.Builders.Alter.Column
 
             foreach (var newDescription in columnDescriptions)
             {
-                WithColumnAdditionalDescription(newDescription.Key, newDescription.Value);
+                ValidateColumnAdditionalDescription(newDescription.Key, newDescription.Value);
+            }
+
+            foreach (var newDescription in columnDescriptions)
+            {
+                Expression.Column.AdditionalColumnDescriptions.Add(newDescription.Key, newDescription.Value);
             }
 
             return this;

--- a/src/FluentMigrator/Builders/Alter/Table/AlterTableExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Alter/Table/AlterTableExpressionBuilder.cs
@@ -180,6 +180,15 @@ namespace FluentMigrator.Builders.Alter.Table
         /// <inheritdoc />
         public IAlterTableColumnOptionOrAddColumnOrAlterColumnSyntax WithColumnAdditionalDescription(string descriptionName, string description)
         {
+            ValidateColumnAdditionalDescription(descriptionName, description);
+
+            CurrentColumn.AdditionalColumnDescriptions.Add(descriptionName, description);
+
+            return this;
+        }
+
+        private void ValidateColumnAdditionalDescription(string descriptionName, string description)
+        {
             if (string.IsNullOrWhiteSpace(descriptionName))
                 throw new ArgumentException(@"Cannot be a null or empty string.", nameof(descriptionName));
 
@@ -191,10 +200,6 @@ namespace FluentMigrator.Builders.Alter.Table
 
             if (CurrentColumn.AdditionalColumnDescriptions.Keys.Any(i => i.Equals(descriptionName)))
                 throw new InvalidOperationException("The given descriptionName is already present in the columnDescription list.");
-
-            CurrentColumn.AdditionalColumnDescriptions.Add(descriptionName, description);
-
-            return this;
         }
 
         /// <inheritdoc />
@@ -208,7 +213,12 @@ namespace FluentMigrator.Builders.Alter.Table
 
             foreach (var newDescription in columnDescriptions)
             {
-                WithColumnAdditionalDescription(newDescription.Key, newDescription.Value);
+                ValidateColumnAdditionalDescription(newDescription.Key, newDescription.Value);
+            }
+
+            foreach (var newDescription in columnDescriptions)
+            {
+                CurrentColumn.AdditionalColumnDescriptions.Add(newDescription.Key, newDescription.Value);
             }
 
             return this;

--- a/src/FluentMigrator/Builders/Create/Column/CreateColumnExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Create/Column/CreateColumnExpressionBuilder.cs
@@ -105,6 +105,14 @@ namespace FluentMigrator.Builders.Create.Column
         /// <inheritdoc />
         public ICreateColumnOptionSyntax WithColumnAdditionalDescription(string descriptionName, string description)
         {
+            ValidateColumnAdditionalDescription(descriptionName, description);
+
+            Expression.Column.AdditionalColumnDescriptions.Add(descriptionName, description);
+            return this;
+        }
+
+        private void ValidateColumnAdditionalDescription(string descriptionName, string description)
+        {
             if (string.IsNullOrWhiteSpace(descriptionName))
                 throw new ArgumentException("Cannot be the empty string.", nameof(descriptionName));
 
@@ -116,9 +124,6 @@ namespace FluentMigrator.Builders.Create.Column
 
             if (Expression.Column.AdditionalColumnDescriptions.Keys.Any(i => i.Equals(descriptionName)))
                 throw new InvalidOperationException("The given descriptionName is already present in the columnDescription list.");
-
-            Expression.Column.AdditionalColumnDescriptions.Add(descriptionName, description);
-            return this;
         }
 
         /// <inheritdoc />
@@ -132,7 +137,12 @@ namespace FluentMigrator.Builders.Create.Column
 
             foreach (var newDescription in columnDescriptions)
             {
-                WithColumnAdditionalDescription(newDescription.Key, newDescription.Value);
+                ValidateColumnAdditionalDescription(newDescription.Key, newDescription.Value);
+            }
+
+            foreach (var newDescription in columnDescriptions)
+            {
+                Expression.Column.AdditionalColumnDescriptions.Add(newDescription.Key, newDescription.Value);
             }
 
             return this;

--- a/src/FluentMigrator/Builders/Create/Table/CreateTableExpressionBuilder.cs
+++ b/src/FluentMigrator/Builders/Create/Table/CreateTableExpressionBuilder.cs
@@ -124,6 +124,15 @@ namespace FluentMigrator.Builders.Create.Table
         /// <inheritdoc />
         public ICreateTableColumnOptionOrWithColumnSyntax WithColumnAdditionalDescription(string descriptionName, string description)
         {
+            ValidateColumnAdditionalDescription(descriptionName, description);
+
+            CurrentColumn.AdditionalColumnDescriptions.Add(descriptionName, description);
+
+            return this;
+        }
+
+        private void ValidateColumnAdditionalDescription(string descriptionName, string description)
+        {
             if (string.IsNullOrWhiteSpace(descriptionName))
                 throw new ArgumentException("Cannot be the empty string.", nameof(descriptionName));
 
@@ -135,10 +144,6 @@ namespace FluentMigrator.Builders.Create.Table
 
             if (CurrentColumn.AdditionalColumnDescriptions.Keys.Any(i => i.Equals(descriptionName)))
                 throw new InvalidOperationException("The given descriptionName is already present in the columnDescription list.");
-
-            CurrentColumn.AdditionalColumnDescriptions.Add(descriptionName, description);
-
-            return this;
         }
 
         /// <inheritdoc />
@@ -152,7 +157,12 @@ namespace FluentMigrator.Builders.Create.Table
 
             foreach (var newDescription in columnDescriptions)
             {
-                WithColumnAdditionalDescription(newDescription.Key, newDescription.Value);
+                ValidateColumnAdditionalDescription(newDescription.Key, newDescription.Value);
+            }
+
+            foreach (var newDescription in columnDescriptions)
+            {
+                CurrentColumn.AdditionalColumnDescriptions.Add(newDescription.Key, newDescription.Value);
             }
 
             return this;

--- a/test/FluentMigrator.Tests/Unit/Builders/Alter/AlterColumnExpressionBuilderTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Builders/Alter/AlterColumnExpressionBuilderTests.cs
@@ -93,6 +93,23 @@ namespace FluentMigrator.Tests.Unit.Builders.Alter
             }));
         }
 
+        [Test]
+        public void CallingWithColumnAdditionalDescriptionsWithLaterDuplicateKeyDoesNotMutateColumn()
+        {
+            var expression = new AlterColumnExpression { Column = new ColumnDefinition { Name = "TestColumn" } };
+            expression.Column.AdditionalColumnDescriptions.Add("Existing", "Value");
+            var builder = new AlterColumnExpressionBuilder(expression, new Mock<IMigrationContext>().Object);
+
+            Should.Throw<InvalidOperationException>(() => builder.WithColumnAdditionalDescriptions(new Dictionary<string, string>
+            {
+                { "New", "NewValue" },
+                { "Existing", "AnotherValue" },
+            }));
+
+            expression.Column.AdditionalColumnDescriptions.Count.ShouldBe(1);
+            expression.Column.AdditionalColumnDescriptions.ShouldNotContainKey("New");
+        }
+
         private void VerifyColumnProperty(Action<ColumnDefinition> columnExpression, Action<AlterColumnExpressionBuilder> callToTest)
         {
             var columnMock = new Mock<ColumnDefinition>();

--- a/test/FluentMigrator.Tests/Unit/Builders/Alter/AlterTableExpressionBuilderTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Builders/Alter/AlterTableExpressionBuilderTests.cs
@@ -401,6 +401,26 @@ namespace FluentMigrator.Tests.Unit.Builders.Alter
         }
 
         [Test]
+        public void CallingWithColumnAdditionalDescriptionsWithLaterDuplicateKeyDoesNotMutateColumn()
+        {
+            var currentColumn = new ColumnDefinition { Name = "TestColumn" };
+            currentColumn.AdditionalColumnDescriptions.Add("Existing", "Value");
+            var builder = new AlterTableExpressionBuilder(new Mock<AlterTableExpression>().Object, new Mock<IMigrationContext>().Object)
+            {
+                CurrentColumn = currentColumn
+            };
+
+            Should.Throw<InvalidOperationException>(() => builder.WithColumnAdditionalDescriptions(new Dictionary<string, string>
+            {
+                { "New", "NewValue" },
+                { "Existing", "AnotherValue" },
+            }));
+
+            currentColumn.AdditionalColumnDescriptions.Count.ShouldBe(1);
+            currentColumn.AdditionalColumnDescriptions.ShouldNotContainKey("New");
+        }
+
+        [Test]
         public void CallingWithDefaultSetsDefaultValue()
         {
             var contextMock = new Mock<IMigrationContext>();

--- a/test/FluentMigrator.Tests/Unit/Builders/Create/CreateColumnExpressionBuilderTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Builders/Create/CreateColumnExpressionBuilderTests.cs
@@ -858,6 +858,23 @@ namespace FluentMigrator.Tests.Unit.Builders.Create
             }));
         }
 
+        [Test]
+        public void CallingWithColumnAdditionalDescriptionsWithLaterDuplicateKeyDoesNotMutateColumn()
+        {
+            var expression = new CreateColumnExpression { Column = new ColumnDefinition { Name = "TestColumn" } };
+            expression.Column.AdditionalColumnDescriptions.Add("Existing", "Value");
+            var builder = new CreateColumnExpressionBuilder(expression, new Mock<IMigrationContext>().Object);
+
+            Should.Throw<InvalidOperationException>(() => builder.WithColumnAdditionalDescriptions(new Dictionary<string, string>
+            {
+                { "New", "NewValue" },
+                { "Existing", "AnotherValue" },
+            }));
+
+            expression.Column.AdditionalColumnDescriptions.Count.ShouldBe(1);
+            expression.Column.AdditionalColumnDescriptions.ShouldNotContainKey("New");
+        }
+
         private void VerifyColumnProperty(Action<ColumnDefinition> columnExpression, Action<CreateColumnExpressionBuilder> callToTest)
         {
             var columnMock = new Mock<ColumnDefinition>();

--- a/test/FluentMigrator.Tests/Unit/Builders/Create/CreateTableExpressionBuilderTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Builders/Create/CreateTableExpressionBuilderTests.cs
@@ -702,6 +702,26 @@ namespace FluentMigrator.Tests.Unit.Builders.Create
             }));
         }
 
+        [Test]
+        public void CallingWithColumnAdditionalDescriptionsWithLaterDuplicateKeyDoesNotMutateColumn()
+        {
+            var currentColumn = new ColumnDefinition { Name = "TestColumn" };
+            currentColumn.AdditionalColumnDescriptions.Add("Existing", "Value");
+            var builder = new CreateTableExpressionBuilder(new Mock<CreateTableExpression>().Object, new Mock<IMigrationContext>().Object)
+            {
+                CurrentColumn = currentColumn
+            };
+
+            Should.Throw<InvalidOperationException>(() => builder.WithColumnAdditionalDescriptions(new Dictionary<string, string>
+            {
+                { "New", "NewValue" },
+                { "Existing", "AnotherValue" },
+            }));
+
+            currentColumn.AdditionalColumnDescriptions.Count.ShouldBe(1);
+            currentColumn.AdditionalColumnDescriptions.ShouldNotContainKey("New");
+        }
+
         private void VerifyColumnHelperCall(Action<CreateTableExpressionBuilder> callToTest, System.Linq.Expressions.Expression<Action<ColumnExpressionBuilderHelper>> expectedHelperAction)
         {
             var expressionMock = new Mock<CreateTableExpression>();


### PR DESCRIPTION
Fixes #2360.

## Summary
- validate all additional column descriptions before mutating the column definition
- apply the transactional bulk behavior to Create.Column, Create.Table, Alter.Column, and Alter.Table
- add regression coverage for a new entry followed by a duplicate entry in every builder

## Root Cause
The bulk overload delegated to the single-entry method while iterating. A validation failure after an earlier successful entry threw an exception after the migration expression had already been partially mutated.

## Validation
`dotnet test test/FluentMigrator.Tests/FluentMigrator.Tests.csproj --configuration Debug --no-restore --filter "FullyQualifiedName~CreateColumnExpressionBuilderTests|FullyQualifiedName~CreateTableExpressionBuilderTests|FullyQualifiedName~AlterColumnExpressionBuilderTests|FullyQualifiedName~AlterTableExpressionBuilderTests" --verbosity minimal`

Passed: 322 tests.