### PR TITLE
Validate include-untagged option values

### DIFF
--- a/src/FluentMigrator.Console/MigratorConsole.cs
+++ b/src/FluentMigrator.Console/MigratorConsole.cs
@@ -221,11 +221,16 @@ namespace FluentMigrator.Console
                                     if (token.Length == 0)
                                         continue;
 
+                                    var hasSign = token.EndsWith("+", StringComparison.Ordinal)
+                                                  || token.EndsWith("-", StringComparison.Ordinal);
+                                    var name = hasSign ? token.Substring(0, token.Length - 1) : token;
                                     var enable = !token.EndsWith("-", StringComparison.Ordinal);
 
-                                    if (token.StartsWith("ma", StringComparison.OrdinalIgnoreCase))
+                                    if (string.Equals(name, "ma", StringComparison.OrdinalIgnoreCase)
+                                        || string.Equals(name, "maintenance", StringComparison.OrdinalIgnoreCase))
                                         IncludeUntaggedMaintenances = enable;
-                                    else if (token.StartsWith("mi", StringComparison.OrdinalIgnoreCase))
+                                    else if (string.Equals(name, "mi", StringComparison.OrdinalIgnoreCase)
+                                             || string.Equals(name, "migrations", StringComparison.OrdinalIgnoreCase))
                                         IncludeUntaggedMigrations = enable;
                                     else
                                         throw new ArgumentOutOfRangeException(

--- a/test/FluentMigrator.Tests/Unit/Runners/MigratorConsoleTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Runners/MigratorConsoleTests.cs
@@ -140,6 +140,10 @@ namespace FluentMigrator.Tests.Unit.Runners
         [TestCase("mo")]
         [TestCase("foo-")]
         [TestCase("z+")]
+        [TestCase("maintenance-typo")]
+        [TestCase("migrationx+")]
+        [TestCase("ma++")]
+        [TestCase("mi--")]
         [TestCase("mi-,zz")]
         public void IncludeUntaggedRejectsUnknownValue(string value)
         {


### PR DESCRIPTION
Fixes #2379.

## Summary
- Parse the optional `+` or `-` suffix before matching an `--include-untagged` token.
- Accept only the documented names: `ma`, `maintenance`, `mi`, and `migrations`.
- Reject invalid prefixes and repeated suffixes instead of silently changing migration-selection behavior.

## Root Cause
#2376 used prefix matching to restore support for explicit values. Consequently, any token beginning with `ma` or `mi` was accepted as a valid option.

## Validation
```
dotnet test test\FluentMigrator.Tests\FluentMigrator.Tests.csproj --configuration Debug --no-restore --filter "FullyQualifiedName~MigratorConsoleTests" --verbosity minimal
```

Result: 57 passed.