### PR TITLE
Fix #2367: console --include-untagged crash for explicit values.

### DIFF
--- a/src/FluentMigrator.Console/MigratorConsole.cs
+++ b/src/FluentMigrator.Console/MigratorConsole.cs
@@ -206,7 +206,7 @@ namespace FluentMigrator.Console
                     },
                     {
                         "include-untagged:",
-                        "Include untagged migrations and/or maintenance objects.",
+                        "Include untagged migrations and/or maintenance objects. Available values are: ma, maintenance, mi, migrations with an optional '+' or '-' at the end to enable or disable the option. Multiple values may be given when separated by a comma.",
                         v =>
                         {
                             if (string.IsNullOrEmpty(v))

--- a/src/FluentMigrator.Console/MigratorConsole.cs
+++ b/src/FluentMigrator.Console/MigratorConsole.cs
@@ -215,38 +215,23 @@ namespace FluentMigrator.Console
                             }
                             else
                             {
-                                var items = v.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
-                                    .Select(x => x.ToLowerInvariant().Trim())
-                                    .Where(x => !string.IsNullOrEmpty(x))
-                                    .Select(
-                                        x =>
-                                        {
-                                            var hasOption = x.EndsWith("+") || x.EndsWith("-");
-                                            var enable = !x.EndsWith("-");
-                                            var name = hasOption ? x.Substring(0, x.Length - 1) : x;
-                                            return new
-                                            {
-                                                FullName = x,
-                                                ShortName = name.Substring(0, Math.Min(2, name.Length)),
-                                                Enable = enable,
-                                            };
-                                        });
-                                foreach (var item in items)
+                                foreach (var raw in v.Split([','], StringSplitOptions.RemoveEmptyEntries))
                                 {
-                                    switch (item.ShortName)
-                                    {
-                                        case "ma":
-                                            IncludeUntaggedMaintenances = item.Enable;
-                                            break;
-                                        case "mi":
-                                            IncludeUntaggedMigrations = item.Enable;
-                                            break;
-                                        default:
-                                            throw new ArgumentOutOfRangeException(
-                                                $"The argument {item.FullName} is not supported. "
-                                              + "Valid values are: ma, maintenance, mi, migrations with an optional '+' or '-' at the end to enable or disable the option. "
-                                              + "Multiple values may be given when separated by a comma.");
-                                    }
+                                    var token = raw.Trim();
+                                    if (token.Length == 0)
+                                        continue;
+
+                                    var enable = !token.EndsWith("-", StringComparison.Ordinal);
+
+                                    if (token.StartsWith("ma", StringComparison.OrdinalIgnoreCase))
+                                        IncludeUntaggedMaintenances = enable;
+                                    else if (token.StartsWith("mi", StringComparison.OrdinalIgnoreCase))
+                                        IncludeUntaggedMigrations = enable;
+                                    else
+                                        throw new ArgumentOutOfRangeException(
+                                            $"The argument {token} is not supported. "
+                                          + "Valid values are: ma, maintenance, mi, migrations with an optional '+' or '-' at the end to enable or disable the option. "
+                                          + "Multiple values may be given when separated by a comma.");
                                 }
                             }
                         }
@@ -426,7 +411,7 @@ namespace FluentMigrator.Console
                         opt.PreviewOnly = PreviewOnly;
                         opt.ProviderSwitches = ProviderSwitches;
                         opt.StripComments = StripComments;
-                        opt.Timeout = Timeout == null ? null : (TimeSpan?)TimeSpan.FromSeconds(Timeout.Value);
+                        opt.Timeout = Timeout == null ? null : (TimeSpan?) TimeSpan.FromSeconds(Timeout.Value);
                     });
 
             if (StopOnError)

--- a/src/FluentMigrator.Console/MigratorConsole.cs
+++ b/src/FluentMigrator.Console/MigratorConsole.cs
@@ -227,7 +227,7 @@ namespace FluentMigrator.Console
                                             return new
                                             {
                                                 FullName = x,
-                                                ShortName = name.Substring(Math.Min(2, name.Length)),
+                                                ShortName = name.Substring(0, Math.Min(2, name.Length)),
                                                 Enable = enable,
                                             };
                                         });
@@ -426,7 +426,7 @@ namespace FluentMigrator.Console
                         opt.PreviewOnly = PreviewOnly;
                         opt.ProviderSwitches = ProviderSwitches;
                         opt.StripComments = StripComments;
-                        opt.Timeout = Timeout == null ? null : (TimeSpan?) TimeSpan.FromSeconds(Timeout.Value);
+                        opt.Timeout = Timeout == null ? null : (TimeSpan?)TimeSpan.FromSeconds(Timeout.Value);
                     });
 
             if (StopOnError)

--- a/test/FluentMigrator.Tests/Unit/Runners/MigratorConsoleTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Runners/MigratorConsoleTests.cs
@@ -78,6 +78,97 @@ namespace FluentMigrator.Tests.Unit.Runners
         }
 
         [Test]
+        public void IncludeUntaggedIsMigrationsOnlyByDefault()
+        {
+            var console = new MigratorConsole();
+            console.IncludeUntaggedMigrations.ShouldBeTrue();
+            console.IncludeUntaggedMaintenances.ShouldBeFalse();
+        }
+
+        [TestCase(null, true, true, TestName = "IncludeUntagged_Absent_EnablesBoth")]
+        [TestCase("", true, true, TestName = "IncludeUntagged_Empty_EnablesBoth")]
+        [TestCase(",", true, false, TestName = "IncludeUntagged_OnlySeparators_LeavesDefaults")]
+        // migrations token, every suffix
+        [TestCase("mi", true, false)]
+        [TestCase("mi+", true, false)]
+        [TestCase("mi-", false, false)]
+        [TestCase("migrations", true, false)]
+        [TestCase("migrations+", true, false)]
+        [TestCase("migrations-", false, false)]
+        // maintenance token, every suffix
+        [TestCase("ma", true, true)]
+        [TestCase("ma+", true, true)]
+        [TestCase("ma-", true, false)]
+        [TestCase("maintenance", true, true)]
+        [TestCase("maintenance+", true, true)]
+        [TestCase("maintenance-", true, false)]
+        // every combination of the two toggles
+        [TestCase("mi+,ma+", true, true)]
+        [TestCase("mi+,ma-", true, false)]
+        [TestCase("mi-,ma+", false, true)]
+        [TestCase("mi-,ma-", false, false)]
+        // order independence
+        [TestCase("ma+,mi-", false, true)]
+        // case-insensitive
+        [TestCase("MI-", false, false)]
+        [TestCase("MA+", true, true)]
+        [TestCase("Migrations-,Maintenance+", false, true)]
+        // whitespace trimming and empty entries removed
+        [TestCase(" mi- , ma+ ", false, true)]
+        [TestCase("mi-,,ma+", false, true)]
+        // long-form combinations, every combination of the two signs
+        [TestCase("migrations+,maintenance+", true, true)]
+        [TestCase("migrations+,maintenance-", true, false)]
+        [TestCase("migrations-,maintenance+", false, true)]
+        [TestCase("migrations-,maintenance-", false, false)]
+        // long-form order independence
+        [TestCase("maintenance+,migrations-", false, true)]
+        [TestCase("maintenance-,migrations+", true, false)]
+        // long-form / short-form mixed
+        [TestCase("migrations-,ma+", false, true)]
+        [TestCase("mi+,maintenance-", true, false)]
+        public void IncludeUntaggedParsesValue(string value, bool expectedMigrations, bool expectedMaintenances)
+        {
+            var (console, exitCode) = RunWithIncludeUntagged(value);
+
+            exitCode.ShouldBe(0);
+            console.IncludeUntaggedMigrations.ShouldBe(expectedMigrations);
+            console.IncludeUntaggedMaintenances.ShouldBe(expectedMaintenances);
+        }
+
+        [TestCase("mo")]
+        [TestCase("foo-")]
+        [TestCase("z+")]
+        [TestCase("mi-,zz")]
+        public void IncludeUntaggedRejectsUnknownValue(string value)
+        {
+            var (_, exitCode) = RunWithIncludeUntagged(value);
+
+            exitCode.ShouldBe(3);
+        }
+
+        private static (MigratorConsole Console, int ExitCode) RunWithIncludeUntagged(string value)
+        {
+            var stringWriter = new StringWriter(new StringBuilder());
+            System.Console.SetOut(stringWriter);
+            System.Console.SetError(stringWriter);
+
+            var includeUntagged = value == null ? "/include-untagged" : "/include-untagged=" + value;
+            var console = new MigratorConsole();
+
+            var exitCode = console.Run(
+                "/db", Database,
+                "/connection", Connection,
+                "/target", Target,
+                "/namespace", "FluentMigrator.Tests.Unit.Runners.Migrations",
+                "/task", "migrate:up",
+                "/version", "0",
+                includeUntagged);
+
+            return (console, exitCode);
+        }
+
+        [Test]
         public void ConsoleAnnouncerHasMoreOutputWhenVerbose()
         {
             var sbNonVerbose = new StringBuilder();

--- a/test/FluentMigrator.Tests/Unit/Runners/MigratorConsoleTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Runners/MigratorConsoleTests.cs
@@ -19,6 +19,7 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 
 using FluentMigrator.Console;
 
@@ -145,6 +146,37 @@ namespace FluentMigrator.Tests.Unit.Runners
             var (_, exitCode) = RunWithIncludeUntagged(value);
 
             exitCode.ShouldBe(3);
+        }
+
+        // Smoke test for the --help output.
+        //
+        // It is intended as the home for verifying any option's help text:
+        // when you add or change an option description in MigratorConsole, add another
+        // `normalized.ShouldContain(...)` assertion here for that option.
+        [Test]
+        public void HelpOutputContainsOptionDescriptions()
+        {
+            var sb = new StringBuilder();
+            var stringWriter = new StringWriter(sb);
+            System.Console.SetOut(stringWriter);
+            System.Console.SetError(stringWriter);
+
+            var exitCode = new MigratorConsole().Run(
+                "/db", Database,
+                "/target", Target,
+                "/help");
+
+            exitCode.ShouldBe(0);
+
+            // WriteOptionDescriptions word-wraps long descriptions across lines,
+            // so collapse whitespace before asserting the description is present.
+            var normalized = Regex.Replace(sb.ToString(), @"\s+", " ");
+
+            // --include-untagged
+            normalized.ShouldContain(
+                "Available values are: ma, maintenance, mi, migrations with an optional '+' or '-' "
+                + "at the end to enable or disable the option. "
+                + "Multiple values may be given when separated by a comma.");
         }
 
         private static (MigratorConsole Console, int ExitCode) RunWithIncludeUntagged(string value)


### PR DESCRIPTION
## Summary

`Migrate.exe --include-untagged=<value>` crashed (exit code 3) for **every** explicit value. Only the bare `--include-untagged` flag worked, so untagged migrations and untagged maintenance objects could not be enabled/disabled individually from the console runner.

Fixes #2367