### PR TITLE
Correct the quoter docs to match the guard, and clear CS1573

### DIFF
--- a/src/FluentMigrator.Abstractions/SqlScriptTokenReplacer.cs
+++ b/src/FluentMigrator.Abstractions/SqlScriptTokenReplacer.cs
@@ -36,14 +36,16 @@ namespace FluentMigrator
         /// <param name="parameters">The tokens to be replaced</param>
         /// <param name="quoter">
         /// The <see cref="IQuoter"/> used to safely quote/format <c>$[name]</c> parameter values
-/// (e.g. numbers, dates, booleans, <see langword="null"/>, strings). Pass the processor's
-/// <c>Quoter</c>. May be <see langword="null"/> only when <paramref name="sqlText"/>
-/// contains no <c>$[name]</c> token that matches a key in <paramref name="parameters"/>, since nothing else consults it.
+        /// (e.g. numbers, dates, booleans, <see langword="null"/>, strings). Pass the processor's
+        /// <c>Quoter</c>. May be <see langword="null"/> when no <c>$[name]</c> token is actually
+        /// expanded, since nothing else consults it - that includes a <c>$[name]</c> whose key is
+        /// absent from <paramref name="parameters"/>, which is left verbatim without rendering.
         /// </param>
         /// <returns>The SQL script with the replaced tokens</returns>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="quoter"/> is <see langword="null"/> and <paramref name="sqlText"/>
-        /// contains a <c>$[name]</c> token.
+        /// contains a <c>$[name]</c> token whose key is present in <paramref name="parameters"/>,
+        /// so a value has to be rendered.
         /// </exception>
         /// <remarks>
         /// Two token styles are supported:
@@ -67,8 +69,10 @@ namespace FluentMigrator
         /// </item>
         /// </list>
         /// <para>
-        /// A <paramref name="quoter"/> is needed only for <c>$[name]</c>. A script using nothing but
-        /// <c>$(name)</c> never consults it and may pass <see langword="null"/>.
+        /// A <paramref name="quoter"/> is needed only where a <c>$[name]</c> value is actually
+        /// rendered. A script using nothing but <c>$(name)</c> never consults it, and neither does a
+        /// <c>$[name]</c> whose key is absent from <paramref name="parameters"/>; both may pass
+        /// <see langword="null"/>.
         /// </para>
         /// <para>
         /// <strong><see cref="RawSql"/> is exempt from quoting in both styles.</strong> It is an
@@ -87,12 +91,12 @@ namespace FluentMigrator
             return ReplaceSqlScriptTokensCore(sqlText, parameters, quoter);
         }
 
-        /// <param name="expandSafeTokens">
-        /// Whether to expand the <c>$[name]</c> token style. The obsolete
-        /// <see cref="IDictionary{TKey,TValue}"/> of <see cref="string"/> overload passes
-        /// <see langword="false"/>, because that token style did not exist when it was the only
-        /// API and 8.0.1 left such text untouched.
-        /// </param>
+        // expandSafeTokens: whether to expand the $[name] token style. The obsolete
+        // IDictionary<string, string> overload passes false, because that token style did not exist
+        // when it was the only API and 8.0.1 left such text untouched.
+        //
+        // Deliberately a plain comment, not a <param> tag: adding one XML param tag to a method
+        // whose other parameters have none produces CS1573, and this method is private.
         private static string ReplaceSqlScriptTokensCore<TValue>(
             [StringSyntax("sql")] string sqlText,
             IDictionary<string, TValue> parameters,

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrix.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrix.md
@@ -9,7 +9,7 @@ Tracking issue: [#2336](https://github.com/fluentmigrator/fluentmigrator/issues/
 
 `SqlScriptTokenReplacer` is reached from `Execute.Sql`, `Execute.Script` and `Execute.EmbeddedScript`
 (`ExecuteSqlStatementExpression.ExecuteWith` and `ExecuteSqlScriptExpressionBase.ExecuteWith` are its
-only callers in `src/`). Those call sites pass `processor?.Quoter`, so token output depends on the
+only callers in `src/`). Those call sites pass `processor.Quoter`, so token output depends on the
 whole DI graph, not just on the replacer.
 
 The axes multiply out to roughly 35,000 combinations. Enumerating each as an NUnit case would be


### PR DESCRIPTION
Claude `claude-opus-5[1m]` opening on behalf of @jzabroski.

Follow-up to #2365, which merged before these landed. **Documentation and warnings only — no behaviour change.**

Addresses the two review findings on that PR, plus one regression I found while verifying them.

## 1. The docs overstated the requirement

The guard sits inside the branch that *renders a value*, so a `$[name]` whose key is **absent** from `parameters` is left verbatim and never consults the quoter. That case has a test — `DoesNotRequireAQuoterForAnUnknownSafeToken` — which the docs directly contradicted.

The Autofix commit on #2365 corrected the `<param>` tag, but the same claim appears in two other places that were left untouched:

| | before | now |
|---|---|---|
| `<exception>` | "contains a `$[name]` token" | "contains a `$[name]` token **whose key is present in `parameters`**, so a value has to be rendered" |
| `<remarks>` | "needed only for `$[name]`" | "needed only where a `$[name]` value is **actually rendered**" |

The `<param>` tag keeps the corrected meaning and **regains its indentation** — the Autofix had flattened three `///` lines to column 0.

## 2. Stale call-pattern in the matrix doc

`TokenSubstitutionMatrix.md` described the call sites as passing `processor?.Quoter`; #2365 changed them to `processor.Quoter`.

Three mentions remain in `adr/proposed/RequireQuoterForTokenSubstitution.md` and are deliberately left alone — two are historical context describing the state *before* the change, one is a forward-looking out-of-scope item. That file is a merged decision record.

## 3. CS1573 ×18 — a regression I introduced

Found while verifying the above. #2365 added a `<param>` tag to the **private** `ReplaceSqlScriptTokensCore` without documenting its other three parameters, which produces CS1573 for each, across each target framework.

CI does not fail on warnings, so it merged green — but #2331 deliberately cleared every warning in this repo, so this put 18 back.

Now a plain `//` comment, since the method is private and needs no XML doc, with a note recording *why* so the tag does not come back. Measured rather than assumed:

```
CS1573 at bf66f419 (main):  18
CS1573 now:                  0
```

## Results

```
5460 passed, 942 skipped, 0 failed   (net48)
```

Only `net48` ran locally — the repo lives on a WSL share. CI covers net8.0.

Refs #2362, #2365.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
