### PR TITLE
Require an IQuoter for $[name] token substitution

### DIFF
--- a/src/FluentMigrator.Abstractions/Expressions/ExecuteSqlScriptExpressionBase.cs
+++ b/src/FluentMigrator.Abstractions/Expressions/ExecuteSqlScriptExpressionBase.cs
@@ -48,7 +48,7 @@ namespace FluentMigrator.Expressions
         /// <param name="sqlScript">The SQL script to execute</param>
         protected void Execute(IMigrationProcessor processor, [StringSyntax("sql")] string sqlScript)
         {
-            var finalSqlScript = SqlScriptTokenReplacer.ReplaceSqlScriptTokens(sqlScript, GetMergedParameters(), processor?.Quoter);
+            var finalSqlScript = SqlScriptTokenReplacer.ReplaceSqlScriptTokens(sqlScript, GetMergedParameters(), processor.Quoter);
             processor.Execute(finalSqlScript);
         }
 

--- a/src/FluentMigrator.Abstractions/Expressions/ExecuteSqlStatementExpression.cs
+++ b/src/FluentMigrator.Abstractions/Expressions/ExecuteSqlStatementExpression.cs
@@ -43,7 +43,7 @@ namespace FluentMigrator.Expressions
         /// <inheritdoc />
         public override void ExecuteWith(IMigrationProcessor processor)
         {
-            var finalSqlScript = SqlScriptTokenReplacer.ReplaceSqlScriptTokens(SqlStatement, GetMergedParameters(), processor?.Quoter);
+            var finalSqlScript = SqlScriptTokenReplacer.ReplaceSqlScriptTokens(SqlStatement, GetMergedParameters(), processor.Quoter);
             processor.Execute(finalSqlScript);
         }
 

--- a/src/FluentMigrator.Abstractions/SqlScriptTokenReplacer.cs
+++ b/src/FluentMigrator.Abstractions/SqlScriptTokenReplacer.cs
@@ -36,9 +36,9 @@ namespace FluentMigrator
         /// <param name="parameters">The tokens to be replaced</param>
         /// <param name="quoter">
         /// The <see cref="IQuoter"/> used to safely quote/format <c>$[name]</c> parameter values
-        /// (e.g. numbers, dates, booleans, <see langword="null"/>, strings). Pass the processor's
-        /// <c>Quoter</c>. May be <see langword="null"/> only when <paramref name="sqlText"/>
-        /// contains no <c>$[name]</c> token, since nothing else consults it.
+/// (e.g. numbers, dates, booleans, <see langword="null"/>, strings). Pass the processor's
+/// <c>Quoter</c>. May be <see langword="null"/> only when <paramref name="sqlText"/>
+/// contains no <c>$[name]</c> token that matches a key in <paramref name="parameters"/>, since nothing else consults it.
         /// </param>
         /// <returns>The SQL script with the replaced tokens</returns>
         /// <exception cref="ArgumentNullException">

--- a/src/FluentMigrator.Abstractions/SqlScriptTokenReplacer.cs
+++ b/src/FluentMigrator.Abstractions/SqlScriptTokenReplacer.cs
@@ -18,7 +18,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Text;
 using System.Text.RegularExpressions;
 
 using FluentMigrator.Generation;
@@ -37,10 +36,15 @@ namespace FluentMigrator
         /// <param name="parameters">The tokens to be replaced</param>
         /// <param name="quoter">
         /// The <see cref="IQuoter"/> used to safely quote/format <c>$[name]</c> parameter values
-        /// (e.g. numbers, dates, booleans, <see langword="null"/>, strings). When <see langword="null"/>,
-        /// a basic string-literal quoting fallback is used, which treats every value as a string.
+        /// (e.g. numbers, dates, booleans, <see langword="null"/>, strings). Pass the processor's
+        /// <c>Quoter</c>. May be <see langword="null"/> only when <paramref name="sqlText"/>
+        /// contains no <c>$[name]</c> token, since nothing else consults it.
         /// </param>
         /// <returns>The SQL script with the replaced tokens</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="quoter"/> is <see langword="null"/> and <paramref name="sqlText"/>
+        /// contains a <c>$[name]</c> token.
+        /// </exception>
         /// <remarks>
         /// Two token styles are supported:
         /// <list type="bullet">
@@ -58,12 +62,14 @@ namespace FluentMigrator
         /// using <paramref name="quoter"/>. Use this style whenever a value should be treated as
         /// data instead of raw SQL. Any value type supported by <see cref="IQuoter.QuoteValue"/> can be
         /// used, e.g. <see cref="string"/>, numbers, <see cref="System.DateTime"/>, <see cref="bool"/>,
-        /// <see cref="System.Guid"/>, or <see langword="null"/>. When no <paramref name="quoter"/> is
-        /// supplied, an invariant-culture rendering equivalent to the default
-        /// <c>GenericQuoter.QuoteValue</c> is used.
+        /// <see cref="System.Guid"/>, or <see langword="null"/>.
         /// </description>
         /// </item>
         /// </list>
+        /// <para>
+        /// A <paramref name="quoter"/> is needed only for <c>$[name]</c>. A script using nothing but
+        /// <c>$(name)</c> never consults it and may pass <see langword="null"/>.
+        /// </para>
         /// <para>
         /// <strong><see cref="RawSql"/> is exempt from quoting in both styles.</strong> It is an
         /// explicit opt-in escape hatch, so a <see cref="RawSql"/> value is emitted verbatim even via
@@ -76,38 +82,60 @@ namespace FluentMigrator
         /// escaping it as <c>$$((name))</c> or <c>$$[[name]]</c> respectively.
         /// </para>
         /// </remarks>
-        public static string ReplaceSqlScriptTokens([StringSyntax("sql")] string sqlText, IDictionary<string, object> parameters, IQuoter quoter = null)
+        public static string ReplaceSqlScriptTokens([StringSyntax("sql")] string sqlText, IDictionary<string, object> parameters, IQuoter quoter)
         {
             return ReplaceSqlScriptTokensCore(sqlText, parameters, quoter);
         }
 
-        private static string ReplaceSqlScriptTokensCore<TValue>([StringSyntax("sql")] string sqlText, IDictionary<string, TValue> parameters, IQuoter quoter)
+        /// <param name="expandSafeTokens">
+        /// Whether to expand the <c>$[name]</c> token style. The obsolete
+        /// <see cref="IDictionary{TKey,TValue}"/> of <see cref="string"/> overload passes
+        /// <see langword="false"/>, because that token style did not exist when it was the only
+        /// API and 8.0.1 left such text untouched.
+        /// </param>
+        private static string ReplaceSqlScriptTokensCore<TValue>(
+            [StringSyntax("sql")] string sqlText,
+            IDictionary<string, TValue> parameters,
+            IQuoter quoter,
+            bool expandSafeTokens = true)
         {
             // Are parameters set?
             if (parameters != null && parameters.Count != 0)
             {
                 // Replace $[word] elements with the values stored in the Parameters
                 // dictionary, rendered as a safely quoted/escaped SQL literal.
-                sqlText = Regex.Replace(
-                    sqlText,
-                    @"\$\[(?<token>\w+)\]",
-                    m =>
-                    {
-                        var key = m.Groups["token"].Value;
-                        if (parameters.TryGetValue(key, out var keyValue))
+                if (expandSafeTokens)
+                {
+                    sqlText = Regex.Replace(
+                        sqlText,
+                        @"\$\[(?<token>\w+)\]",
+                        m =>
                         {
-                            object value = keyValue;
-                            return quoter != null
-                                ? quoter.QuoteValue(value)
-                                : QuoteSqlLiteral(value);
-                        }
+                            var key = m.Groups["token"].Value;
+                            if (parameters.TryGetValue(key, out var keyValue))
+                            {
+                                // Guarded here rather than at method entry on purpose: a script
+                                // using only $(name) never consults the quoter, so rejecting it up
+                                // front would fail callers that have no need of one.
+                                if (quoter is null)
+                                {
+                                    throw new ArgumentNullException(
+                                        nameof(quoter),
+                                        $"Expanding the $[{key}] token requires an IQuoter. Pass the " +
+                                        "processor's Quoter.");
+                                }
 
-                        // Return the whole match value when the key
-                        // wasn't found in the Parameters dictionary.
-                        // This might help finding unset variables.
-                        return m.Value;
-                    }
-                );
+                                object value = keyValue;
+                                return quoter.QuoteValue(value);
+                            }
+
+                            // Return the whole match value when the key
+                            // wasn't found in the Parameters dictionary.
+                            // This might help finding unset variables.
+                            return m.Value;
+                        }
+                    );
+                }
 
                 // Replace $(word) elements with values stored
                 // in the Parameters dictionary.
@@ -132,8 +160,13 @@ namespace FluentMigrator
                 // Replace $$((word)) with $(word)
                 sqlText = Regex.Replace(sqlText, @"\${2}\({2}(\w+)\){2}", @"$$($1)");
 
-                // Replace $$[[word]] with $[word]
-                sqlText = Regex.Replace(sqlText, @"\${2}\[{2}(\w+)\]{2}", @"$$[$1]");
+                // Replace $$[[word]] with $[word]. Gated with the token it escapes: both arrived
+                // together, so a caller that does not get $[name] should not get its escape form
+                // rewritten either.
+                if (expandSafeTokens)
+                {
+                    sqlText = Regex.Replace(sqlText, @"\${2}\[{2}(\w+)\]{2}", @"$$[$1]");
+                }
             }
 
             return sqlText;
@@ -164,128 +197,19 @@ namespace FluentMigrator
         /// <para>
         /// The supplied dictionary is queried directly, preserving its key lookup semantics.
         /// </para>
+        /// <para>
+        /// <strong>This overload does not expand <c>$[name]</c>.</strong> That token style did not
+        /// exist when this was the only API - 8.0.1 returned such text unchanged - and there is no
+        /// quoter here to render it with. <c>$[name]</c> and its <c>$$[[name]]</c> escape are left
+        /// verbatim, exactly as in 8.0.1. Callers wanting safely quoted literals should move to the
+        /// <see cref="ReplaceSqlScriptTokens(string, IDictionary{string, object}, IQuoter)"/>
+        /// overload and pass the processor's <c>Quoter</c>.
+        /// </para>
         /// </remarks>
         [Obsolete("Use the IDictionary<string, object> overload instead. The IDictionary<string, string> overload is kept for backwards compatibility and will be removed in a future major version.")]
         public static string ReplaceSqlScriptTokens([StringSyntax("sql")] string sqlText, IDictionary<string, string> parameters)
         {
-            return ReplaceSqlScriptTokensCore(sqlText, parameters, null);
-        }
-
-        /// <summary>
-        /// Renders a value as a SQL literal when no <see cref="IQuoter"/> was supplied.
-        /// </summary>
-        /// <param name="value">The value to render</param>
-        /// <returns>The value as a SQL literal</returns>
-        /// <exception cref="NotSupportedException">
-        /// <paramref name="value"/> is a <see cref="SystemMethods"/>, which has no dialect-independent
-        /// rendering.
-        /// </exception>
-        /// <remarks>
-        /// <para>
-        /// Deliberately mirrors the default rendering of <c>GenericQuoter.QuoteValue</c>, which lives
-        /// in <c>FluentMigrator.Runner.Core</c> and so cannot be referenced from this assembly. The
-        /// two must agree: a token expanded without a quoter and the same value written by
-        /// <c>Insert</c>/<c>Update</c>/<c>Delete</c> should produce the same literal. That agreement
-        /// is asserted by <c>TokenSubstitutionMatrixTests</c>.
-        /// </para>
-        /// <para>
-        /// Culture handling, precisely: numbers, <see cref="DateTime"/> and <see cref="DateTimeOffset"/>
-        /// are formatted with <see cref="CultureInfo.InvariantCulture"/>, as is any other
-        /// <see cref="IFormattable"/>. Enums render by name, which is culture-independent. Anything
-        /// else falls back to <see cref="object.ToString"/> and therefore renders however that type
-        /// chooses - <c>GenericQuoter.QuoteValue</c> has the same fallback. Before this, *every* value
-        /// was stringified with the ambient culture, so a German build agent emitted <c>'1234,5678'</c>
-        /// for a <see cref="double"/>.
-        /// </para>
-        /// </remarks>
-        private static string QuoteSqlLiteral(object value)
-        {
-            switch (value)
-            {
-                case null:
-                case DBNull _:
-                    return "NULL";
-
-                // An explicit opt-in escape hatch: the caller owns this SQL, so it must not be
-                // quoted, escaped or otherwise altered.
-                case RawSql rawSql:
-                    return rawSql.Value;
-
-                // Matched ahead of Enum, which would otherwise render it as the string literal
-                // 'CurrentDateTime' - valid SQL syntax that silently means the wrong thing. There is
-                // no dialect-independent rendering for these: CURRENT_TIMESTAMP, GETDATE(), SYSDATE
-                // and NOW() are all spelled differently, which is why GenericQuoter delegates to
-                // FormatSystemMethods and throws by default. Failing here says "supply an IQuoter"
-                // instead of emitting a string that looks like it worked.
-                case SystemMethods systemMethod:
-                    throw new NotSupportedException(
-                        $"The system method {systemMethod} cannot be rendered without an IQuoter, because its SQL " +
-                        "spelling is dialect-specific. Pass the processor's IQuoter to ReplaceSqlScriptTokens, " +
-                        "or substitute an explicit RawSql value.");
-
-                case bool b:
-                    return b ? "1" : "0";
-
-                case byte[] bytes:
-                    return FormatByteArray(bytes);
-
-                case DateTime dateTime:
-                    return QuoteString(dateTime.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture));
-
-                case DateTimeOffset dateTimeOffset:
-                    return QuoteString(dateTimeOffset.ToString("yyyy-MM-ddTHH:mm:sszzz", CultureInfo.InvariantCulture));
-
-                // Numeric literals are emitted unquoted so they keep their SQL type. Enum is
-                // deliberately matched before the integral types, since it renders as a string.
-                case Enum _:
-                    return QuoteString(value.ToString());
-
-                case sbyte _:
-                case byte _:
-                case short _:
-                case ushort _:
-                case int _:
-                case uint _:
-                case long _:
-                case ulong _:
-                case float _:
-                case double _:
-                case decimal _:
-                    return ((IFormattable)value).ToString(null, CultureInfo.InvariantCulture);
-
-                case IFormattable formattable:
-                    return QuoteString(formattable.ToString(null, CultureInfo.InvariantCulture));
-
-                default:
-                    return QuoteString(value.ToString());
-            }
-        }
-
-        /// <summary>
-        /// Wraps a value in single quotes, escaping embedded single quotes by doubling them.
-        /// </summary>
-        /// <param name="value">The value to quote</param>
-        /// <returns>The quoted value</returns>
-        private static string QuoteString(string value)
-        {
-            return "'" + value.Replace("'", "''") + "'";
-        }
-
-        /// <summary>
-        /// Renders a byte array as a hexadecimal SQL literal, matching <c>GenericQuoter</c>.
-        /// </summary>
-        /// <param name="value">The bytes to render</param>
-        /// <returns>The hexadecimal literal</returns>
-        private static string FormatByteArray(byte[] value)
-        {
-            var hex = new StringBuilder((value.Length * 2) + 2);
-            hex.Append("0x");
-            foreach (var b in value)
-            {
-                hex.AppendFormat(CultureInfo.InvariantCulture, "{0:x2}", b);
-            }
-
-            return hex.ToString();
+            return ReplaceSqlScriptTokensCore(sqlText, parameters, quoter: null, expandSafeTokens: false);
         }
     }
 }

--- a/test/FluentMigrator.Tests/Unit/Expressions/ExecuteSqlStatementExpressionTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Expressions/ExecuteSqlStatementExpressionTests.cs
@@ -186,6 +186,7 @@ namespace FluentMigrator.Tests.Unit.Expressions
             };
 
             var processor = new Mock<IMigrationProcessor>();
+            processor.SetupGet(x => x.Quoter).Returns(new GenericQuoter());
             processor.Setup(x => x.Execute("SELECT * FROM Users WHERE SchemaName = 'te''nant'")).Verifiable();
 
             expression.ExecuteWith(processor.Object);
@@ -208,6 +209,7 @@ namespace FluentMigrator.Tests.Unit.Expressions
             };
 
             var processor = new Mock<IMigrationProcessor>();
+            processor.SetupGet(x => x.Quoter).Returns(new GenericQuoter());
             processor.Setup(x => x.Execute("SELECT * FROM Users WHERE SchemaName = 'tenant1'")).Verifiable();
 
             expression.ExecuteWith(processor.Object);

--- a/test/FluentMigrator.Tests/Unit/Infrastructure/DefaultSqlTokenProviderTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Infrastructure/DefaultSqlTokenProviderTests.cs
@@ -22,6 +22,8 @@ using System.Linq;
 using FluentMigrator.Runner.Conventions;
 using FluentMigrator.Runner.Infrastructure;
 
+using FluentMigrator.Runner.Generators.Generic;
+
 using NUnit.Framework;
 
 using Shouldly;
@@ -63,7 +65,7 @@ namespace FluentMigrator.Tests.Unit.Infrastructure
 
             var result = SqlScriptTokenReplacer.ReplaceSqlScriptTokens(
                 "ALTER TABLE $(DefaultSchema).Users ADD COLUMN Foo INT",
-                ToObjectDictionary(provider.GetTokens()));
+                ToObjectDictionary(provider.GetTokens()), null);
 
             result.ShouldBe("ALTER TABLE testdefault.Users ADD COLUMN Foo INT");
         }
@@ -76,7 +78,7 @@ namespace FluentMigrator.Tests.Unit.Infrastructure
 
             var result = SqlScriptTokenReplacer.ReplaceSqlScriptTokens(
                 "SELECT * FROM Users WHERE SchemaName = $[DefaultSchema]",
-                ToObjectDictionary(provider.GetTokens()));
+                ToObjectDictionary(provider.GetTokens()), new GenericQuoter());
 
             result.ShouldBe("SELECT * FROM Users WHERE SchemaName = 'testdefault'");
         }
@@ -89,7 +91,7 @@ namespace FluentMigrator.Tests.Unit.Infrastructure
 
             var result = SqlScriptTokenReplacer.ReplaceSqlScriptTokens(
                 "SELECT * FROM Users WHERE SchemaName = $[DefaultSchema]",
-                ToObjectDictionary(provider.GetTokens()));
+                ToObjectDictionary(provider.GetTokens()), new GenericQuoter());
 
             result.ShouldBe("SELECT * FROM Users WHERE SchemaName = 'te''st'");
         }
@@ -102,7 +104,7 @@ namespace FluentMigrator.Tests.Unit.Infrastructure
 
             var result = SqlScriptTokenReplacer.ReplaceSqlScriptTokens(
                 "ALTER TABLE $(DefaultSchema).Users ADD COLUMN Foo INT; SELECT $[DefaultSchema]",
-                ToObjectDictionary(provider.GetTokens()));
+                ToObjectDictionary(provider.GetTokens()), new GenericQuoter());
 
             result.ShouldBe("ALTER TABLE $(DefaultSchema).Users ADD COLUMN Foo INT; SELECT $[DefaultSchema]");
         }

--- a/test/FluentMigrator.Tests/Unit/SqlScriptTokenReplacerTests.cs
+++ b/test/FluentMigrator.Tests/Unit/SqlScriptTokenReplacerTests.cs
@@ -35,14 +35,14 @@ namespace FluentMigrator.Tests.Unit
         [Test]
         public void ReturnsOriginalTextWhenParametersAreNull()
         {
-            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT $(Foo)", (IDictionary<string, object>)null)
+            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT $(Foo)", (IDictionary<string, object>)null, null)
                 .ShouldBe("SELECT $(Foo)");
         }
 
         [Test]
         public void ReturnsOriginalTextWhenParametersAreEmpty()
         {
-            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT $(Foo)", new Dictionary<string, object>())
+            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT $(Foo)", new Dictionary<string, object>(), null)
                 .ShouldBe("SELECT $(Foo)");
         }
 
@@ -51,7 +51,7 @@ namespace FluentMigrator.Tests.Unit
         {
             var parameters = new Dictionary<string, object> { ["TablePrefix"] = "App_" };
 
-            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT * FROM $(TablePrefix)Users", parameters)
+            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT * FROM $(TablePrefix)Users", parameters, null)
                 .ShouldBe("SELECT * FROM App_Users");
         }
 
@@ -65,7 +65,7 @@ namespace FluentMigrator.Tests.Unit
                 CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
                 var parameters = new Dictionary<string, object> { ["Price"] = 12.34m };
 
-                SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT $(Price)", parameters)
+                SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT $(Price)", parameters, null)
                     .ShouldBe("SELECT 12.34");
             }
             finally
@@ -82,7 +82,7 @@ namespace FluentMigrator.Tests.Unit
                 ["CurrentTimestamp"] = RawSql.Insert("CURRENT_TIMESTAMP")
             };
 
-            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT $(CurrentTimestamp)", parameters)
+            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT $(CurrentTimestamp)", parameters, null)
                 .ShouldBe("SELECT CURRENT_TIMESTAMP");
         }
 
@@ -91,7 +91,7 @@ namespace FluentMigrator.Tests.Unit
         {
             var parameters = new Dictionary<string, object> { ["Known"] = "Value" };
 
-            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT $(Unknown)", parameters)
+            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT $(Unknown)", parameters, null)
                 .ShouldBe("SELECT $(Unknown)");
         }
 
@@ -100,7 +100,7 @@ namespace FluentMigrator.Tests.Unit
         {
             var parameters = new Dictionary<string, object> { ["Foo"] = "Bar" };
 
-            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT '$$((Foo))'", parameters)
+            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT '$$((Foo))'", parameters, null)
                 .ShouldBe("SELECT '$(Foo)'");
         }
 
@@ -109,7 +109,7 @@ namespace FluentMigrator.Tests.Unit
         {
             var parameters = new Dictionary<string, object> { ["DefaultStatus"] = "isn't active" };
 
-            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT $[DefaultStatus]", parameters)
+            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT $[DefaultStatus]", parameters, new GenericQuoter())
                 .ShouldBe("SELECT 'isn''t active'");
         }
 
@@ -118,7 +118,7 @@ namespace FluentMigrator.Tests.Unit
         {
             var parameters = new Dictionary<string, object> { ["Value"] = null };
 
-            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT $[Value]", parameters)
+            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT $[Value]", parameters, new GenericQuoter())
                 .ShouldBe("SELECT NULL");
         }
 
@@ -127,7 +127,7 @@ namespace FluentMigrator.Tests.Unit
         {
             var parameters = new Dictionary<string, object> { ["Known"] = "Value" };
 
-            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT $[Unknown]", parameters)
+            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT $[Unknown]", parameters, new GenericQuoter())
                 .ShouldBe("SELECT $[Unknown]");
         }
 
@@ -136,7 +136,7 @@ namespace FluentMigrator.Tests.Unit
         {
             var parameters = new Dictionary<string, object> { ["Foo"] = "Bar" };
 
-            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT '$$[[Foo]]'", parameters)
+            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT '$$[[Foo]]'", parameters, new GenericQuoter())
                 .ShouldBe("SELECT '$[Foo]'");
         }
 
@@ -152,7 +152,7 @@ namespace FluentMigrator.Tests.Unit
 
             var sql = SqlScriptTokenReplacer.ReplaceSqlScriptTokens(
                 "INSERT INTO $(TablePrefix)Users (Status, CreatedAt) VALUES ($[DefaultStatus], $(CurrentDate));",
-                parameters);
+                parameters, new GenericQuoter());
 
             sql.ShouldBe("INSERT INTO App_Users (Status, CreatedAt) VALUES ('isn''t active', GETDATE());");
         }
@@ -213,13 +213,44 @@ namespace FluentMigrator.Tests.Unit
                 .ShouldBe("SELECT * FROM App_Users");
         }
 
+        /// <summary>
+        /// The obsolete overload does not expand <c>$[name]</c>, and never did: that token style
+        /// arrived long after this overload, and 8.0.1 returned such text unchanged. There is also
+        /// no quoter here to render it with. Restoring that is deliberate - see
+        /// <c>adr/proposed/RequireQuoterForTokenSubstitution.md</c>.
+        /// </summary>
         [Test]
-        public void LegacyStringDictionaryOverloadReplacesSafeTokenWithQuotedLiteral()
+        public void LegacyStringDictionaryOverloadLeavesSafeTokenVerbatim()
         {
             var parameters = new Dictionary<string, string> { ["Name"] = "isn't" };
 
             SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT $[Name]", parameters)
-                .ShouldBe("SELECT 'isn''t'");
+                .ShouldBe("SELECT $[Name]");
+        }
+
+        /// <summary>
+        /// The escape form travels with the token it escapes. Both arrived together, so an overload
+        /// that does not expand <c>$[name]</c> must not rewrite <c>$$[[name]]</c> either.
+        /// </summary>
+        [Test]
+        public void LegacyStringDictionaryOverloadLeavesSafeTokenEscapeVerbatim()
+        {
+            var parameters = new Dictionary<string, string> { ["Foo"] = "Bar" };
+
+            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT '$$[[Foo]]'", parameters)
+                .ShouldBe("SELECT '$$[[Foo]]'");
+        }
+
+        /// <summary>
+        /// The raw token style is unaffected, which is what 8.0.1 callers actually use.
+        /// </summary>
+        [Test]
+        public void LegacyStringDictionaryOverloadStillExpandsRawTokenAndItsEscape()
+        {
+            var parameters = new Dictionary<string, string> { ["Foo"] = "Bar" };
+
+            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT $(Foo), '$$((Foo))'", parameters)
+                .ShouldBe("SELECT Bar, '$(Foo)'");
         }
 
         [Test]
@@ -262,5 +293,53 @@ namespace FluentMigrator.Tests.Unit
                 .ShouldBe("SELECT * FROM App_Users");
         }
 #pragma warning restore CS0618 // Type or member is obsolete
+
+        #region Quoter is required only where $[name] is expanded
+
+        // The guard lives inside the $[name] branch rather than at method entry. These two tests
+        // are the pair that makes that visible; the second is the one that regresses if someone
+        // "tidies" the check up to the top of the method.
+        // See adr/proposed/RequireQuoterForTokenSubstitution.md.
+
+        [Test]
+        public void ThrowsWhenSafeTokenIsExpandedWithoutAQuoter()
+        {
+            var parameters = new Dictionary<string, object> { ["DefaultStatus"] = "active" };
+
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT $[DefaultStatus]", parameters, quoter: null));
+
+            Assert.Multiple(() =>
+            {
+                exception.ParamName.ShouldBe("quoter");
+
+                // Names the token that forced the failure, so a long script points at one place.
+                exception.Message.ShouldContain("$[DefaultStatus]");
+            });
+        }
+
+        [Test]
+        public void DoesNotRequireAQuoterWhenOnlyRawTokensAreExpanded()
+        {
+            var parameters = new Dictionary<string, object> { ["TablePrefix"] = "App_" };
+
+            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT * FROM $(TablePrefix)Users", parameters, quoter: null)
+                .ShouldBe("SELECT * FROM App_Users");
+        }
+
+        /// <summary>
+        /// An unresolved <c>$[name]</c> is left verbatim without consulting the quoter, so it never
+        /// reaches the guard.
+        /// </summary>
+        [Test]
+        public void DoesNotRequireAQuoterForAnUnknownSafeToken()
+        {
+            var parameters = new Dictionary<string, object> { ["Known"] = "Value" };
+
+            SqlScriptTokenReplacer.ReplaceSqlScriptTokens("SELECT $[Unknown]", parameters, quoter: null)
+                .ShouldBe("SELECT $[Unknown]");
+        }
+
+        #endregion
     }
 }

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/BASELINE-FAILURES.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/BASELINE-FAILURES.md
@@ -5,6 +5,13 @@ the next commit's diff shows exactly which cells the fixes move.
 
 Run against `e25bf5ef` ("Fix RawSql script token replacement (#2333)") on `net48`, `en-US` host.
 
+> **Historical note.** The `$[x] no quoter` column referenced throughout this document no longer
+> exists. The private fallback it recorded was deleted when the quoter became required — a null
+> quoter now throws, identically for every value and dialect, so the column carried one fact
+> repeated 161 times. See `adr/proposed/RequireQuoterForTokenSubstitution.md` and the three
+> dedicated tests in `SqlScriptTokenReplacerTests`. This file is kept as the record of what the
+> matrix found, not as a description of the current fixture.
+
 ```
 Failed!  - Failed: 48, Passed: 151, Skipped: 0, Total: 199 - FluentMigrator.Tests.dll (net48)
 ```

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrix.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrix.md
@@ -22,7 +22,7 @@ markdown table rather than one of 35,000 opaque case names.
 | # | Axis | Values | Why it matters |
 |---|---|---|---|
 | 1 | Token style | `$(name)` raw, `$[name]` safe-quoted | Different code paths: raw bypasses the quoter entirely |
-| 2 | Quoter presence | supplied vs `null` | The `IQuoter` parameter is optional and the fallback has its own semantics |
+| 2 | Quoter presence | supplied only | A `null` quoter no longer renders anything - it throws when `$[name]` is expanded, identically for every value and dialect. Covered once in `SqlScriptTokenReplacerTests` rather than as a matrix column; see `adr/proposed/RequireQuoterForTokenSubstitution.md` |
 | 3 | Value type | every branch of `GenericQuoter.QuoteValue`, plus uncased fall-through, plus `RawSql` | The reported defects are all value-type specific |
 | 4 | Dialect | ~30 `Add*()` registrations on `IMigrationRunnerBuilder` | Each wires a different quoter/typemap/generator triple |
 | 5 | `IQuoter` switch | `binaryGuid`, `QuoteIdentifiers`, `ForceQuote`, quoted-identifier variants | Orthogonal to dialect; changes value rendering |

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=MySql.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=MySql.verified.md
@@ -8,31 +8,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `MySqlQuoter`
 - processor.Quoter: `MySqlQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### MySql5
 
@@ -40,31 +40,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `MySqlQuoter`
 - processor.Quoter: `MySqlQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### MySql8
 
@@ -72,29 +72,29 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `MySqlQuoter`
 - processor.Quoter: `MySqlQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Oracle.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Oracle.verified.md
@@ -8,31 +8,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `OracleQuoter`
 - processor.Quoter: `OracleQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### OracleManaged
 
@@ -40,31 +40,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `OracleQuoter`
 - processor.Quoter: `OracleQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### DotConnectOracle
 
@@ -72,31 +72,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `OracleQuoter`
 - processor.Quoter: `OracleQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Oracle12C
 
@@ -104,31 +104,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `OracleQuoter`
 - processor.Quoter: `OracleQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Oracle12CManaged
 
@@ -136,31 +136,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `OracleQuoter`
 - processor.Quoter: `OracleQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### DotConnectOracle12C
 
@@ -168,29 +168,29 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `OracleQuoter`
 - processor.Quoter: `OracleQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111222233334444555555555555'` | `'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` | `to_date('2026-07-28 13:45:06', 'yyyy-mm-dd hh24:mi:ss')` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'0 1:2:3.0'` | `'0 1:2:3.0'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Other.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Other.verified.md
@@ -8,31 +8,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `Db2Quoter`
 - processor.Quoter: `Db2Quoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28-13.45.06'` | `'2026-07-28-13.45.06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28-13.45.06'` | `'2026-07-28-13.45.06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Db2ISeries
 
@@ -40,31 +40,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `Db2ISeriesQuoter`
 - processor.Quoter: `Db2ISeriesQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28-13.45.06'` | `'2026-07-28-13.45.06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28-13.45.06'` | `'2026-07-28-13.45.06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Firebird
 
@@ -72,31 +72,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `FirebirdQuoter`
 - processor.Quoter: `FirebirdQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28 13:45:06'` | `'2026-07-28 13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28 13:45:06'` | `'2026-07-28 13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `LOCALTIMESTAMP` | `LOCALTIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Hana8
 
@@ -104,31 +104,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `HanaQuoter`
 - processor.Quoter: `HanaQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `TRUE` | `TRUE` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `N'O''Brien'` | `N'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `TRUE` | `TRUE` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Hana10
 
@@ -136,31 +136,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `HanaQuoter`
 - processor.Quoter: `HanaQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `TRUE` | `TRUE` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `N'O''Brien'` | `N'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `TRUE` | `TRUE` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Redshift
 
@@ -168,29 +168,29 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `RedshiftQuoter`
 - processor.Quoter: `RedshiftQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `true` | `true` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `SYSDATE` | `SYSDATE` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `E'\\xDEAD'` | `E'\\xDEAD'` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `true` | `true` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `SYSDATE` | `SYSDATE` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Postgres.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Postgres.verified.md
@@ -8,31 +8,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `PostgresQuoter`
 - processor.Quoter: `PostgresQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `true` | `true` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `now()` | `now()` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `E'\\xDEAD'` | `E'\\xDEAD'` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `true` | `true` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `now()` | `now()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Postgres92(ForceQuote=True)
 
@@ -40,31 +40,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `PostgresQuoter`
 - processor.Quoter: `PostgresQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `true` | `true` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `now()` | `now()` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `E'\\xDEAD'` | `E'\\xDEAD'` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `true` | `true` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `now()` | `now()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Postgres10_0(ForceQuote=True)
 
@@ -72,31 +72,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `PostgresQuoter`
 - processor.Quoter: `PostgresQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `true` | `true` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `now()` | `now()` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `E'\\xDEAD'` | `E'\\xDEAD'` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `true` | `true` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `now()` | `now()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Postgres11_0(ForceQuote=True)
 
@@ -104,31 +104,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `PostgresQuoter`
 - processor.Quoter: `PostgresQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `true` | `true` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `now()` | `now()` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `E'\\xDEAD'` | `E'\\xDEAD'` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `true` | `true` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `now()` | `now()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Postgres15_0(ForceQuote=True)
 
@@ -136,31 +136,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `PostgresQuoter`
 - processor.Quoter: `PostgresQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `true` | `true` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `now()` | `now()` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `E'\\xDEAD'` | `E'\\xDEAD'` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `true` | `true` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `now()` | `now()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Postgres(ForceQuote=False)
 
@@ -168,31 +168,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `PostgresQuoter`
 - processor.Quoter: `PostgresQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `true` | `true` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `now()` | `now()` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `E'\\xDEAD'` | `E'\\xDEAD'` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `true` | `true` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `now()` | `now()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Postgres92(ForceQuote=False)
 
@@ -200,31 +200,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `PostgresQuoter`
 - processor.Quoter: `PostgresQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `true` | `true` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `now()` | `now()` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `E'\\xDEAD'` | `E'\\xDEAD'` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `true` | `true` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `now()` | `now()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Postgres10_0(ForceQuote=False)
 
@@ -232,31 +232,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `PostgresQuoter`
 - processor.Quoter: `PostgresQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `true` | `true` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `now()` | `now()` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `E'\\xDEAD'` | `E'\\xDEAD'` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `true` | `true` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `now()` | `now()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Postgres11_0(ForceQuote=False)
 
@@ -264,31 +264,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `PostgresQuoter`
 - processor.Quoter: `PostgresQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `true` | `true` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `now()` | `now()` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `E'\\xDEAD'` | `E'\\xDEAD'` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `true` | `true` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `now()` | `now()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Postgres15_0(ForceQuote=False)
 
@@ -296,29 +296,29 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `PostgresQuoter`
 - processor.Quoter: `PostgresQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `true` | `true` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `now()` | `now()` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `E'\\xDEAD'` | `E'\\xDEAD'` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `true` | `true` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `now()` | `now()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `E'\\xDEAD'` | `E'\\xDEAD'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=SQLite.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=SQLite.verified.md
@@ -8,31 +8,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `SQLiteQuoter`
 - processor.Quoter: `SQLiteQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SQLite(guid=False,strict=False,compat=STRICT)
 
@@ -40,31 +40,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `SQLiteQuoter`
 - processor.Quoter: `SQLiteQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SQLite(guid=False,strict=False,compat=LOOSE)
 
@@ -72,31 +72,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `SQLiteQuoter`
 - processor.Quoter: `SQLiteQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SQLite(guid=False,strict=True,compat=null)
 
@@ -104,31 +104,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `SQLiteQuoter`
 - processor.Quoter: `SQLiteQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SQLite(guid=False,strict=True,compat=STRICT)
 
@@ -136,31 +136,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `SQLiteQuoter`
 - processor.Quoter: `SQLiteQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SQLite(guid=False,strict=True,compat=LOOSE)
 
@@ -168,31 +168,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `SQLiteQuoter`
 - processor.Quoter: `SQLiteQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SQLite(guid=True,strict=False,compat=null)
 
@@ -200,31 +200,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `SQLiteQuoter`
 - processor.Quoter: `SQLiteQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SQLite(guid=True,strict=False,compat=STRICT)
 
@@ -232,31 +232,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `SQLiteQuoter`
 - processor.Quoter: `SQLiteQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SQLite(guid=True,strict=False,compat=LOOSE)
 
@@ -264,31 +264,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `SQLiteQuoter`
 - processor.Quoter: `SQLiteQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SQLite(guid=True,strict=True,compat=null)
 
@@ -296,31 +296,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `SQLiteQuoter`
 - processor.Quoter: `SQLiteQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SQLite(guid=True,strict=True,compat=STRICT)
 
@@ -328,31 +328,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `SQLiteQuoter`
 - processor.Quoter: `SQLiteQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SQLite(guid=True,strict=True,compat=LOOSE)
 
@@ -360,29 +360,29 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `SQLiteQuoter`
 - processor.Quoter: `SQLiteQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `X'dead'` | `X'dead'` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `x'11111111222233334444555555555555'` | `x'11111111222233334444555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `(datetime('now','localtime'))` | `(datetime('now','localtime'))` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `X'dead'` | `X'dead'` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Snowflake.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Snowflake.verified.md
@@ -8,31 +8,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `SnowflakeQuoter`
 - processor.Quoter: `SnowflakeQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28 13:45:06'` | `'2026-07-28 13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28 13:45:06 -04:00'` | `'2026-07-28 13:45:06 -04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `CURRENT_TIMESTAMP()` | `CURRENT_TIMESTAMP()` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28 13:45:06'` | `'2026-07-28 13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28 13:45:06 -04:00'` | `'2026-07-28 13:45:06 -04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `CURRENT_TIMESTAMP()` | `CURRENT_TIMESTAMP()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### Snowflake(QuoteIdentifiers=False)
 
@@ -40,29 +40,29 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `SnowflakeQuoter`
 - processor.Quoter: `SnowflakeQuoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` | `'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28 13:45:06'` | `'2026-07-28 13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28 13:45:06 -04:00'` | `'2026-07-28 13:45:06 -04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `CURRENT_TIMESTAMP()` | `CURRENT_TIMESTAMP()` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28 13:45:06'` | `'2026-07-28 13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28 13:45:06 -04:00'` | `'2026-07-28 13:45:06 -04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `CURRENT_TIMESTAMP()` | `CURRENT_TIMESTAMP()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=SqlServer.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=SqlServer.verified.md
@@ -8,31 +8,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `SqlServer2000Quoter`
 - processor.Quoter: `SqlServer2000Quoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `GETDATE()` | `GETDATE()` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `N'O''Brien'` | `N'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `GETDATE()` | `GETDATE()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SqlServer2005
 
@@ -40,31 +40,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `SqlServer2005Quoter`
 - processor.Quoter: `SqlServer2005Quoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `GETDATE()` | `GETDATE()` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `N'O''Brien'` | `N'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `GETDATE()` | `GETDATE()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SqlServer2008
 
@@ -72,31 +72,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `SqlServer2008Quoter`
 - processor.Quoter: `SqlServer2008Quoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `GETDATE()` | `GETDATE()` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `N'O''Brien'` | `N'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `GETDATE()` | `GETDATE()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SqlServer2012
 
@@ -104,31 +104,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `SqlServer2008Quoter`
 - processor.Quoter: `SqlServer2008Quoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `GETDATE()` | `GETDATE()` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `N'O''Brien'` | `N'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `GETDATE()` | `GETDATE()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SqlServer2014
 
@@ -136,31 +136,31 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `SqlServer2008Quoter`
 - processor.Quoter: `SqlServer2008Quoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `GETDATE()` | `GETDATE()` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `N'O''Brien'` | `N'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `GETDATE()` | `GETDATE()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
 ### SqlServer2016
 
@@ -168,29 +168,29 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 - generator.Quoter: `SqlServer2008Quoter`
 - processor.Quoter: `SqlServer2008Quoter`
 
-| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |
-|---|---|---|---|---|
-| null | *(empty)* | `NULL` | `NULL` | `NULL` |
-| DBNull | *(empty)* | `NULL` | `NULL` | `NULL` |
-| string | `O'Brien` | `'O''Brien'` | `N'O''Brien'` | `N'O''Brien'` |
-| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` | `'ansi'` |
-| char | `x` | `'x'` | `'x'` | `'x'` |
-| bool | `True` | `1` | `1` | `1` |
-| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
-| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
-| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
-| double | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| float | `1234.5` | `1234.5` | `1234.5` | `1234.5` |
-| decimal | `1234.5678` | `1234.5678` | `1234.5678` | `1234.5678` |
-| int | `-1234` | `-1234` | `-1234` | `-1234` |
-| long(uncased) | `-1234` | `-1234` | `-1234` | `-1234` |
-| short(uncased) | `-12` | `-12` | `-12` | `-12` |
-| byte(uncased) | `7` | `7` | `7` | `7` |
-| SystemMethods | `CurrentDateTime` | `<throws NotSupportedException>` | `GETDATE()` | `GETDATE()` |
-| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` | `'Tuesday'` |
-| byte[] | `System.Byte[]` | `0xdead` | `0xdead` | `0xdead` |
-| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` | `'01:02:03'` |
-| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
-| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
-| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `N'O''Brien'` | `N'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `GETDATE()` | `GETDATE()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.cs
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.cs
@@ -351,8 +351,13 @@ namespace FluentMigrator.Tests.Unit.TokenSubstitution
             sb.AppendLine($"- generator.Quoter: `{r.GeneratorQuoter.GetType().Name}`");
             sb.AppendLine($"- processor.Quoter: `{r.ProcessorQuoter.GetType().Name}`");
             sb.AppendLine();
-            sb.AppendLine("| value | `$(x)` | `$[x]` no quoter | `$[x]` w/ quoter | QuoteValue (DML) |");
-            sb.AppendLine("|---|---|---|---|---|");
+            // There was once a "no quoter" column here, recording what the private QuoteSqlLiteral
+            // fallback rendered. That fallback is gone: a null quoter now throws, identically for
+            // every value and every dialect, so the column carried one fact repeated 161 times.
+            // The contract it documented is covered once, in SqlScriptTokenReplacerTests, by
+            // ThrowsWhenSafeTokenIsExpandedWithoutAQuoter and its two companions.
+            sb.AppendLine("| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |");
+            sb.AppendLine("|---|---|---|---|");
 
             foreach (var v in ValueCases())
             {
@@ -360,7 +365,6 @@ namespace FluentMigrator.Tests.Unit.TokenSubstitution
                     " | ",
                     "| " + v.Label,
                     Cell(Expand(RawToken, v.Value, r.ProcessorQuoter)),
-                    Cell(Expand(SafeToken, v.Value, null)),
                     Cell(Expand(SafeToken, v.Value, r.ProcessorQuoter)),
                     Cell(QuoteValueOrThrow(r.GeneratorQuoter, v.Value)) + " |"));
             }


### PR DESCRIPTION
Claude `claude-opus-5[1m]` opening on behalf of @jzabroski.

Implements #2362, per the ADR merged in #2355 and amended in #2364.

## What it does

`SqlScriptTokenReplacer` had **two** implementations of value rendering: the private `QuoteSqlLiteral` in `FluentMigrator.Abstractions`, and `GenericQuoter.QuoteValue` in `Runner.Core`, held in agreement only by a test. This deletes the duplicate rather than relocating it.

- **The `IDictionary<string, object>` overload requires a quoter** — the `= null` default is gone.
- **The guard sits inside the `$[name]` branch**, not at method entry. A script using only `$(name)` never consults the quoter, so rejecting it up front would fail callers with no need of one — including four of the five mock-based expression test files. The message names the token that forced the failure.
- **`QuoteSqlLiteral` and its helpers are deleted.** Nothing is added to Abstractions; `GenericQuoter` is untouched, keeping its virtual dispatch and ~30 provider overrides.
- **The private core gains an `expandSafeTokens` flag.** The obsolete `IDictionary<string, string>` overload passes `false`, so `$[name]` and its `$$[[name]]` escape pass through verbatim — exactly as in 8.0.1, which had no such token.
- **The two production call sites drop the vestigial `?.`** on `processor?.Quoter`. `ExecuteWith` dereferences `processor` unconditionally on the next line, so it never guarded a null processor.

## This reverts a silent behaviour change

The string-dictionary overload dates from `ce4d9428`, **2018-04-04**, and is the only public overload in 8.0.1. It cannot supply a quoter. `main` had started routing it through the shared core, so a script whose text contains `$[...]` was being **substituted** where 8.0.1 returned it untouched — an unannounced change on the oldest API in the file. Item 4 restores the old behaviour, pinned by three tests.

## The matrix column, and the check that matters

The matrix had a `$[x] no quoter` column recording what the fallback rendered. With the fallback gone it reads `<throws ArgumentNullException>` for every value in every dialect — one fact repeated 161 times. Removed, and replaced by three focused tests: the throw, a `$(name)`-only script succeeding without a quoter, and an unresolved `$[name]` not needing one either.

**I verified that removing it moved nothing else.** Discounting that column, all seven snapshots are **byte-identical** to before:

```
MySql:     diff-after-removing-column = 0
Oracle:    diff-after-removing-column = 0
Other:     diff-after-removing-column = 0
Postgres:  diff-after-removing-column = 0
SQLite:    diff-after-removing-column = 0
Snowflake: diff-after-removing-column = 0
SqlServer: diff-after-removing-column = 0
```

That was the ADR's strongest acceptance criterion, and it confirms `QuoteSqlLiteral` and `GenericQuoter.QuoteValue` had not drifted — the deletion is provably behaviour-preserving for every path that still renders.

**One correction to the ADR's wording:** it asked for byte-identical snapshots outright. That was carried over from Option G, where the fallback still rendered. Under Option I the no-quoter column *must* change, because there is no longer a fallback to render it. The criterion holds for every column that produces SQL, which is what it was actually protecting.

## Compatibility

`ReplaceSqlScriptTokens(sqlText, parameters)` stops compiling — free externally, since 8.0.1 exposes only the string-dictionary overload and has no `IMigrationProcessor.Quoter` at all. 23 call sites in our own tests were updated: those expanding only `$(name)` now state `null` explicitly; the rest pass a real quoter.

Two mock-based tests that expand `$[name]` gained a `Quoter` stub, per the ADR. The other twenty mock-processor call sites are untouched — their scripts use `$(name)` only, which is exactly why the guard was narrowed.

## Results

```
5460 passed, 941 skipped, 0 failed   (net48)
```

## Reviewer notes

- **Only `net48` ran locally** — the repo lives on a WSL share. CI covers net8.0.
- `BASELINE-FAILURES.md` is kept as the historical record of what the matrix found, with a note that the column it describes no longer exists. It documents a past run, not the current fixture.
- The `$(name)` DateTime portability question (#2354) is untouched and unaffected either way.

Fixes #2362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
