### PR TITLE
Fix SQL literal prefix expansion

### DIFF
--- a/src/FluentMigrator.Analyzers/RawSqlTokenInterpolationCodeFixProvider.cs
+++ b/src/FluentMigrator.Analyzers/RawSqlTokenInterpolationCodeFixProvider.cs
@@ -131,14 +131,58 @@ namespace FluentMigrator.Analyzers
                 return tokenSpan;
             }
 
-            // Walk back over a literal prefix: N'...', E'...', U&'...', _utf8mb4'...'.
-            var prefixStart = start;
-            while (prefixStart > 0 && (char.IsLetterOrDigit(text[prefixStart - 1]) || text[prefixStart - 1] == '_' || text[prefixStart - 1] == '&'))
+            // Consider the entire identifier-like run before the quote. It is part of the
+            // replacement only when that whole run is a recognized literal prefix; SQL such as
+            // LIKE'...' and columnN'...' must keep the adjacent keyword or identifier intact.
+            var candidateStart = start;
+            if (candidateStart >= 2 && text[candidateStart - 1] == '&' &&
+                (text[candidateStart - 2] == 'U' || text[candidateStart - 2] == 'u'))
             {
-                prefixStart--;
+                candidateStart -= 2;
+            }
+            else
+            {
+                while (candidateStart > 0 &&
+                       (char.IsLetterOrDigit(text[candidateStart - 1]) || text[candidateStart - 1] == '_'))
+                {
+                    candidateStart--;
+                }
             }
 
+            var candidate = text.ToString(TextSpan.FromBounds(candidateStart, start));
+            var hasIdentifierBoundary = candidateStart == 0 ||
+                                        !(char.IsLetterOrDigit(text[candidateStart - 1]) || text[candidateStart - 1] == '_');
+            var prefixStart = hasIdentifierBoundary && IsKnownLiteralPrefix(candidate) ? candidateStart : start;
+
             return TextSpan.FromBounds(prefixStart, end + 1);
+        }
+
+        private static bool IsKnownLiteralPrefix(string candidate)
+        {
+            if (candidate.Length == 0)
+            {
+                return false;
+            }
+
+            // MySQL character-set introducers use the open-ended _charset_name form, for
+            // example _utf8mb4'...' or _custom_charset'...'.
+            if (candidate[0] == '_')
+            {
+                return candidate.Length > 1 &&
+                       candidate.Skip(1).All(c => char.IsLetterOrDigit(c) || c == '_');
+            }
+
+            switch (candidate.ToUpperInvariant())
+            {
+                case "N":   // national character literal - T-SQL, Oracle, MySQL, standard
+                case "E":   // PostgreSQL escape-string literal
+                case "B":   // bit-string literal
+                case "X":   // hex-string literal
+                case "U&":  // Unicode escape literal
+                    return true;
+                default:
+                    return false;
+            }
         }
     }
 }

--- a/test/FluentMigrator.Analyzers.Tests/RawSqlTokenInterpolationUnitTests.cs
+++ b/test/FluentMigrator.Analyzers.Tests/RawSqlTokenInterpolationUnitTests.cs
@@ -61,6 +61,52 @@ namespace FluentMigrator.Analyzers.Tests
     }
 ";
 
+        private static string Source(string sql) => @"
+    using ConsoleApplication1;
+
+    namespace ConsoleApplication1
+    {
+        public class TypeName
+        {
+            public void Up()
+            {
+                new FakeExecuteExpressionRoot().Sql(""" + sql + @""");
+            }
+        }
+    }";
+
+        private static async Task VerifyCodeFixAsync(string sql, string fixedSql)
+        {
+            var source = Source(sql);
+            var fixedSource = Source(fixedSql);
+            var sourceLine = "                new FakeExecuteExpressionRoot().Sql(\"" + sql + "\");";
+            var tokenColumn = sourceLine.IndexOf("$(name)") + 1;
+            var expected = Verify.Diagnostic(RawSqlTokenInterpolationAnalyzer.DiagnosticId)
+                .WithSpan(10, tokenColumn, 10, tokenColumn + "$(name)".Length)
+                .WithArguments("$(name)", "$[name]");
+
+            var ut = new VerifyTest
+            {
+                TestState =
+                {
+                    Sources = { source, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+                FixedState =
+                {
+                    Sources = { fixedSource, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+            };
+
+            ut.TestState.ExpectedDiagnostics.Add(expected);
+#if NET
+            ut.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+#endif
+
+            await ut.RunAsync();
+        }
+
         [Test]
         public async Task Doesnt_Warn_On_Quoted_Token()
         {
@@ -264,6 +310,56 @@ namespace FluentMigrator.Analyzers.Tests
 #endif
 
             await ut.RunAsync();
+        }
+
+        /// <summary>
+        /// SQL keywords and identifiers may be adjacent to a string literal. The code fix must
+        /// remove only the literal delimiter, without consuming the preceding SQL text as a prefix.
+        /// </summary>
+        [Test]
+        public async Task Fix_Preserves_Sql_Text_Adjacent_To_A_Literal()
+        {
+            await VerifyCodeFixAsync(
+                "SELECT * FROM Foo WHERE Name LIKE'$(name)'",
+                "SELECT * FROM Foo WHERE Name LIKE$[name]");
+        }
+
+        [TestCase("N")]
+        [TestCase("n")]
+        [TestCase("E")]
+        [TestCase("e")]
+        [TestCase("B")]
+        [TestCase("b")]
+        [TestCase("X")]
+        [TestCase("x")]
+        [TestCase("_utf8mb4")]
+        [TestCase("_custom_charset")]
+        [TestCase("U&")]
+        [TestCase("u&")]
+        public async Task Fix_Removes_Known_Literal_Prefix(string prefix)
+        {
+            await VerifyCodeFixAsync("SELECT " + prefix + "'$(name)'", "SELECT $[name]");
+        }
+
+        [TestCase("1&N", "1&")]
+        [TestCase("1&U&", "1&")]
+        public async Task Fix_Removes_Literal_Prefix_After_NonIdentifier_Boundary(
+            string sqlBeforeQuote,
+            string fixedSqlBeforeToken)
+        {
+            await VerifyCodeFixAsync(
+                "SELECT " + sqlBeforeQuote + "'$(name)'",
+                "SELECT " + fixedSqlBeforeToken + "$[name]");
+        }
+
+        [TestCase("columnN")]
+        [TestCase("columnU&")]
+        [TestCase("column_utf8mb4")]
+        public async Task Fix_Preserves_Identifier_Text_Adjacent_To_A_Literal(string adjacentText)
+        {
+            await VerifyCodeFixAsync(
+                "SELECT " + adjacentText + "'$(name)'",
+                "SELECT " + adjacentText + "$[name]");
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- restrict enclosing-quote expansion to recognized SQL literal prefixes at identifier boundaries
- preserve adjacent SQL keywords, identifiers, and operators
- add regression coverage for case-insensitive prefixes, MySQL charset introducers, and boundary cases

## Testing

- `dotnet test test/FluentMigrator.Analyzers.Tests/FluentMigrator.Analyzers.Tests.csproj --configuration Release` (58 passed, net48)

Fixes #2353
