### PR TITLE
Close two coverage gaps in the token substitution matrix

### DIFF
--- a/test/FluentMigrator.Tests/EmbeddedResources/EmbeddedTestScriptWithSafeToken.sql
+++ b/test/FluentMigrator.Tests/EmbeddedResources/EmbeddedTestScriptWithSafeToken.sql
@@ -1,0 +1,1 @@
+EMBEDDED TEST SCRIPT $(parameter) $[safe_parameter]

--- a/test/FluentMigrator.Tests/TestScriptWithSafeToken.sql
+++ b/test/FluentMigrator.Tests/TestScriptWithSafeToken.sql
@@ -1,0 +1,1 @@
+TEST SCRIPT $(parameter) $[safe_parameter]

--- a/test/FluentMigrator.Tests/Unit/Expressions/ExecuteEmbeddedSqlExpressionTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Expressions/ExecuteEmbeddedSqlExpressionTests.cs
@@ -24,6 +24,8 @@ using FluentMigrator.Expressions;
 using FluentMigrator.Tests.Helpers;
 using FluentMigrator.Infrastructure;
 
+using FluentMigrator.Runner.Generators.Generic;
+
 using Moq;
 
 using NUnit.Framework;
@@ -132,6 +134,35 @@ namespace FluentMigrator.Tests.Unit.Expressions
         {
             var expression = new ExecuteSqlScriptExpression { SqlScript = TestSqlScript };
             expression.ToString().ShouldBe("ExecuteSqlScript embeddedtestscript.sql");
+        }
+
+        /// <summary>
+        /// <c>Execute.EmbeddedScript</c> shares
+        /// <c>ExecuteSqlScriptExpressionBase.ExecuteWith</c> with <c>Execute.Script</c>, so it
+        /// reaches the token replacer by the same call site. Pinned separately because the two
+        /// entry points resolve their script content differently, and only the resolved text
+        /// reaches the replacer.
+        /// </summary>
+        [Test]
+        public void ExecutesTheEmbeddedScriptWithSafeTokenUsingProcessorQuoter()
+        {
+            var provider = new DefaultEmbeddedResourceProvider(Assembly.GetExecutingAssembly());
+            var expression = new ExecuteEmbeddedSqlScriptExpression(new[] { provider })
+            {
+                SqlScript = "EmbeddedTestScriptWithSafeToken.sql",
+                Parameters = new Dictionary<string, object>
+                {
+                    { "parameter", "ParameterValue" },
+                    { "safe_parameter", "isn't safe" },
+                },
+            };
+
+            var processor = new Mock<IMigrationProcessor>();
+            processor.SetupGet(x => x.Quoter).Returns(new GenericQuoter());
+            processor.Setup(x => x.Execute("EMBEDDED TEST SCRIPT ParameterValue 'isn''t safe'")).Verifiable();
+
+            expression.ExecuteWith(processor.Object);
+            processor.Verify();
         }
     }
 }

--- a/test/FluentMigrator.Tests/Unit/Expressions/ExecuteSqlScriptExpressionTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Expressions/ExecuteSqlScriptExpressionTests.cs
@@ -25,6 +25,8 @@ using FluentMigrator.Infrastructure;
 using FluentMigrator.Runner;
 using FluentMigrator.Tests.Helpers;
 
+using FluentMigrator.Runner.Generators.Generic;
+
 using Moq;
 
 using NUnit.Framework;
@@ -143,6 +145,58 @@ namespace FluentMigrator.Tests.Unit.Expressions
             var processed = expression.Apply(conventionSet);
 
             processed.SqlScript.ShouldBe(scriptOnAnotherDrive);
+        }
+
+        /// <summary>
+        /// <c>Execute.Script</c> reaches the token replacer through
+        /// <c>ExecuteSqlScriptExpressionBase.ExecuteWith</c>, which is a different call site from the
+        /// one <c>Execute.Sql</c> uses. Every other test on this path uses <c>$(name)</c> only, so
+        /// nothing proved this call site passes the processor's quoter - it could have been reverted
+        /// to <see langword="null"/> and the suite would have stayed green.
+        /// </summary>
+        [Test]
+        public void ExecutesTheScriptWithSafeTokenUsingProcessorQuoter()
+        {
+            var expression = new ExecuteSqlScriptExpression
+            {
+                SqlScript = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "TestScriptWithSafeToken.sql"),
+                Parameters = new Dictionary<string, object>
+                {
+                    { "parameter", "ParameterValue" },
+                    { "safe_parameter", "isn't safe" },
+                },
+            };
+
+            var processor = new Mock<IMigrationProcessor>();
+            processor.SetupGet(x => x.Quoter).Returns(new GenericQuoter());
+            processor.Setup(x => x.Execute("TEST SCRIPT ParameterValue 'isn''t safe'")).Verifiable();
+
+            expression.ExecuteWith(processor.Object);
+            processor.Verify();
+        }
+
+        /// <summary>
+        /// The counterpart: without a quoter the same script must fail loudly rather than emit
+        /// something unquoted.
+        /// </summary>
+        [Test]
+        public void ExecutingTheScriptWithSafeTokenAndNoQuoterThrows()
+        {
+            var expression = new ExecuteSqlScriptExpression
+            {
+                SqlScript = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "TestScriptWithSafeToken.sql"),
+                Parameters = new Dictionary<string, object>
+                {
+                    { "parameter", "ParameterValue" },
+                    { "safe_parameter", "isn't safe" },
+                },
+            };
+
+            // Quoter deliberately unstubbed, so the mock returns null.
+            var processor = new Mock<IMigrationProcessor>();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => expression.ExecuteWith(processor.Object));
+            exception.Message.ShouldContain("$[safe_parameter]");
         }
     }
 }

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/BASELINE-FAILURES.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/BASELINE-FAILURES.md
@@ -62,7 +62,7 @@ non-string values as string literals:
 | `RawSql.Insert("CURRENT_TIMESTAMP")` | `'FluentMigrator.RawSql'` | `CURRENT_TIMESTAMP` |
 
 These are visible in the golden tables rather than asserted individually, because the correct
-behaviour of the fallback is an API decision (see #2336) rather than an unambiguous bug.
+behaviour of the fallback is an API decision (resolved by adr/proposed/RequireQuoterForTokenSubstitution.md, implemented in #2365) rather than an unambiguous bug.
 
 ## After the fixes
 
@@ -93,7 +93,7 @@ take, and it is also what `Insert`/`Update`/`Delete` emit.
 One cell deliberately not changed: `$(x)` still renders a `DateTime` as `07/28/2026 13:45:06`. The
 raw token style is documented as verbatim `ToString()`, and it is invariant-culture, so this is
 consistent - but it is not a portable SQL datetime literal. Callers wanting one should use `$[x]`.
-Noted in #2336 rather than changed here.
+Noted for follow-up rather than changed here; now tracked as #2354.
 
 One cell changed to a throw rather than a value:
 

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrix.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrix.md
@@ -3,7 +3,7 @@
 Reference document for `TokenSubstitutionMatrixTests`. Describes *what* the matrix covers and *why*
 each axis exists. The measured output lives in the `*.verified.md` snapshots beside this file.
 
-Tracking issue: [#2336](https://github.com/fluentmigrator/fluentmigrator/issues/2336).
+Origin: [#2336](https://github.com/fluentmigrator/fluentmigrator/issues/2336), the coverage request this fixture answers. Design decisions since then live in `adr/proposed/RequireQuoterForTokenSubstitution.md`.
 
 ## Why a matrix
 
@@ -104,8 +104,31 @@ because token substitution reads `processor.Quoter` while DML generation reads `
 type strings for DDL. The orthogonality is therefore true by construction today, and this test exists
 so that a future refactor cannot quietly couple them.
 
+## What this fixture does *not* cover
+
+The matrix calls `SqlScriptTokenReplacer` directly with a quoter resolved from a real container. It
+therefore proves what the replacer does with a given quoter, but not that the production call sites
+hand it the right one. That is covered separately, and deliberately, because the two call sites are
+distinct pieces of code:
+
+| Entry point | Call site | Covered by |
+|---|---|---|
+| `Execute.Sql` | `ExecuteSqlStatementExpression.ExecuteWith` | `ExecuteSqlStatementExpressionTests` |
+| `Execute.Script` | `ExecuteSqlScriptExpressionBase.ExecuteWith` | `ExecuteSqlScriptExpressionTests` |
+| `Execute.EmbeddedScript` | same base | `ExecuteEmbeddedSqlExpressionTests` |
+
+Each has a test that expands a `$[name]` token through a mock processor with a stubbed `Quoter`, so
+reverting a call site to `null` fails rather than silently degrading. Before those existed, only
+`Execute.Sql` was pinned - the script paths used `$(name)` exclusively and would have stayed green.
+
 ## Known-wrong cells
 
-Cells that are wrong at the time of writing are marked in the snapshots and tracked in #2336. The
-snapshot is a record of *current* behaviour, not of *desired* behaviour; the assertion tests above
-encode desired behaviour and are the ones that fail while a defect is open.
+The snapshot is a record of *current* behaviour, not of *desired* behaviour; the assertion tests
+above encode desired behaviour and are the ones that fail while a defect is open.
+
+One cell is knowingly wrong today: `$(x)` renders a `DateTime` as `07/28/2026 13:45:06`, which is
+invariant but not a portable SQL datetime literal. Tracked in
+[#2354](https://github.com/fluentmigrator/fluentmigrator/issues/2354). The defects the matrix was
+built to find - [#2332](https://github.com/fluentmigrator/fluentmigrator/issues/2332),
+[#2335](https://github.com/fluentmigrator/fluentmigrator/issues/2335) and the culture and
+fallback bugs - are fixed, so no other cell is pending.

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=MySql.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=MySql.verified.md
@@ -2,6 +2,38 @@
 
 See `TokenSubstitutionMatrix.md` for what each column means.
 
+### MySql(unversioned)
+
+- generator: `MySql8Generator`
+- generator.Quoter: `MySqlQuoter`
+- processor.Quoter: `MySqlQuoter`
+
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `'O''Brien'` | `'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
 ### MySql4
 
 - generator: `MySql4Generator`

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Other.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Other.verified.md
@@ -98,6 +98,38 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 | RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
 | RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
 
+### Hana(unversioned)
+
+- generator: `HanaGenerator`
+- generator.Quoter: `HanaQuoter`
+- processor.Quoter: `HanaQuoter`
+
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `N'O''Brien'` | `N'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `TRUE` | `TRUE` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
 ### Hana8
 
 - generator: `HanaGenerator`

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=SqlServer.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=SqlServer.verified.md
@@ -2,6 +2,38 @@
 
 See `TokenSubstitutionMatrix.md` for what each column means.
 
+### SqlServer(unversioned)
+
+- generator: `SqlServer2016Generator`
+- generator.Quoter: `SqlServer2008Quoter`
+- processor.Quoter: `SqlServer2008Quoter`
+
+| value | `$(x)` | `$[x]` w/ quoter | QuoteValue (DML) |
+|---|---|---|---|
+| null | *(empty)* | `NULL` | `NULL` |
+| DBNull | *(empty)* | `NULL` | `NULL` |
+| string | `O'Brien` | `N'O''Brien'` | `N'O''Brien'` |
+| NonUnicodeString | `ansi` | `'ansi'` | `'ansi'` |
+| char | `x` | `'x'` | `'x'` |
+| bool | `True` | `1` | `1` |
+| Guid | `11111111-2222-3333-4444-555555555555` | `'11111111-2222-3333-4444-555555555555'` | `'11111111-2222-3333-4444-555555555555'` |
+| DateTime | `07/28/2026 13:45:06` | `'2026-07-28T13:45:06'` | `'2026-07-28T13:45:06'` |
+| DateTimeOffset | `07/28/2026 13:45:06 -04:00` | `'2026-07-28T13:45:06-04:00'` | `'2026-07-28T13:45:06-04:00'` |
+| double | `1234.5678` | `1234.5678` | `1234.5678` |
+| float | `1234.5` | `1234.5` | `1234.5` |
+| decimal | `1234.5678` | `1234.5678` | `1234.5678` |
+| int | `-1234` | `-1234` | `-1234` |
+| long(uncased) | `-1234` | `-1234` | `-1234` |
+| short(uncased) | `-12` | `-12` | `-12` |
+| byte(uncased) | `7` | `7` | `7` |
+| SystemMethods | `CurrentDateTime` | `GETDATE()` | `GETDATE()` |
+| Enum | `Tuesday` | `'Tuesday'` | `'Tuesday'` |
+| byte[] | `System.Byte[]` | `0xdead` | `0xdead` |
+| TimeSpan | `01:02:03` | `'01:02:03'` | `'01:02:03'` |
+| RawSql | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` |
+| RawSql+backslash | `c REGEXP '\d+'` | `c REGEXP '\d+'` | `c REGEXP '\d+'` |
+| RawSql+quote | `name = 'O''Brien'` | `name = 'O''Brien'` | `name = 'O''Brien'` |
+
 ### SqlServer2000
 
 - generator: `SqlServer2000Generator`

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.cs
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.cs
@@ -60,7 +60,7 @@ namespace FluentMigrator.Tests.Unit.TokenSubstitution
     /// while the value x token-style grid becomes a snapshot payload. A regression surfaces as a
     /// one-cell diff in a markdown table rather than one of 35,000 opaque case names.
     /// </para>
-    /// <para>Tracking issue: https://github.com/fluentmigrator/fluentmigrator/issues/2336</para>
+    /// <para>Origin: https://github.com/fluentmigrator/fluentmigrator/issues/2336</para>
     /// </remarks>
     [TestFixture]
     [Category("SqlScriptTokenReplacer")]
@@ -103,6 +103,11 @@ namespace FluentMigrator.Tests.Unit.TokenSubstitution
         private static IEnumerable<DialectCase> DialectCases()
         {
             // --- SQL Server -------------------------------------------------------------------
+            // The unversioned entry point is a separate registration block, not a delegation to the
+            // versioned one - AddSqlServer() wires SqlServer2016Processor/Generator and
+            // SqlServer2008Quoter in its own body. It is also the form most user code calls, so it
+            // is pinned here rather than assumed to match AddSqlServer2016().
+            yield return new DialectCase("SqlServer(unversioned)", "SqlServer", b => b.AddSqlServer());
             yield return new DialectCase("SqlServer2000", "SqlServer", b => b.AddSqlServer2000());
             yield return new DialectCase("SqlServer2005", "SqlServer", b => b.AddSqlServer2005());
             yield return new DialectCase("SqlServer2008", "SqlServer", b => b.AddSqlServer2008());
@@ -111,6 +116,8 @@ namespace FluentMigrator.Tests.Unit.TokenSubstitution
             yield return new DialectCase("SqlServer2016", "SqlServer", b => b.AddSqlServer2016());
 
             // --- MySQL: MySql4/5/8 differ only by ITypeMap, so their matrices must be identical.
+            // Likewise its own block, wiring MySql8Processor/Generator.
+            yield return new DialectCase("MySql(unversioned)", "MySql", b => b.AddMySql());
             yield return new DialectCase("MySql4", "MySql", b => b.AddMySql4());
             yield return new DialectCase("MySql5", "MySql", b => b.AddMySql5(), typeMapVariantOf: "MySql4");
             yield return new DialectCase("MySql8", "MySql", b => b.AddMySql8(), typeMapVariantOf: "MySql4");
@@ -185,6 +192,7 @@ namespace FluentMigrator.Tests.Unit.TokenSubstitution
             yield return new DialectCase("Db2", "Other", b => b.AddDb2());
             yield return new DialectCase("Db2ISeries", "Other", b => b.AddDb2ISeries());
             yield return new DialectCase("Firebird", "Other", b => b.AddFirebird());
+            yield return new DialectCase("Hana(unversioned)", "Other", b => b.AddHana());
             yield return new DialectCase("Hana8", "Other", b => b.AddHana8());
             yield return new DialectCase("Hana10", "Other", b => b.AddHana10());
             yield return new DialectCase("Redshift", "Other", b => b.AddRedshift());


### PR DESCRIPTION
Claude `claude-opus-5[1m]` opening on behalf of @jzabroski.

Audit of #2336 before closing it. **Test-only — no production code.**

The seven assertions #2336 asked for are all present on `main`, and both deferred items have homes: `$(name)` DateTime portability is #2354, and the `IQuoter` question was settled by the ADR and implemented in #2365. Two gaps were still open.

## Gap 1 — the unversioned provider registrations were untested

The matrix covered `AddSqlServer2000..2016`, `AddMySql4/5/8` and `AddHana8/10`, but **not** the unversioned `AddSqlServer()`, `AddMySql()` and `AddHana()`.

Those are not thin delegations. `AddSqlServer()` wires `SqlServer2016Processor`, `SqlServer2016Generator` and `SqlServer2008Quoter` **in its own body**; `AddMySql()` wires MySql8 the same way. They are duplicated registration blocks that can drift from the versioned ones — and `AddSqlServer()` is the form most user code actually calls.

They render **identically** to their versioned twins today, verified by diffing the new snapshot sections against `SqlServer2016`, `MySql8` and `Hana10`. So this pins existing behaviour rather than fixing a bug.

## Gap 2 — `$[name]` was never exercised through `Execute.Script` or `Execute.EmbeddedScript`

This is the one that mattered.

Those entry points reach the replacer through `ExecuteSqlScriptExpressionBase.ExecuteWith` — a **different call site** from the one `Execute.Sql` uses. Every existing test on that path used `$(name)` only, and `$(name)` never consults the quoter. So the call site could have been reverted to `null` and the entire suite would have stayed green.

That is precisely the regression #2365 was written to prevent, on the one path it did not cover.

Adds a safe-token fixture per entry point and three tests: both paths expand `$[name]` through a stubbed processor `Quoter`, and the file-based path additionally asserts that omitting the quoter throws, naming the offending token.

## Documentation

`TokenSubstitutionMatrix.md` gains a **"What this fixture does not cover"** section. The matrix calls the replacer directly, so it proves what the replacer does with a given quoter but not that the call sites hand it the right one — with a table pointing at where each is covered. That distinction is what hid gap 2.

Stale `#2336` references are repointed so the issue can close without orphaning them. The "known-wrong cells" section named #2336 for defects that are now fixed; it now names #2354 for the one that is not. The two remaining mentions are provenance, not tracking.

## Results

```
5475 passed, 942 skipped, 0 failed   (net48)
```

Only `net48` ran locally — the repo lives on a WSL share. CI covers net8.0.

## On closing #2336

With this merged I would close it. Everything it proposed exists, the two gaps found in audit are filled, and its deferred items are tracked elsewhere.

Refs #2336, #2354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
