### PR TITLE
Reject automatic reversal of table description changes

### DIFF
--- a/src/FluentMigrator.Abstractions/Expressions/AlterTableExpression.cs
+++ b/src/FluentMigrator.Abstractions/Expressions/AlterTableExpression.cs
@@ -56,6 +56,11 @@ namespace FluentMigrator.Expressions
         /// <inheritdoc />
         public override IMigrationExpression Reverse()
         {
+            if (!string.IsNullOrEmpty(TableDescription))
+            {
+                return base.Reverse();
+            }
+
             return new AlterTableExpression
             {
                 SchemaName = SchemaName,

--- a/test/FluentMigrator.Tests/Unit/AutoReversingMigrationTests.cs
+++ b/test/FluentMigrator.Tests/Unit/AutoReversingMigrationTests.cs
@@ -88,6 +88,15 @@ namespace FluentMigrator.Tests.Unit
         }
 
         [Test]
+        public void DownMigrationWithTableDescriptionCannotBeAutoReversed()
+        {
+            var autoReversibleMigration = new TestAlterTableDescriptionAutoReversingMigration();
+            _context.Object.Expressions = new Collection<IMigrationExpression>();
+
+            Should.Throw<System.NotSupportedException>(() => autoReversibleMigration.GetDownExpressions(_context.Object));
+        }
+
+        [Test]
         public void AlterTableAddColumnAutoReversingMigrationGivesDeleteColumnDown()
         {
             var autoReversibleMigration = new TestAlterTableAddColumnAutoReversingMigration();
@@ -137,6 +146,14 @@ namespace FluentMigrator.Tests.Unit
                 .AddColumn("organization_details_ar").AsString(2000).Nullable()
                 .AddColumn("details_ar").AsString(2000).Nullable()
                 .AddColumn("address_ar").AsString(250).Nullable();
+        }
+    }
+
+    internal class TestAlterTableDescriptionAutoReversingMigration : AutoReversingMigration
+    {
+        public override void Up()
+        {
+            Alter.Table("Foo").WithDescription("Stores test data");
         }
     }
 }

--- a/test/FluentMigrator.Tests/Unit/Expressions/AlterTableExpressionTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Expressions/AlterTableExpressionTests.cs
@@ -81,7 +81,7 @@ namespace FluentMigrator.Tests.Unit.Expressions
         }
 
         [Test]
-        public void ReverseReturnsAlterTableExpression()
+        public void ReverseThrowsWhenTableDescriptionIsSet()
         {
             var expression = new AlterTableExpression
             {
@@ -90,13 +90,26 @@ namespace FluentMigrator.Tests.Unit.Expressions
                 TableDescription = "TestDescription"
             };
 
+            Should.Throw<System.NotSupportedException>(() => expression.Reverse());
+        }
+
+        [Test]
+        public void ReverseReturnsAlterTableExpressionWhenTableDescriptionIsNotSet()
+        {
+            var expression = new AlterTableExpression
+            {
+                TableName = "TestTable",
+                SchemaName = "TestSchema",
+                IfExists = true
+            };
+
             var reversed = expression.Reverse();
 
             Assert.That(reversed, Is.TypeOf<AlterTableExpression>());
             var reversedExpression = (AlterTableExpression)reversed;
             Assert.That(reversedExpression.TableName, Is.EqualTo("TestTable"));
             Assert.That(reversedExpression.SchemaName, Is.EqualTo("TestSchema"));
-            Assert.That(reversedExpression.TableDescription, Is.EqualTo("TestDescription"));
+            Assert.That(reversedExpression.IfExists, Is.True);
         }
     }
 }


### PR DESCRIPTION
## Summary

- Reject automatic reversal of `Alter.Table(...).WithDescription(...)`.
- Preserve reversal of `AlterTableExpression` instances that do not change a description.
- Add expression-level and `AutoReversingMigration` regression coverage.

Fixes #2394.

## Root cause

`AlterTableExpression.Reverse()` copied the new `TableDescription` into the generated Down expression. That applies the same description a second time; it cannot restore the prior value because FluentMigrator does not retain it.

The fix follows the established fail-safe behavior for unsafe generated reversals: delegate to the base implementation, which throws `NotSupportedException`. Authors who know the prior description can still use a regular migration with an explicit `Down()`.

## Validation

- Focused regression tests: 12 passed
- Full `FluentMigrator.Tests` suite: 5,529 passed, 943 skipped, 0 failed
- `git diff --check`: clean