### PR TITLE
Preserve SQL Server index filters with null predicates

### DIFF
--- a/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2008Generator.cs
+++ b/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2008Generator.cs
@@ -107,9 +107,9 @@ namespace FluentMigrator.Runner.Generators.SqlServer
                 return baseFilter;
             }
 
-            baseFilter = string.IsNullOrEmpty(baseFilter) ?
-                $" WHERE {nullsDistinct}" :
-                $" AND  {nullsDistinct}";
+            baseFilter = string.IsNullOrEmpty(baseFilter)
+                ? $" WHERE {nullsDistinct}"
+                : $"{baseFilter} AND {nullsDistinct}";
 
             return baseFilter;
         }

--- a/test/FluentMigrator.Tests/Unit/Generators/SqlServer2008/SqlServer2008IndexTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SqlServer2008/SqlServer2008IndexTests.cs
@@ -152,6 +152,18 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2008
         }
 
         [Test]
+        public void CanCreateUniqueIndexWithFilterAndNonDistinctNulls()
+        {
+            var expression = GeneratorTestHelper.GetCreateUniqueIndexExpression();
+            expression.Index.Columns.First().SetAdditionalFeature(SqlServerExtensions.IndexColumnNullsDistinct, false);
+            new CreateIndexExpressionBuilder(expression).Filter("TestColumn2 = 1");
+
+            var result = _generator.Generate(expression);
+
+            result.ShouldBe("CREATE UNIQUE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC) WHERE TestColumn2 = 1 AND [TestColumn1] IS NOT NULL;");
+        }
+
+        [Test]
         public void CanCreateUniqueIndexWithNonDistinctNullsAlternativeSyntax()
         {
             var expression = new CreateIndexExpression()


### PR DESCRIPTION
## Summary

- Preserve a user-supplied SQL Server index filter when adding the `NullsNotDistinct()` predicate.
- Add regression coverage for the combined filter and null-distinctness path.

Fixes #2397.

## Root cause

`SqlServer2008Generator.GetFilterString()` replaced the existing `WHERE` filter with an `AND ... IS NOT NULL` fragment whenever both options were set. The generated `CREATE INDEX` statement was invalid SQL and silently discarded the user filter.

The generator now appends the generated null predicate to the existing filter. When no custom filter exists, it continues to create the `WHERE` clause itself.

## Validation

- `SqlServer2008IndexTests`: 23 passed
- Full `FluentMigrator.Tests` suite: 5,528 passed, 943 skipped, 0 failed
- `git diff --check`: clean