### PR TITLE
Fix DB2 conditional table drop catalog lookup

### DIFF
--- a/src/FluentMigrator.Runner.Db2/Generators/Db2/Db2Generator.cs
+++ b/src/FluentMigrator.Runner.Db2/Generators/Db2/Db2Generator.cs
@@ -23,6 +23,7 @@ using System.Text;
 
 using FluentMigrator.Model;
 using FluentMigrator.Runner.Generators.Generic;
+using FluentMigrator.Runner.Helpers;
 
 using Microsoft.Extensions.Options;
 
@@ -202,14 +203,25 @@ namespace FluentMigrator.Runner.Generators.DB2
                 }
 
                 return FormatStatement(
-                    "IF( EXISTS(SELECT 1 FROM SYSCAT.TABLES WHERE TABSCHEMA = '{0}' AND TABNAME = '{1}')) THEN DROP TABLE {2} END IF",
-                    Quoter.QuoteSchemaName(expression.SchemaName),
-                    Quoter.QuoteTableName(expression.TableName),
+                    "IF( EXISTS(SELECT 1 FROM SYSCAT.TABLES WHERE {0} AND {1})) THEN DROP TABLE {2} END IF",
+                    BuildCatalogNameComparison("TABSCHEMA", expression.SchemaName),
+                    BuildCatalogNameComparison("TABNAME", expression.TableName),
                     Quoter.QuoteTableName(expression.TableName, expression.SchemaName)
                 );
             }
 
             return FormatStatement(DropTable, Quoter.QuoteTableName(expression.TableName, expression.SchemaName));
+        }
+
+        private string BuildCatalogNameComparison(string catalogColumn, string identifier)
+        {
+            var name = FormatHelper.FormatSqlEscape(Quoter.UnQuote(identifier));
+            if (Quoter.IsQuoted(identifier))
+            {
+                return $"{Quoter.QuoteColumnName(catalogColumn)} = '{name}'";
+            }
+
+            return $"LCASE({Quoter.QuoteColumnName(catalogColumn)})=LCASE('{name}')";
         }
 
         /// <inheritdoc />

--- a/test/FluentMigrator.Tests/Unit/Generators/Db2/Db2TableTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/Db2/Db2TableTests.cs
@@ -257,7 +257,18 @@ namespace FluentMigrator.Tests.Unit.Generators.Db2
             expression.SchemaName = "TestSchema";
 
             var result = Generator.Generate(expression);
-            result.ShouldBe(@"IF( EXISTS(SELECT 1 FROM SYSCAT.TABLES WHERE TABSCHEMA = 'TestSchema' AND TABNAME = 'TestTable1')) THEN DROP TABLE TestSchema.TestTable1 END IF;");
+            result.ShouldBe(@"IF( EXISTS(SELECT 1 FROM SYSCAT.TABLES WHERE LCASE(TABSCHEMA)=LCASE('TestSchema') AND LCASE(TABNAME)=LCASE('TestTable1'))) THEN DROP TABLE TestSchema.TestTable1 END IF;");
+        }
+
+        [Test]
+        public void CanDropTableIfExistsWithQuotedIdentifiers()
+        {
+            var expression = GeneratorTestHelper.GetDeleteTableIfExistsExpression();
+            expression.SchemaName = "\"TestSchema\"";
+            expression.TableName = "\"TestTable1\"";
+
+            var result = Generator.Generate(expression);
+            result.ShouldBe(@"IF( EXISTS(SELECT 1 FROM SYSCAT.TABLES WHERE TABSCHEMA = 'TestSchema' AND TABNAME = 'TestTable1')) THEN DROP TABLE ""TestSchema"".""TestTable1"" END IF;");
         }
 
         [Test]


### PR DESCRIPTION
Fixes #2391.

## Summary
- Match `SYSCAT.TABLES` case-insensitively when `Delete.Table(...).IfExists()` uses ordinary DB2 identifiers.
- Preserve exact matching for explicitly quoted identifiers.
- Escape catalog lookup values and cover both identifier modes.

## Root cause
The DB2 generator compared catalog values directly against the user-supplied strings. DB2 folds ordinary identifiers to uppercase when it processes them, so mixed-case input such as `TestSchema` and `TestTable1` did not match their catalog entries and the guarded statement did not drop an existing table.

## Validation
```
dotnet test test\FluentMigrator.Tests\FluentMigrator.Tests.csproj --configuration Debug --no-restore --filter "FullyQualifiedName~Generators.Db2" --verbosity minimal
```

Result: 145 passed.