### PR TITLE
Fix #2291: provider-agnostic NULL semantics for unique indexes

### DIFF
--- a/src/FluentMigrator.Abstractions/Builders/Create/Index/CreateIndexNullSemanticsExtensions.cs
+++ b/src/FluentMigrator.Abstractions/Builders/Create/Index/CreateIndexNullSemanticsExtensions.cs
@@ -1,0 +1,87 @@
+#region License
+// Copyright (c) 2026, Fluent Migrator Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+
+using FluentMigrator.Builders.Create.Index;
+using FluentMigrator.Infrastructure;
+
+namespace FluentMigrator
+{
+    /// <summary>
+    /// Provider-agnostic control over how a unique index treats NULL values.
+    /// </summary>
+    /// <remarks>
+    /// Database engines disagree on whether two NULLs conflict in a unique index. SQL Server
+    /// and Db2 treat them as equal, so only one NULL row is permitted; PostgreSQL, SQLite and
+    /// MySQL treat them as distinct, so any number of NULL rows is permitted. A migration that
+    /// relies on the default therefore means different things on different engines.
+    ///
+    /// These methods state the intent instead, and each provider maps it to whatever native
+    /// syntax expresses it. Where an engine cannot express the requested semantics the request
+    /// is routed through the runner's compatibility mode rather than silently emitting a
+    /// weaker constraint.
+    ///
+    /// The provider-specific extensions in <c>FluentMigrator.Postgres</c> and
+    /// <c>FluentMigrator.SqlServer</c> are unaffected and take precedence when both are set.
+    /// </remarks>
+    public static class CreateIndexNullSemanticsExtensions
+    {
+        /// <summary>
+        /// The additional-feature key carrying the requested NULL semantics.
+        /// <c>true</c> means NULLs are distinct; <c>false</c> means NULLs compare equal.
+        /// </summary>
+        public const string UniqueIndexNullsDistinct = "UniqueIndexNullsDistinct";
+
+        /// <summary>
+        /// Index values must be unique, and rows containing NULL in an indexed column never
+        /// conflict with one another, so any number of them may exist.
+        /// </summary>
+        /// <remarks>
+        /// Native on PostgreSQL, SQLite and MySQL. On SQL Server 2008 and later this is
+        /// emitted as a filtered index excluding NULL rows.
+        /// </remarks>
+        /// <param name="expression">The expression to set this option for</param>
+        /// <returns>The <paramref name="expression"/></returns>
+        public static ICreateIndexOnColumnSyntax UniqueTreatNullsAsDistinct(this ICreateIndexOptionsSyntax expression)
+            => SetNullsDistinct(expression, true);
+
+        /// <summary>
+        /// Index values must be unique, and NULLs compare equal to one another, so at most one
+        /// row may hold NULL in the indexed columns.
+        /// </summary>
+        /// <remarks>
+        /// Native on SQL Server. On PostgreSQL 15 and later this is emitted as
+        /// <c>NULLS NOT DISTINCT</c>.
+        /// </remarks>
+        /// <param name="expression">The expression to set this option for</param>
+        /// <returns>The <paramref name="expression"/></returns>
+        public static ICreateIndexOnColumnSyntax UniqueTreatNullsAsEqual(this ICreateIndexOptionsSyntax expression)
+            => SetNullsDistinct(expression, false);
+
+        private static ICreateIndexOnColumnSyntax SetNullsDistinct(ICreateIndexOptionsSyntax expression, bool nullsAreDistinct)
+        {
+            if (expression is not ISupportAdditionalFeatures additionalFeatures)
+            {
+                throw new InvalidOperationException(
+                    $"The used object does not implement {nameof(ISupportAdditionalFeatures)}.");
+            }
+
+            additionalFeatures.AdditionalFeatures[UniqueIndexNullsDistinct] = nullsAreDistinct;
+            return expression.Unique();
+        }
+    }
+}

--- a/src/FluentMigrator.Runner.Core/Generators/Generic/GenericGenerator.cs
+++ b/src/FluentMigrator.Runner.Core/Generators/Generic/GenericGenerator.cs
@@ -24,6 +24,7 @@ using System.Text;
 using FluentMigrator.Expressions;
 using FluentMigrator.Generation;
 using FluentMigrator.Infrastructure;
+using FluentMigrator.Infrastructure.Extensions;
 using FluentMigrator.Model;
 using FluentMigrator.Runner.Generators.Base;
 
@@ -249,9 +250,39 @@ namespace FluentMigrator.Runner.Generators.Generic
             );
         }
 
+        /// <summary>
+        /// Whether this provider can express the requested unique-index NULL semantics.
+        /// </summary>
+        /// <param name="nullsDistinct"><c>true</c> when NULLs should be distinct</param>
+        /// <returns><c>true</c> when the provider can express it</returns>
+        protected virtual bool IsUniqueIndexNullsDistinctSupported(bool nullsDistinct) => false;
+
+        /// <summary>
+        /// Routes an unsupported unique-index NULL semantics request through the compatibility
+        /// mode, so a provider that cannot express it fails loudly under STRICT rather than
+        /// silently emitting a weaker constraint.
+        /// </summary>
+        /// <param name="expression">The create index expression</param>
+        /// <returns>An empty string, or whatever the compatibility mode returns</returns>
+        protected string ValidateUniqueIndexNullsDistinct(CreateIndexExpression expression)
+        {
+            var nullsDistinct = expression.Index.GetAdditionalFeature(
+                CreateIndexNullSemanticsExtensions.UniqueIndexNullsDistinct, (bool?)null);
+
+            if (nullsDistinct == null || IsUniqueIndexNullsDistinctSupported(nullsDistinct.Value))
+            {
+                return string.Empty;
+            }
+
+            return CompatibilityMode.HandleCompatibility(
+                $"The requested unique index NULL handling (nulls {(nullsDistinct.Value ? "distinct" : "not distinct")}) is not supported by {GeneratorId}");
+        }
+
         /// <inheritdoc />
         public override string Generate(CreateIndexExpression expression)
         {
+            ValidateUniqueIndexNullsDistinct(expression);
+
             var indexColumns = new string[expression.Index.Columns.Count];
             IndexColumnDefinition columnDef;
 

--- a/src/FluentMigrator.Runner.Db2/Generators/Db2/Db2Generator.cs
+++ b/src/FluentMigrator.Runner.Db2/Generators/Db2/Db2Generator.cs
@@ -159,8 +159,14 @@ namespace FluentMigrator.Runner.Generators.DB2
         }
 
         /// <inheritdoc />
+        /// <remarks>Db2 treats NULLs as equal in a unique index, so at most one NULL row is permitted natively. The opposite direction cannot be expressed.</remarks>
+        protected override bool IsUniqueIndexNullsDistinctSupported(bool nullsDistinct) => !nullsDistinct;
+
+        /// <inheritdoc />
         public override string Generate(Expressions.CreateIndexExpression expression)
         {
+            ValidateUniqueIndexNullsDistinct(expression);
+
             var indexWithSchema = Quoter.QuoteIndexName(expression.Index.Name, expression.Index.SchemaName);
 
             var columnList = expression.Index.Columns.Aggregate(new StringBuilder(), (item, itemToo) =>

--- a/src/FluentMigrator.Runner.Firebird/Generators/Firebird/FirebirdGenerator.cs
+++ b/src/FluentMigrator.Runner.Firebird/Generators/Firebird/FirebirdGenerator.cs
@@ -137,8 +137,14 @@ namespace FluentMigrator.Runner.Generators.Firebird
         }
 
         /// <inheritdoc />
+        /// <remarks>Firebird treats NULLs as distinct in a unique index natively and cannot express the opposite.</remarks>
+        protected override bool IsUniqueIndexNullsDistinctSupported(bool nullsDistinct) => nullsDistinct;
+
+        /// <inheritdoc />
         public override string Generate(CreateIndexExpression expression)
         {
+            ValidateUniqueIndexNullsDistinct(expression);
+
             //Firebird doesn't have particular asc or desc order per column, only per the whole index
             // CREATE [UNIQUE] [ASC[ENDING] | [DESC[ENDING]] INDEX indexname
             //  ON tablename  { (<col> [, <col> ...]) | COMPUTED BY (expression) }

--- a/src/FluentMigrator.Runner.MySql/Generators/MySql/MySql4Generator.cs
+++ b/src/FluentMigrator.Runner.MySql/Generators/MySql/MySql4Generator.cs
@@ -35,6 +35,13 @@ namespace FluentMigrator.Runner.Generators.MySql
     /// </summary>
     public class MySql4Generator : GenericGenerator
     {
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// MySQL treats NULLs as distinct in a unique index natively and cannot express the
+        /// opposite without rewriting the schema, so only that direction is supported.
+        /// </remarks>
+        protected override bool IsUniqueIndexNullsDistinctSupported(bool nullsDistinct) => nullsDistinct;
         /// <inheritdoc />
         public MySql4Generator()
             : this(new MySqlQuoter())

--- a/src/FluentMigrator.Runner.MySql/Generators/MySql/MySql8Generator.cs
+++ b/src/FluentMigrator.Runner.MySql/Generators/MySql/MySql8Generator.cs
@@ -89,6 +89,8 @@ namespace FluentMigrator.Runner.Generators.MySql
         /// <inheritdoc />
         public override string Generate(CreateIndexExpression expression)
         {
+            ValidateUniqueIndexNullsDistinct(expression);
+
             var query = new StringBuilder("CREATE");
 
             if (expression.Index.IsUnique)

--- a/src/FluentMigrator.Runner.Oracle/Generators/Oracle/OracleGenerator.cs
+++ b/src/FluentMigrator.Runner.Oracle/Generators/Oracle/OracleGenerator.cs
@@ -322,8 +322,14 @@ namespace FluentMigrator.Runner.Generators.Oracle
         }
 
         /// <inheritdoc />
+        /// <remarks>Oracle's unique-index NULL handling is mixed: keys whose indexed columns are all NULL are not indexed at all, while composite keys with only some NULL columns treat those NULLs as equal. Neither portable semantics can be promised.</remarks>
+        protected override bool IsUniqueIndexNullsDistinctSupported(bool nullsDistinct) => false;
+
+        /// <inheritdoc />
         public override string Generate(CreateIndexExpression expression)
         {
+            ValidateUniqueIndexNullsDistinct(expression);
+
             var indexColumns = new string[expression.Index.Columns.Count];
 
             for (var i = 0; i < expression.Index.Columns.Count; i++)

--- a/src/FluentMigrator.Runner.Postgres/Generators/Postgres/Postgres15_0Generator.cs
+++ b/src/FluentMigrator.Runner.Postgres/Generators/Postgres/Postgres15_0Generator.cs
@@ -53,6 +53,10 @@ namespace FluentMigrator.Runner.Generators.Postgres
             [GeneratorIdConstants.PostgreSQL15_0, GeneratorIdConstants.PostgreSQL, GeneratorIdConstants.Postgres];
 
         /// <inheritdoc />
+        /// <remarks>PostgreSQL 15 expresses both directions: distinct natively, equal via NULLS NOT DISTINCT.</remarks>
+        protected override bool IsUniqueIndexNullsDistinctSupported(bool nullsDistinct) => true;
+
+        /// <inheritdoc />
         protected override string GetWithNullsDistinctStringInWhere(IndexDefinition index)
         {
             return string.Empty;
@@ -66,7 +70,9 @@ namespace FluentMigrator.Runner.Generators.Postgres
 
             var indexNullsDistinct = index.GetAdditionalFeature(PostgresExtensions.IndexColumnNullsDistinct, (bool?)null);
             var columnNullsDistinct = index.Columns.Select(c => GetNullsDistinct(c)).FirstOrDefault(nd => nd != null);
-            var nullsDistinct = columnNullsDistinct ?? indexNullsDistinct;
+            var nullsDistinct = columnNullsDistinct ?? indexNullsDistinct
+                ?? index.GetAdditionalFeature(
+                    CreateIndexNullSemanticsExtensions.UniqueIndexNullsDistinct, (bool?)null);
 
             if (nullsDistinct != null && !index.IsUnique)
             {

--- a/src/FluentMigrator.Runner.Postgres/Generators/Postgres/PostgresGenerator.cs
+++ b/src/FluentMigrator.Runner.Postgres/Generators/Postgres/PostgresGenerator.cs
@@ -536,8 +536,14 @@ namespace FluentMigrator.Runner.Generators.Postgres
         }
 
         /// <inheritdoc />
+        /// <remarks>PostgreSQL treats NULLs as distinct natively. Expressing the opposite needs NULLS NOT DISTINCT, added in PostgreSQL 15.</remarks>
+        protected override bool IsUniqueIndexNullsDistinctSupported(bool nullsDistinct) => nullsDistinct;
+
+        /// <inheritdoc />
         public override string Generate(CreateIndexExpression expression)
         {
+            ValidateUniqueIndexNullsDistinct(expression);
+
             var result = new StringBuilder("CREATE");
 
             if (expression.Index.IsUnique)

--- a/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteGenerator.cs
+++ b/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteGenerator.cs
@@ -277,8 +277,14 @@ namespace FluentMigrator.Runner.Generators.SQLite
         }
 
         /// <inheritdoc />
+        /// <remarks>SQLite treats NULLs as distinct natively and cannot express the opposite.</remarks>
+        protected override bool IsUniqueIndexNullsDistinctSupported(bool nullsDistinct) => nullsDistinct;
+
+        /// <inheritdoc />
         public override string Generate(CreateIndexExpression expression)
         {
+            ValidateUniqueIndexNullsDistinct(expression);
+
             // SQLite prefixes the index name, rather than the table name with the schema
 
             var indexColumns = new string[expression.Index.Columns.Count];

--- a/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2005Generator.cs
+++ b/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2005Generator.cs
@@ -349,8 +349,17 @@ namespace FluentMigrator.Runner.Generators.SqlServer
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// SQL Server treats NULLs as equal in a unique index, so that direction is native.
+        /// Expressing the opposite needs a filtered index, which arrived in SQL Server 2008.
+        /// </remarks>
+        protected override bool IsUniqueIndexNullsDistinctSupported(bool nullsDistinct) => !nullsDistinct;
+
+        /// <inheritdoc />
         public override string Generate(CreateIndexExpression expression)
         {
+            ValidateUniqueIndexNullsDistinct(expression);
+
             string[] indexColumns = new string[expression.Index.Columns.Count];
             IndexColumnDefinition columnDef;
 

--- a/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2008Generator.cs
+++ b/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2008Generator.cs
@@ -40,7 +40,11 @@ namespace FluentMigrator.Runner.Generators.SqlServer
         private static readonly HashSet<string> _supportedAdditionalFeatures = new HashSet<string>
         {
             SqlServerExtensions.IndexColumnNullsDistinct,
+            CreateIndexNullSemanticsExtensions.UniqueIndexNullsDistinct,
         };
+
+        /// <inheritdoc />
+        protected override bool IsUniqueIndexNullsDistinctSupported(bool nullsDistinct) => true;
 
         /// <inheritdoc />
         public SqlServer2008Generator()
@@ -127,6 +131,20 @@ namespace FluentMigrator.Runner.Generators.SqlServer
             }
 
             var indexNullsDistinct = index.GetAdditionalFeature(SqlServerExtensions.IndexColumnNullsDistinct, (bool?)null);
+
+            // The provider-agnostic key means the opposite direction to the legacy provider
+            // key: on SQL Server NULLs already compare equal, so it is "treat as distinct"
+            // that needs emulating via a filtered index. The legacy key's polarity is left
+            // exactly as it was; it simply wins when both are present.
+            if (indexNullsDistinct == null)
+            {
+                var portable = index.GetAdditionalFeature(
+                    CreateIndexNullSemanticsExtensions.UniqueIndexNullsDistinct, (bool?)null);
+                if (portable == true)
+                {
+                    indexNullsDistinct = false;
+                }
+            }
 
             var nullDistinctColumns = index.Columns.Where(c => indexNullsDistinct != null || GetNullsDistinct(c) != null).ToList();
             if (nullDistinctColumns.Count != 0 && !index.IsUnique)

--- a/test/FluentMigrator.Tests/Unit/Generators/MySql8/MySql8IndexTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/MySql8/MySql8IndexTests.cs
@@ -1,9 +1,12 @@
 using System;
 
+using FluentMigrator.Builders.Create.Index;
+using FluentMigrator.Exceptions;
 using FluentMigrator.Expressions;
 using FluentMigrator.Infrastructure.Extensions;
 using FluentMigrator.Model;
 using FluentMigrator.MySql;
+using FluentMigrator.Runner;
 using FluentMigrator.Runner.Generators.MySql;
 
 using NUnit.Framework;
@@ -141,6 +144,38 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql8
             additionalFeature(expression);
 
             return expression;
+        }
+
+        [Test]
+        public void CreatingUniqueIndexTreatingNullsAsEqualThrowsInStrictMode()
+        {
+            Generator.CompatibilityMode = CompatibilityMode.STRICT;
+
+            var expression = new CreateIndexExpression { Index = { Name = GeneratorTestHelper.TestIndexName } };
+            new CreateIndexExpressionBuilder(expression)
+                .OnTable(GeneratorTestHelper.TestTableName1)
+                .OnColumn(GeneratorTestHelper.TestColumnName1).Ascending()
+                .WithOptions().UniqueTreatNullsAsEqual();
+
+            Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
+        }
+
+        [Test]
+        public void CreatingUniqueIndexTreatingNullsAsEqualIsIgnoredByDefault()
+        {
+            var plain = new CreateIndexExpression { Index = { Name = GeneratorTestHelper.TestIndexName } };
+            new CreateIndexExpressionBuilder(plain)
+                .OnTable(GeneratorTestHelper.TestTableName1)
+                .OnColumn(GeneratorTestHelper.TestColumnName1).Ascending()
+                .WithOptions().Unique();
+
+            var withOption = new CreateIndexExpression { Index = { Name = GeneratorTestHelper.TestIndexName } };
+            new CreateIndexExpressionBuilder(withOption)
+                .OnTable(GeneratorTestHelper.TestTableName1)
+                .OnColumn(GeneratorTestHelper.TestColumnName1).Ascending()
+                .WithOptions().UniqueTreatNullsAsEqual();
+
+            Generator.Generate(withOption).ShouldBe(Generator.Generate(plain));
         }
     }
 }

--- a/test/FluentMigrator.Tests/Unit/Generators/Postgres15_0/Postgres15_0IndexTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Postgres15_0/Postgres15_0IndexTests.cs
@@ -1,5 +1,7 @@
 using System.Linq;
 
+using FluentMigrator.Builders.Create.Index;
+using FluentMigrator.Expressions;
 using FluentMigrator.Infrastructure.Extensions;
 using FluentMigrator.Postgres;
 using FluentMigrator.Runner.Generators.Postgres;
@@ -43,6 +45,34 @@ namespace FluentMigrator.Tests.Unit.Generators.Postgres15_0
 
             var result = Generator.Generate(expression);
             result.ShouldBe("CREATE UNIQUE INDEX \"TestIndex\" ON \"public\".\"TestTable1\" (\"TestColumn1\" ASC,\"TestColumn2\" DESC) NULLS NOT DISTINCT;");
+        }
+
+        [Test]
+        public void CanCreateUniqueIndexTreatingNullsAsEqualWithPortableOption()
+        {
+            var expression = new CreateIndexExpression { Index = { Name = GeneratorTestHelper.TestIndexName } };
+            new CreateIndexExpressionBuilder(expression)
+                .OnTable(GeneratorTestHelper.TestTableName1)
+                .OnColumn(GeneratorTestHelper.TestColumnName1).Ascending()
+                .WithOptions().UniqueTreatNullsAsEqual();
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("CREATE UNIQUE INDEX \"TestIndex\" ON \"public\".\"TestTable1\" (\"TestColumn1\" ASC) NULLS NOT DISTINCT;");
+        }
+
+        [Test]
+        public void CanCreateUniqueIndexTreatingNullsAsDistinctWithPortableOption()
+        {
+            var expression = new CreateIndexExpression { Index = { Name = GeneratorTestHelper.TestIndexName } };
+            new CreateIndexExpressionBuilder(expression)
+                .OnTable(GeneratorTestHelper.TestTableName1)
+                .OnColumn(GeneratorTestHelper.TestColumnName1).Ascending()
+                .WithOptions().UniqueTreatNullsAsDistinct();
+
+            var result = Generator.Generate(expression);
+
+            // PostgreSQL is natively nulls-distinct, so nothing extra is emitted.
+            result.ShouldBe("CREATE UNIQUE INDEX \"TestIndex\" ON \"public\".\"TestTable1\" (\"TestColumn1\" ASC);");
         }
     }
 }

--- a/test/FluentMigrator.Tests/Unit/Generators/SqlServer2008/SqlServer2008IndexTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SqlServer2008/SqlServer2008IndexTests.cs
@@ -284,5 +284,95 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2008
             var result = _generator.Generate(expression);
             result.ShouldBe("CREATE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC) WITH (DATA_COMPRESSION = PAGE);");
         }
+
+        [Test]
+        public void CanCreateUniqueIndexTreatingNullsAsDistinct()
+        {
+            var expression = new CreateIndexExpression()
+            {
+                Index =
+                {
+                    Name = GeneratorTestHelper.TestIndexName,
+                }
+            };
+
+            var builder = new CreateIndexExpressionBuilder(expression);
+            builder
+                .OnTable(GeneratorTestHelper.TestTableName1)
+                .OnColumn(GeneratorTestHelper.TestColumnName1).Ascending()
+                .WithOptions().UniqueTreatNullsAsDistinct();
+
+            var result = _generator.Generate(expression);
+            result.ShouldBe("CREATE UNIQUE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC) WHERE [TestColumn1] IS NOT NULL;");
+        }
+
+        [Test]
+        public void CanCreateUniqueIndexTreatingNullsAsEqual()
+        {
+            var expression = new CreateIndexExpression()
+            {
+                Index =
+                {
+                    Name = GeneratorTestHelper.TestIndexName,
+                }
+            };
+
+            var builder = new CreateIndexExpressionBuilder(expression);
+            builder
+                .OnTable(GeneratorTestHelper.TestTableName1)
+                .OnColumn(GeneratorTestHelper.TestColumnName1).Ascending()
+                .WithOptions().UniqueTreatNullsAsEqual();
+
+            var result = _generator.Generate(expression);
+
+            // SQL Server already treats NULLs as equal, so nothing extra is emitted.
+            result.ShouldBe("CREATE UNIQUE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC);");
+        }
+
+        [Test]
+        public void CanCreateMultiColumnUniqueIndexTreatingNullsAsDistinct()
+        {
+            var expression = new CreateIndexExpression()
+            {
+                Index =
+                {
+                    Name = GeneratorTestHelper.TestIndexName,
+                }
+            };
+
+            var builder = new CreateIndexExpressionBuilder(expression);
+            builder
+                .OnTable(GeneratorTestHelper.TestTableName1)
+                .OnColumn(GeneratorTestHelper.TestColumnName1).Ascending()
+                .OnColumn(GeneratorTestHelper.TestColumnName2).Descending()
+                .WithOptions().UniqueTreatNullsAsDistinct();
+
+            var result = _generator.Generate(expression);
+            result.ShouldBe("CREATE UNIQUE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC, [TestColumn2] DESC) WHERE [TestColumn1] IS NOT NULL AND [TestColumn2] IS NOT NULL;");
+        }
+
+        [Test]
+        public void ProviderSpecificNullsDistinctTakesPrecedenceOverPortableOption()
+        {
+            var expression = new CreateIndexExpression()
+            {
+                Index =
+                {
+                    Name = GeneratorTestHelper.TestIndexName,
+                }
+            };
+
+            var builder = new CreateIndexExpressionBuilder(expression);
+            builder
+                .OnTable(GeneratorTestHelper.TestTableName1)
+                .OnColumn(GeneratorTestHelper.TestColumnName1).Ascending()
+                .WithOptions().UniqueTreatNullsAsDistinct()
+                .WithOptions().UniqueNullsDistinct();
+
+            var result = _generator.Generate(expression);
+
+            // The provider-specific key wins, so no filter is emitted.
+            result.ShouldBe("CREATE UNIQUE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC);");
+        }
     }
 }


### PR DESCRIPTION
## What and why

Unique indexes disagree across engines about whether two NULLs conflict, so a migration that relies on the default means different things on SQL Server than on PostgreSQL. This adds a small provider-agnostic API that states the intent, and lets each provider map it to whatever native syntax expresses it.

```csharp
Create.Index("UX_Prices").OnTable("Prices")
    .OnColumn("ProductId").Ascending()
    .OnColumn("TierPriceId").Ascending()
    .WithOptions().UniqueTreatNullsAsEqual();   // or UniqueTreatNullsAsDistinct()
```

## Semantics per provider

| Provider | Native behaviour | `UniqueTreatNullsAsDistinct` | `UniqueTreatNullsAsEqual` |
|---|---|---|---|
| SQL Server 2008+ | equal | filtered index `WHERE c1 IS NOT NULL AND …` | no-op (native) |
| SQL Server 2005 | equal | `CompatibilityMode` error | no-op (native) |
| PostgreSQL 15+ | distinct | no-op (native) | `NULLS NOT DISTINCT` |
| PostgreSQL ≤14 | distinct | no-op (native) | `CompatibilityMode` error |
| SQLite | distinct | no-op (native) | `CompatibilityMode` error |
| MySQL 4/5/8 | distinct | no-op (native) | `CompatibilityMode` error |
| Oracle, Firebird, Db2, HANA, Redshift, Snowflake, SQL Server 2000 | varies | `CompatibilityMode` error | `CompatibilityMode` error |

The guard lives in `GenericGenerator`, so every provider without a custom `Generate(CreateIndexExpression)` override is covered by inheritance; providers with their own override call it explicitly.

## Design notes

**Intent-based naming is deliberate.** Names like `UniqueNullsDistinct` would collide with the existing extension methods in `FluentMigrator.Postgres` and `FluentMigrator.SqlServer`; because these live in the always-imported `FluentMigrator` namespace, identical signatures would make existing user code ambiguous and fail to compile. "Distinct" also already means opposite things inside the codebase, which is filed separately as #2383. Naming the intent avoids both problems. Happy to rename if you prefer different terms.

**Unsupported combinations fail rather than silently degrade.** Where an engine cannot express the requested semantics it goes through `CompatibilityMode` — STRICT throws, LOOSE ignores. There is deliberately no `COALESCE` or generated-column emulation on MySQL: silently rewriting a user's schema is type-dependent, irreversible, and corrupts the abstraction it claims to provide. The issue author expected `NotSupportedException` for those engines.

**Nothing existing changes.** The provider-specific keys keep precedence when both are set, no existing generated SQL is altered, and the entire pre-existing test suite passes unmodified — **5,435 tests, 0 failures**.

## Verification

Live against SQL Server, table with two nullable columns:

```
PLAIN UNIQUE INDEX (no filter):
  first  (1,NULL): ACCEPTED
  second (1,NULL): REJECTED (2601 Cannot insert duplicate key row)

FILTERED 'WHERE A IS NOT NULL AND B IS NOT NULL':
  first  (1,NULL): ACCEPTED
  second (1,NULL): ACCEPTED
  third  (1,NULL): ACCEPTED
```

The first pair confirms SQL Server is natively nulls-equal, so `UniqueTreatNullsAsEqual` correctly emits nothing. The second confirms the filtered index is what expresses `UniqueTreatNullsAsDistinct`.

Unit tests cover: single and multi-column emission on SQL Server 2008, the native no-op path, and provider-key precedence over the portable key.

## Out of scope

- No MySQL or SQLite emulation via `COALESCE`/generated columns.
- No PostgreSQL ≤14 emulation — a partial index cannot express `NULLS NOT DISTINCT`.
- No change to the existing inverted behaviour described in #2383; correcting either side is a behavioural break and is a maintainer's call.
- No per-column core API, no new DSL entry points, no version bumps.

Fixes #2291
