### PR TITLE
Clone constraint definitions independently

### DIFF
--- a/src/FluentMigrator.Abstractions/Model/ConstraintDefinition.cs
+++ b/src/FluentMigrator.Abstractions/Model/ConstraintDefinition.cs
@@ -83,7 +83,7 @@ namespace FluentMigrator.Model
         {
             var result = new ConstraintDefinition(_constraintType)
             {
-                Columns = new List<string>(Columns),
+                Columns = new HashSet<string>(Columns),
                 ConstraintName = ConstraintName,
                 SchemaName = SchemaName,
                 TableName = TableName

--- a/src/FluentMigrator.Abstractions/Model/ConstraintDefinition.cs
+++ b/src/FluentMigrator.Abstractions/Model/ConstraintDefinition.cs
@@ -83,8 +83,9 @@ namespace FluentMigrator.Model
         {
             var result = new ConstraintDefinition(_constraintType)
             {
-                Columns = Columns,
+                Columns = new List<string>(Columns),
                 ConstraintName = ConstraintName,
+                SchemaName = SchemaName,
                 TableName = TableName
             };
 

--- a/test/FluentMigrator.Tests/Unit/Definitions/ConstraintDefinitionTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Definitions/ConstraintDefinitionTests.cs
@@ -28,6 +28,25 @@ namespace FluentMigrator.Tests.Unit.Definitions
     public class ConstraintDefinitionTests
     {
         [Test]
+        public void ClonePreservesSchemaAndDoesNotShareColumns()
+        {
+            var definition = new ConstraintDefinition(ConstraintType.PrimaryKey)
+            {
+                ConstraintName = "PK_Users",
+                SchemaName = "tenant",
+                TableName = "Users",
+            };
+            definition.Columns.Add("Id");
+
+            var clone = (ConstraintDefinition)definition.Clone();
+            clone.Columns.Add("TenantId");
+
+            Assert.That(clone.SchemaName, Is.EqualTo("tenant"));
+            Assert.That(definition.Columns, Is.EquivalentTo(new[] { "Id" }));
+            Assert.That(clone.Columns, Is.EquivalentTo(new[] { "Id", "TenantId" }));
+        }
+
+        [Test]
         public void WhenDefaultSchemaConventionIsAppliedAndSchemaIsNotSetThenSchemaShouldBeNull()
         {
             var expr = new CreateConstraintExpression(ConstraintType.PrimaryKey)


### PR DESCRIPTION
Fixes #2374.

## Summary
- Preserve the schema when cloning a constraint definition.
- Create a distinct column collection for the clone.
- Add regression coverage for both behaviors.

## Root cause
`ConstraintDefinition.Clone()` omitted `SchemaName` and assigned the original `Columns` list to the clone. A clone therefore lost schema-qualified constraint information, and editing its columns also edited the original definition.

## Validation
```
dotnet test test\FluentMigrator.Tests\FluentMigrator.Tests.csproj --configuration Debug --no-restore --filter "FullyQualifiedName~ConstraintDefinitionTests|FullyQualifiedName~CreateConstraintExpressionTests|FullyQualifiedName~DeleteConstraintExpressionTests" --verbosity minimal
```