### PR TITLE
Fix #2386: DROP TABLE IF EXISTS ignores schema (Postgres & SQLite)

### DIFF
--- a/src/FluentMigrator.Runner.Core/Generators/Generic/GenericGenerator.cs
+++ b/src/FluentMigrator.Runner.Core/Generators/Generic/GenericGenerator.cs
@@ -166,7 +166,7 @@ namespace FluentMigrator.Runner.Generators.Generic
         {
             if (expression.IfExists)
             {
-                return FormatStatement(DropTableIfExists, Quoter.QuoteTableName(expression.TableName));
+                return FormatStatement(DropTableIfExists, Quoter.QuoteTableName(expression.TableName, expression.SchemaName));
             }
 
             return FormatStatement(DropTable, Quoter.QuoteTableName(expression.TableName, expression.SchemaName));

--- a/test/FluentMigrator.Tests/Helpers/PostgresTestTable.cs
+++ b/test/FluentMigrator.Tests/Helpers/PostgresTestTable.cs
@@ -74,10 +74,12 @@ namespace FluentMigrator.Tests.Helpers
 
         public void Drop()
         {
+            // Use IF EXISTS so cleanup stays robust even when the table under test was
+            // already dropped by the migration/expression being executed.
             var sb = new StringBuilder();
-            sb.AppendFormat("DROP TABLE {0}", NameWithSchema);
+            sb.AppendFormat("DROP TABLE IF EXISTS {0}", NameWithSchema);
             if (!string.IsNullOrEmpty(_schemaName))
-                sb.AppendFormat(";DROP SCHEMA \"{0}\"", _schemaName);
+                sb.AppendFormat(";DROP SCHEMA IF EXISTS \"{0}\"", _schemaName);
 
             using (var command = new NpgsqlCommand(sb.ToString(), Connection, Transaction))
                 command.ExecuteNonQuery();

--- a/test/FluentMigrator.Tests/Integration/Processors/Postgres/PostgresTableTests.cs
+++ b/test/FluentMigrator.Tests/Integration/Processors/Postgres/PostgresTableTests.cs
@@ -16,6 +16,7 @@
 //
 #endregion
 
+using FluentMigrator.Expressions;
 using FluentMigrator.Runner;
 using FluentMigrator.Runner.Initialization;
 using FluentMigrator.Runner.Processors.Postgres;
@@ -69,6 +70,23 @@ namespace FluentMigrator.Tests.Integration.Processors.Postgres
         {
             using (var table = new PostgresTestTable(Processor, "TestSchema", "id int"))
                 Processor.TableExists("TestSchema", table.Name).ShouldBeTrue();
+        }
+
+        [Test]
+        public void CanDropTableIfExistsInCustomSchema()
+        {
+            using var table = new PostgresTestTable(Processor, "TestSchema", "id int");
+
+            Processor.TableExists("TestSchema", table.Name).ShouldBeTrue();
+
+            Processor.Process(new DeleteTableExpression
+            {
+                TableName = table.Name,
+                SchemaName = "TestSchema",
+                IfExists = true,
+            });
+
+            Processor.TableExists("TestSchema", table.Name).ShouldBeFalse();
         }
 
         [OneTimeSetUp]

--- a/test/FluentMigrator.Tests/Unit/Generators/Firebird/FirebirdTableTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Firebird/FirebirdTableTests.cs
@@ -259,6 +259,16 @@ namespace FluentMigrator.Tests.Unit.Generators.Firebird
         }
 
         [Test]
+        public void CanDropTableIfExistsWithCustomSchema()
+        {
+            var expression = GeneratorTestHelper.GetDeleteTableIfExistsExpression();
+            expression.SchemaName = "TestSchema";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("IF( EXISTS( SELECT 1 FROM RDB$RELATIONS WHERE (rdb$flags IS NOT NULL) AND LOWER(RDB$RELATION_NAME) = LOWER('TestTable1'))) THEN EXECUTE STATEMENT 'DROP TABLE TestTable1');");
+        }
+
+        [Test]
         public override void CanRenameTableWithCustomSchema()
         {
             var expression = GeneratorTestHelper.GetRenameTableExpression();

--- a/test/FluentMigrator.Tests/Unit/Generators/MySql4/MySql4TableTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/MySql4/MySql4TableTests.cs
@@ -264,6 +264,16 @@ namespace FluentMigrator.Tests.Unit.Generators.MySql4
         }
 
         [Test]
+        public void CanDropTableIfExistsWithCustomSchema()
+        {
+            var expression = GeneratorTestHelper.GetDeleteTableIfExistsExpression();
+            expression.SchemaName = "TestSchema";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DROP TABLE IF EXISTS `TestTable1`;");
+        }
+
+        [Test]
         public override void CanRenameTableWithCustomSchema()
         {
             var expression = GeneratorTestHelper.GetRenameTableExpression();

--- a/test/FluentMigrator.Tests/Unit/Generators/Postgres/PostgresTableTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Postgres/PostgresTableTests.cs
@@ -269,6 +269,16 @@ namespace FluentMigrator.Tests.Unit.Generators.Postgres
         }
 
         [Test]
+        public void CanDropTableIfExistsWithCustomSchema()
+        {
+            var expression = GeneratorTestHelper.GetDeleteTableIfExistsExpression();
+            expression.SchemaName = "TestSchema";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DROP TABLE IF EXISTS \"TestSchema\".\"TestTable1\";");
+        }
+
+        [Test]
         public void CanCreateTableIfNotExistsWithDefaultSchema()
         {
             var expression = GeneratorTestHelper.GetCreateTableExpression();

--- a/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteTableTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteTableTests.cs
@@ -394,6 +394,16 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         }
 
         [Test]
+        public void CanDropTableIfExistsWithCustomSchema()
+        {
+            var expression = GeneratorTestHelper.GetDeleteTableIfExistsExpression();
+            expression.SchemaName = "TestSchema";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("DROP TABLE IF EXISTS \"TestSchema\".\"TestTable1\";");
+        }
+
+        [Test]
         public override void CanRenameTableWithCustomSchema()
         {
             var expression = GeneratorTestHelper.GetRenameTableExpression();

--- a/test/FluentMigrator.Tests/Unit/Generators/SqlServer2000/SqlServer2000TableTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SqlServer2000/SqlServer2000TableTests.cs
@@ -293,6 +293,16 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2000
         }
 
         [Test]
+        public void CanDropTableIfExistsWithCustomSchema()
+        {
+            var expression = GeneratorTestHelper.GetDeleteTableIfExistsExpression();
+            expression.SchemaName = "TestSchema";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe("IF OBJECT_ID('[TestTable1]') IS NOT NULL DROP TABLE [TestTable1];");
+        }
+
+        [Test]
         public override void CanRenameTableWithCustomSchema()
         {
             var expression = GeneratorTestHelper.GetRenameTableExpression();


### PR DESCRIPTION
## Problem

Fixes #2386 

When deleting a table with both `IfExists()` and a non-default schema, the generated `DROP TABLE IF EXISTS` statement omits the schema.

This affects PostgreSQL and SQLite dialects. On PostgreSQL a missing schema resolves to `public`, so the statement silently targets the wrong table.

Only the dialects using the generic `DROP TABLE IF EXISTS` generation are affected (PostgreSQL, SQLite). Dialects that override `Generate(DeleteTableExpression)` (SQL Server, Oracle, Db2, Snowflake, Redshift, HANA) already pass the schema and are unaffected.