### PR TITLE
Fix #2353: only strip known literal prefixes in the FM0002 code fix

### DIFF
--- a/src/FluentMigrator.Analyzers/Analysis/SqlLiteralScanner.cs
+++ b/src/FluentMigrator.Analyzers/Analysis/SqlLiteralScanner.cs
@@ -271,12 +271,23 @@ namespace FluentMigrator.Analyzers.Analysis
         {
             var start = quoteIndex;
 
-            // U&'...' - the ampersand is part of the prefix.
+            // U&'...' - the ampersand is part of the prefix. The character before the "U" must not
+            // be an identifier character: in FOO_U&'x' the "U" is the tail of the identifier FOO_U
+            // and the ampersand an operator, not a Unicode-escape prefix.
             if (quoteIndex >= 2 && sql[quoteIndex - 1] == '&' && (sql[quoteIndex - 2] == 'U' || sql[quoteIndex - 2] == 'u'))
             {
-                return quoteIndex - 2;
+                var beforePrefix = quoteIndex - 3;
+                if (beforePrefix < 0 || !(char.IsLetterOrDigit(sql[beforePrefix]) || sql[beforePrefix] == '_'))
+                {
+                    return quoteIndex - 2;
+                }
+
+                return start;
             }
 
+            // Walking back over the whole adjacent identifier run is what gives the boundary rule
+            // for the other prefixes: ColumnN'x' yields the candidate "ColumnN", which is not a
+            // known prefix, so the literal is reported without one.
             var i = quoteIndex - 1;
             while (i >= 0 && (char.IsLetterOrDigit(sql[i]) || sql[i] == '_'))
             {
@@ -289,18 +300,11 @@ namespace FluentMigrator.Analyzers.Analysis
                 return start;
             }
 
-            // Only treat the run as a prefix when it is not preceded by something that would make it
-            // an identifier, e.g. `col='x'` has no prefix but `WHERE N'x'` does.
-            if (i >= 0 && (char.IsLetterOrDigit(sql[i]) || sql[i] == '_'))
-            {
-                return start;
-            }
-
             var candidate = sql.Substring(i + 1, candidateLength);
             return IsKnownLiteralPrefix(candidate) ? i + 1 : start;
         }
 
-        private static bool IsKnownLiteralPrefix(string candidate)
+        internal static bool IsKnownLiteralPrefix(string candidate)
         {
             if (candidate.Length == 0)
             {

--- a/src/FluentMigrator.Analyzers/RawSqlTokenInterpolationCodeFixProvider.cs
+++ b/src/FluentMigrator.Analyzers/RawSqlTokenInterpolationCodeFixProvider.cs
@@ -20,6 +20,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using FluentMigrator.Analyzers.Analysis;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -99,8 +101,8 @@ namespace FluentMigrator.Analyzers
         }
 
         /// <summary>
-        /// Grows a token span to cover the SQL string literal that encloses it, including any
-        /// literal prefix such as <c>N</c>, <c>E</c> or <c>_utf8mb4</c>.
+        /// Grows a token span to cover the SQL string literal that encloses it, including a
+        /// recognised literal prefix such as <c>N</c>, <c>E</c>, <c>U&amp;</c> or <c>_utf8mb4</c>.
         /// </summary>
         /// <remarks>
         /// <para>
@@ -112,9 +114,17 @@ namespace FluentMigrator.Analyzers
         /// </para>
         /// <para>
         /// The analyzer has already established that the token is the entire content of the literal,
-        /// so this only has to find the delimiters on either side. If the surrounding text is not
-        /// what was expected the original span is returned unchanged, leaving the previous - still
-        /// conservative - behaviour.
+        /// so this only has to find the delimiters on either side. The analyzer works on the string
+        /// value while this walk works on the C# source, so a quote or prefix spelled with an escape
+        /// sequence (<c>\'</c>, <c>\u004E</c>) is not matched here; in that case the original span
+        /// is returned unchanged and only the token itself is rewritten, as before this method
+        /// existed.
+        /// </para>
+        /// <para>
+        /// Only a run that <see cref="SqlLiteralScanner.IsKnownLiteralPrefix"/> recognises is
+        /// absorbed. Any other adjacent identifier belongs to the surrounding SQL rather than to
+        /// the literal, so it is left in place and only the quotes are removed - otherwise
+        /// <c>LIKE'$(name)'</c> would lose its <c>LIKE</c>.
         /// </para>
         /// </remarks>
         private static TextSpan ExpandOverEnclosingQuotes(SourceText text, TextSpan tokenSpan)
@@ -131,14 +141,45 @@ namespace FluentMigrator.Analyzers
                 return tokenSpan;
             }
 
-            // Walk back over a literal prefix: N'...', E'...', U&'...', _utf8mb4'...'.
+            var spanWithoutPrefix = TextSpan.FromBounds(start, end + 1);
+
+            // U&'...' is handled separately because '&' is not part of an identifier, so the
+            // general walk below would stop at it. The character before the "U" must not be an
+            // identifier character either: in FOO_U&'x' the "U" is the tail of the identifier
+            // FOO_U and the ampersand an operator, not a Unicode-escape prefix. This mirrors
+            // SqlLiteralScanner.ReadLiteralPrefixStart, which applies the same rule to the string
+            // value; it cannot be shared directly because this walk reads the C# source.
+            if (start >= 2 && text[start - 1] == '&' && (text[start - 2] == 'U' || text[start - 2] == 'u'))
+            {
+                var beforePrefix = start - 3;
+                if (beforePrefix < 0 || !(char.IsLetterOrDigit(text[beforePrefix]) || text[beforePrefix] == '_'))
+                {
+                    return TextSpan.FromBounds(start - 2, end + 1);
+                }
+
+                return spanWithoutPrefix;
+            }
+
+            // Walk back over the whole adjacent identifier run, then absorb it only when the
+            // scanner recognises it as a literal prefix. Consuming the entire run is what gives
+            // the identifier-boundary rule for free: ColumnN'...' yields the candidate "ColumnN",
+            // which is not a known prefix, so the column name survives.
             var prefixStart = start;
-            while (prefixStart > 0 && (char.IsLetterOrDigit(text[prefixStart - 1]) || text[prefixStart - 1] == '_' || text[prefixStart - 1] == '&'))
+            while (prefixStart > 0 && (char.IsLetterOrDigit(text[prefixStart - 1]) || text[prefixStart - 1] == '_'))
             {
                 prefixStart--;
             }
 
-            return TextSpan.FromBounds(prefixStart, end + 1);
+            if (prefixStart == start)
+            {
+                return spanWithoutPrefix;
+            }
+
+            var candidate = text.ToString(TextSpan.FromBounds(prefixStart, start));
+
+            return SqlLiteralScanner.IsKnownLiteralPrefix(candidate)
+                ? TextSpan.FromBounds(prefixStart, end + 1)
+                : spanWithoutPrefix;
         }
     }
 }

--- a/test/FluentMigrator.Analyzers.Tests/RawSqlTokenInterpolationUnitTests.cs
+++ b/test/FluentMigrator.Analyzers.Tests/RawSqlTokenInterpolationUnitTests.cs
@@ -396,5 +396,632 @@ namespace FluentMigrator.Analyzers.Tests
 
             await ut.RunAsync();
         }
+
+        /// <summary>
+        /// An adjacent identifier that is not a literal prefix belongs to the surrounding SQL, so only
+        /// the quotes are removed and the keyword survives.
+        /// </summary>
+        [Test]
+        public async Task Fix_Keeps_Adjacent_Keyword_When_It_Touches_The_Literal()
+        {
+            //language=csharp
+            const string source = @"
+using ConsoleApplication1;
+
+namespace ConsoleApplication1
+{
+    public class TypeName
+    {
+        public void Up()
+        {
+            new FakeExecuteExpressionRoot().Sql(""SELECT * FROM Foo WHERE Name LIKE'$(name)'"");
+        }
+    }
+}";
+
+            //language=csharp
+            const string fixedSource = @"
+using ConsoleApplication1;
+
+namespace ConsoleApplication1
+{
+    public class TypeName
+    {
+        public void Up()
+        {
+            new FakeExecuteExpressionRoot().Sql(""SELECT * FROM Foo WHERE Name LIKE$[name]"");
+        }
+    }
+}";
+
+            var expected = Verify.Diagnostic(RawSqlTokenInterpolationAnalyzer.DiagnosticId)
+                .WithSpan(10, 84, 10, 91)
+                .WithArguments("$(name)", "$[name]");
+
+            var ut = new VerifyTest
+            {
+                TestState =
+                {
+                    Sources = { source, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+                FixedState =
+                {
+                    Sources = { fixedSource, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+            };
+
+            ut.TestState.ExpectedDiagnostics.Add(expected);
+#if NET
+            ut.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+#endif
+
+            await ut.RunAsync();
+        }
+
+        /// <summary>
+        /// A recognised prefix is part of the literal and goes with the quotes.
+        /// </summary>
+        [Test]
+        public async Task Fix_Strips_National_Character_Prefix()
+        {
+            //language=csharp
+            const string source = @"
+using ConsoleApplication1;
+
+namespace ConsoleApplication1
+{
+    public class TypeName
+    {
+        public void Up()
+        {
+            new FakeExecuteExpressionRoot().Sql(""UPDATE Foo SET Name = N'$(name)'"");
+        }
+    }
+}";
+
+            //language=csharp
+            const string fixedSource = @"
+using ConsoleApplication1;
+
+namespace ConsoleApplication1
+{
+    public class TypeName
+    {
+        public void Up()
+        {
+            new FakeExecuteExpressionRoot().Sql(""UPDATE Foo SET Name = $[name]"");
+        }
+    }
+}";
+
+            var expected = Verify.Diagnostic(RawSqlTokenInterpolationAnalyzer.DiagnosticId)
+                .WithSpan(10, 74, 10, 81)
+                .WithArguments("$(name)", "$[name]");
+
+            var ut = new VerifyTest
+            {
+                TestState =
+                {
+                    Sources = { source, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+                FixedState =
+                {
+                    Sources = { fixedSource, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+            };
+
+            ut.TestState.ExpectedDiagnostics.Add(expected);
+#if NET
+            ut.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+#endif
+
+            await ut.RunAsync();
+        }
+
+        /// <summary>
+        /// Prefix recognition is case-insensitive.
+        /// </summary>
+        [Test]
+        public async Task Fix_Strips_Lowercase_National_Character_Prefix()
+        {
+            //language=csharp
+            const string source = @"
+using ConsoleApplication1;
+
+namespace ConsoleApplication1
+{
+    public class TypeName
+    {
+        public void Up()
+        {
+            new FakeExecuteExpressionRoot().Sql(""UPDATE Foo SET Name = n'$(name)'"");
+        }
+    }
+}";
+
+            //language=csharp
+            const string fixedSource = @"
+using ConsoleApplication1;
+
+namespace ConsoleApplication1
+{
+    public class TypeName
+    {
+        public void Up()
+        {
+            new FakeExecuteExpressionRoot().Sql(""UPDATE Foo SET Name = $[name]"");
+        }
+    }
+}";
+
+            var expected = Verify.Diagnostic(RawSqlTokenInterpolationAnalyzer.DiagnosticId)
+                .WithSpan(10, 74, 10, 81)
+                .WithArguments("$(name)", "$[name]");
+
+            var ut = new VerifyTest
+            {
+                TestState =
+                {
+                    Sources = { source, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+                FixedState =
+                {
+                    Sources = { fixedSource, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+            };
+
+            ut.TestState.ExpectedDiagnostics.Add(expected);
+#if NET
+            ut.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+#endif
+
+            await ut.RunAsync();
+        }
+
+        /// <summary>
+        /// MySQL charset introducers are literal prefixes.
+        /// </summary>
+        [Test]
+        public async Task Fix_Strips_Charset_Introducer_Prefix()
+        {
+            //language=csharp
+            const string source = @"
+using ConsoleApplication1;
+
+namespace ConsoleApplication1
+{
+    public class TypeName
+    {
+        public void Up()
+        {
+            new FakeExecuteExpressionRoot().Sql(""UPDATE Foo SET Name = _utf8mb4'$(name)'"");
+        }
+    }
+}";
+
+            //language=csharp
+            const string fixedSource = @"
+using ConsoleApplication1;
+
+namespace ConsoleApplication1
+{
+    public class TypeName
+    {
+        public void Up()
+        {
+            new FakeExecuteExpressionRoot().Sql(""UPDATE Foo SET Name = $[name]"");
+        }
+    }
+}";
+
+            var expected = Verify.Diagnostic(RawSqlTokenInterpolationAnalyzer.DiagnosticId)
+                .WithSpan(10, 81, 10, 88)
+                .WithArguments("$(name)", "$[name]");
+
+            var ut = new VerifyTest
+            {
+                TestState =
+                {
+                    Sources = { source, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+                FixedState =
+                {
+                    Sources = { fixedSource, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+            };
+
+            ut.TestState.ExpectedDiagnostics.Add(expected);
+#if NET
+            ut.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+#endif
+
+            await ut.RunAsync();
+        }
+
+        /// <summary>
+        /// The Unicode-escape prefix ends in an ampersand, which is not an identifier character, so it
+        /// is matched separately.
+        /// </summary>
+        [Test]
+        public async Task Fix_Strips_Unicode_Escape_Prefix()
+        {
+            //language=csharp
+            const string source = @"
+using ConsoleApplication1;
+
+namespace ConsoleApplication1
+{
+    public class TypeName
+    {
+        public void Up()
+        {
+            new FakeExecuteExpressionRoot().Sql(""UPDATE Foo SET Name = U&'$(name)'"");
+        }
+    }
+}";
+
+            //language=csharp
+            const string fixedSource = @"
+using ConsoleApplication1;
+
+namespace ConsoleApplication1
+{
+    public class TypeName
+    {
+        public void Up()
+        {
+            new FakeExecuteExpressionRoot().Sql(""UPDATE Foo SET Name = $[name]"");
+        }
+    }
+}";
+
+            var expected = Verify.Diagnostic(RawSqlTokenInterpolationAnalyzer.DiagnosticId)
+                .WithSpan(10, 75, 10, 82)
+                .WithArguments("$(name)", "$[name]");
+
+            var ut = new VerifyTest
+            {
+                TestState =
+                {
+                    Sources = { source, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+                FixedState =
+                {
+                    Sources = { fixedSource, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+            };
+
+            ut.TestState.ExpectedDiagnostics.Add(expected);
+#if NET
+            ut.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+#endif
+
+            await ut.RunAsync();
+        }
+
+        /// <summary>
+        /// An ampersand after an identifier is an operator, not the tail of a Unicode-escape prefix,
+        /// so the identifier and the ampersand stay in place.
+        /// </summary>
+        [Test]
+        public async Task Fix_Keeps_Identifier_Followed_By_Ampersand()
+        {
+            //language=csharp
+            const string source = @"
+using ConsoleApplication1;
+
+namespace ConsoleApplication1
+{
+    public class TypeName
+    {
+        public void Up()
+        {
+            new FakeExecuteExpressionRoot().Sql(""UPDATE Foo SET Name = FOO_U&'$(name)'"");
+        }
+    }
+}";
+
+            //language=csharp
+            const string fixedSource = @"
+using ConsoleApplication1;
+
+namespace ConsoleApplication1
+{
+    public class TypeName
+    {
+        public void Up()
+        {
+            new FakeExecuteExpressionRoot().Sql(""UPDATE Foo SET Name = FOO_U&$[name]"");
+        }
+    }
+}";
+
+            var expected = Verify.Diagnostic(RawSqlTokenInterpolationAnalyzer.DiagnosticId)
+                .WithSpan(10, 79, 10, 86)
+                .WithArguments("$(name)", "$[name]");
+
+            var ut = new VerifyTest
+            {
+                TestState =
+                {
+                    Sources = { source, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+                FixedState =
+                {
+                    Sources = { fixedSource, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+            };
+
+            ut.TestState.ExpectedDiagnostics.Add(expected);
+#if NET
+            ut.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+#endif
+
+            await ut.RunAsync();
+        }
+
+        /// <summary>
+        /// The whole adjacent run is tested, so an identifier merely ending in a prefix letter is not
+        /// mistaken for one.
+        /// </summary>
+        [Test]
+        public async Task Fix_Keeps_Identifier_That_Ends_In_A_Prefix_Letter()
+        {
+            //language=csharp
+            const string source = @"
+using ConsoleApplication1;
+
+namespace ConsoleApplication1
+{
+    public class TypeName
+    {
+        public void Up()
+        {
+            new FakeExecuteExpressionRoot().Sql(""UPDATE Foo SET Name = ColumnN'$(name)'"");
+        }
+    }
+}";
+
+            //language=csharp
+            const string fixedSource = @"
+using ConsoleApplication1;
+
+namespace ConsoleApplication1
+{
+    public class TypeName
+    {
+        public void Up()
+        {
+            new FakeExecuteExpressionRoot().Sql(""UPDATE Foo SET Name = ColumnN$[name]"");
+        }
+    }
+}";
+
+            var expected = Verify.Diagnostic(RawSqlTokenInterpolationAnalyzer.DiagnosticId)
+                .WithSpan(10, 80, 10, 87)
+                .WithArguments("$(name)", "$[name]");
+
+            var ut = new VerifyTest
+            {
+                TestState =
+                {
+                    Sources = { source, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+                FixedState =
+                {
+                    Sources = { fixedSource, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+            };
+
+            ut.TestState.ExpectedDiagnostics.Add(expected);
+#if NET
+            ut.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+#endif
+
+            await ut.RunAsync();
+        }
+
+        /// <summary>
+        /// The PostgreSQL escape-string prefix changes how backslashes in the value are read, so it
+        /// must go with the quotes: E$[name] would re-escape the expanded value.
+        /// </summary>
+        [Test]
+        public async Task Fix_Strips_Escape_String_Prefix()
+        {
+            //language=csharp
+            const string source = @"
+using ConsoleApplication1;
+
+namespace ConsoleApplication1
+{
+    public class TypeName
+    {
+        public void Up()
+        {
+            new FakeExecuteExpressionRoot().Sql(""UPDATE Foo SET Name = E'$(name)'"");
+        }
+    }
+}";
+
+            //language=csharp
+            const string fixedSource = @"
+using ConsoleApplication1;
+
+namespace ConsoleApplication1
+{
+    public class TypeName
+    {
+        public void Up()
+        {
+            new FakeExecuteExpressionRoot().Sql(""UPDATE Foo SET Name = $[name]"");
+        }
+    }
+}";
+
+            var expected = Verify.Diagnostic(RawSqlTokenInterpolationAnalyzer.DiagnosticId)
+                .WithSpan(10, 74, 10, 81)
+                .WithArguments("$(name)", "$[name]");
+
+            var ut = new VerifyTest
+            {
+                TestState =
+                {
+                    Sources = { source, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+                FixedState =
+                {
+                    Sources = { fixedSource, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+            };
+
+            ut.TestState.ExpectedDiagnostics.Add(expected);
+#if NET
+            ut.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+#endif
+
+            await ut.RunAsync();
+        }
+
+        /// <summary>
+        /// A Unicode-escape literal at the very start of the SQL text has nothing before its prefix,
+        /// which exercises the boundary check's start-of-input branch.
+        /// </summary>
+        [Test]
+        public async Task Fix_Strips_Unicode_Escape_Prefix_At_Start_Of_Sql()
+        {
+            //language=csharp
+            const string source = @"
+using ConsoleApplication1;
+
+namespace ConsoleApplication1
+{
+    public class TypeName
+    {
+        public void Up()
+        {
+            new FakeExecuteExpressionRoot().Sql(""U&'$(name)'"");
+        }
+    }
+}";
+
+            //language=csharp
+            const string fixedSource = @"
+using ConsoleApplication1;
+
+namespace ConsoleApplication1
+{
+    public class TypeName
+    {
+        public void Up()
+        {
+            new FakeExecuteExpressionRoot().Sql(""$[name]"");
+        }
+    }
+}";
+
+            var expected = Verify.Diagnostic(RawSqlTokenInterpolationAnalyzer.DiagnosticId)
+                .WithSpan(10, 53, 10, 60)
+                .WithArguments("$(name)", "$[name]");
+
+            var ut = new VerifyTest
+            {
+                TestState =
+                {
+                    Sources = { source, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+                FixedState =
+                {
+                    Sources = { fixedSource, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+            };
+
+            ut.TestState.ExpectedDiagnostics.Add(expected);
+#if NET
+            ut.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+#endif
+
+            await ut.RunAsync();
+        }
+
+        /// <summary>
+        /// A charset introducer is only a prefix when it starts the run: an identifier that merely
+        /// ends in one is kept.
+        /// </summary>
+        [Test]
+        public async Task Fix_Keeps_Identifier_That_Ends_In_A_Charset_Introducer()
+        {
+            //language=csharp
+            const string source = @"
+using ConsoleApplication1;
+
+namespace ConsoleApplication1
+{
+    public class TypeName
+    {
+        public void Up()
+        {
+            new FakeExecuteExpressionRoot().Sql(""UPDATE Foo SET Name = Col_utf8mb4'$(name)'"");
+        }
+    }
+}";
+
+            //language=csharp
+            const string fixedSource = @"
+using ConsoleApplication1;
+
+namespace ConsoleApplication1
+{
+    public class TypeName
+    {
+        public void Up()
+        {
+            new FakeExecuteExpressionRoot().Sql(""UPDATE Foo SET Name = Col_utf8mb4$[name]"");
+        }
+    }
+}";
+
+            var expected = Verify.Diagnostic(RawSqlTokenInterpolationAnalyzer.DiagnosticId)
+                .WithSpan(10, 84, 10, 91)
+                .WithArguments("$(name)", "$[name]");
+
+            var ut = new VerifyTest
+            {
+                TestState =
+                {
+                    Sources = { source, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+                FixedState =
+                {
+                    Sources = { fixedSource, StubDefinitions },
+                    MarkupHandling = MarkupMode.None,
+                },
+            };
+
+            ut.TestState.ExpectedDiagnostics.Add(expected);
+#if NET
+            ut.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+#endif
+
+            await ut.RunAsync();
+        }
     }
 }


### PR DESCRIPTION
Fixes #2353.

**Problem.** `RawSqlTokenInterpolationCodeFixProvider.ExpandOverEnclosingQuotes` greedily walked back over any letter/digit/underscore/`&` run before the opening quote, so applying the FM0002 code fix to `... WHERE Name LIKE'$(name)'` deleted the `LIKE` keyword along with the quotes.

**Cause.** The analyzer classifies the literal with `SqlLiteralScanner` (known-prefix list, boundary-aware), but the code fix re-derived the span with a hand-rolled greedy walk that treated *every* adjacent identifier as a literal prefix.

**Change.**

- The code fix now walks back over the whole adjacent identifier run and absorbs it only when `SqlLiteralScanner.IsKnownLiteralPrefix` (made `internal`) recognises it (`N`, `E`, `B`, `X`, `_charset`). An unrecognised run stays in place and only the quotes are stripped: `LIKE'$(name)'` → `LIKE$[name]`, and `ColumnN'$(name)'` keeps `ColumnN`. Consuming the entire run is what supplies the identifier-boundary rule, since the candidate becomes `ColumnN` rather than `N`.
- `U&'...'` is matched explicitly (the `&` is not an identifier character) with an identifier-boundary check: in `FOO_U&'x'` the `U` is the tail of the identifier `FOO_U` and the `&` an operator, so both survive.
- The same boundary rule is added to `SqlLiteralScanner.ReadLiteralPrefixStart`, which previously recognised `U&` unconditionally, so the analyzer's literal-region classification and the fix's span expansion agree on the shape of the literal. This is diagnostics-neutral: the region's `ContentStart` is unchanged, so FM0002's strip-quotes decision is identical; only FM0003's reported opener for the pathological `FOO_U&'x'` input changes, from `U&'` to `'`, which is the accurate description. The scanner's old post-walk "not preceded by an identifier" check was unreachable — the walk already consumes the maximal run — and is removed.

Full sharing of one routine between the two sides isn't possible: the code fix walks the C# `SourceText` while the scanner walks the string value. So the rule is stated in the scanner and explicitly mirrored in the fix, with comments on both sides pointing at each other.

**Known limitation (pre-existing, unchanged).** The analyzer works on the string literal's *value* while the span expansion works on the C# *source*, so quotes or prefixes spelled with escape sequences (`"\'$(name)\'"`, `"N'$(name)'"`) are not matched by the source walk and the fix falls back to rewriting the token alone, as it did before this change. This is now documented on `ExpandOverEnclosingQuotes`; handling it would require mapping value-text positions back to source positions.

**Tests.** Ten new tests in `RawSqlTokenInterpolationUnitTests`: keyword adjacency (`LIKE'...'`), prefix stripping (`N`, `n`, `E`, `_utf8mb4`, `U&`, and `U&` at the start of the SQL), and rejection cases (`FOO_U&`, `ColumnN`, glued `Col_utf8mb4`). Analyzer suite 50/50; full unit suite 5431 passed, 0 failed, every pre-existing test unmodified.
