### PR TITLE
Fix #2397: keep the index filter when NULLs are not distinct

### DIFF
--- a/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2008Generator.cs
+++ b/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2008Generator.cs
@@ -16,6 +16,7 @@
 //
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -37,6 +38,8 @@ namespace FluentMigrator.Runner.Generators.SqlServer
     /// </summary>
     public class SqlServer2008Generator : SqlServer2005Generator
     {
+        private const string WhereClause = " WHERE ";
+
         private static readonly HashSet<string> _supportedAdditionalFeatures = new HashSet<string>
         {
             SqlServerExtensions.IndexColumnNullsDistinct,
@@ -97,21 +100,25 @@ namespace FluentMigrator.Runner.Generators.SqlServer
             var baseFilter = base.GetFilterString(createIndexExpression);
             var nullsDistinct = GetWithNullsDistinctString(createIndexExpression.Index);
 
-            if (string.IsNullOrEmpty(baseFilter) && string.IsNullOrEmpty(nullsDistinct))
-            {
-                return string.Empty;
-            }
-
             if (string.IsNullOrEmpty(nullsDistinct))
             {
                 return baseFilter;
             }
 
-            baseFilter = string.IsNullOrEmpty(baseFilter) ?
-                $" WHERE {nullsDistinct}" :
-                $" AND  {nullsDistinct}";
+            if (string.IsNullOrEmpty(baseFilter))
+            {
+                return $" WHERE {nullsDistinct}";
+            }
 
-            return baseFilter;
+            // The base filter is the user's own predicate, already prefixed with WHERE.
+            // It is arbitrary SQL, so it is parenthesised before the generated predicate
+            // is appended: an OR inside it would otherwise bind more loosely than the
+            // appended AND and the index would cover the wrong rows.
+            var userFilter = baseFilter.StartsWith(WhereClause, StringComparison.Ordinal)
+                ? baseFilter.Substring(WhereClause.Length)
+                : baseFilter;
+
+            return $" WHERE ({userFilter}) AND {nullsDistinct}";
         }
 
         /// <summary>

--- a/test/FluentMigrator.Tests/Unit/Generators/SqlServer2008/SqlServer2008IndexTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SqlServer2008/SqlServer2008IndexTests.cs
@@ -241,6 +241,56 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2008
         }
 
         [Test]
+        public void CanCreateUniqueIndexWithNonDistinctNullsAndFilter()
+        {
+            var expression = new CreateIndexExpression()
+            {
+                Index =
+                {
+                    Name = GeneratorTestHelper.TestIndexName,
+                }
+            };
+
+            var builder = new CreateIndexExpressionBuilder(expression);
+            builder
+                .OnTable(GeneratorTestHelper.TestTableName1)
+                .OnColumn(GeneratorTestHelper.TestColumnName1)
+                .Ascending()
+                .NullsNotDistinct()
+                .WithOptions().Unique();
+            builder.Filter("TestColumn2 = 1");
+
+            var result = _generator.Generate(expression);
+            result.ShouldBe("CREATE UNIQUE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC) WHERE (TestColumn2 = 1) AND [TestColumn1] IS NOT NULL;");
+        }
+
+        [Test]
+        public void CanCreateUniqueIndexWithNonDistinctNullsAndFilterContainingOr()
+        {
+            var expression = new CreateIndexExpression()
+            {
+                Index =
+                {
+                    Name = GeneratorTestHelper.TestIndexName,
+                }
+            };
+
+            var builder = new CreateIndexExpressionBuilder(expression);
+            builder
+                .OnTable(GeneratorTestHelper.TestTableName1)
+                .OnColumn(GeneratorTestHelper.TestColumnName1)
+                .Ascending()
+                .NullsNotDistinct()
+                .WithOptions().Unique();
+            builder.Filter("TestColumn2 = 1 OR TestColumn3 = 2");
+
+            // Without the parentheses the appended AND would bind tighter than the OR
+            // and the index would cover a different set of rows than the filter asks for.
+            var result = _generator.Generate(expression);
+            result.ShouldBe("CREATE UNIQUE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC) WHERE (TestColumn2 = 1 OR TestColumn3 = 2) AND [TestColumn1] IS NOT NULL;");
+        }
+
+        [Test]
         public void CanCreateIndexWithFilter()
         {
             var expression = GeneratorTestHelper.GetCreateIndexExpression();


### PR DESCRIPTION
Fixes #2397.

`SqlServer2008Generator.GetFilterString` computes the user's filter and the generated `IS NOT NULL` predicate, and in the case where both are present it returned only the predicate. The filter and its `WHERE` keyword were dropped, so a unique index that combined `Filter(...)` with `NullsNotDistinct()` emitted SQL that starts a clause with `AND`:

```sql
CREATE UNIQUE INDEX [IX_Test] ON [dbo].[TestTable] ([TestColumn1] ASC) AND  [TestColumn1] IS NOT NULL;
```

The fix appends instead of replacing, and parenthesises the user's filter first, because the filter is arbitrary SQL and an `OR` inside it would otherwise bind more loosely than the appended `AND`, leaving the index covering a different set of rows than the migration asked for.

The filter-only and predicate-only cases are untouched, so anything that does not combine the two renders exactly as it did before. `GetFilterString(CreateIndexExpression)` is overridden only on `SqlServer2008Generator`, and the 2012, 2014 and 2016 generators inherit it, so all four are covered.

Two tests in `SqlServer2008IndexTests`: the combined case from the report, and a filter containing `OR` that pins the precedence behaviour. Full `FluentMigrator.Tests` run on net8.0: 5524 passed, 0 failed, 1011 skipped (main is 5522 passed, 0 failed, same skips).
