### PR TITLE
Fix #2400: give Oracle12cManaged a generator of its own

### DIFF
--- a/src/FluentMigrator.Runner.Oracle/Generators/Oracle/IOracle12CManagedGenerator.cs
+++ b/src/FluentMigrator.Runner.Oracle/Generators/Oracle/IOracle12CManagedGenerator.cs
@@ -1,0 +1,27 @@
+#region License
+// Copyright (c) 2026, Fluent Migrator Project
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace FluentMigrator.Runner.Generators.Oracle;
+
+/// <summary>
+/// Defines the interface for the Oracle 12c Managed SQL generator used in FluentMigrator.
+/// </summary>
+/// <remarks>
+/// This interface extends <see cref="IOracle12CGenerator"/> to provide functionality specific to Oracle 12c via the managed driver.
+/// </remarks>
+public interface IOracle12CManagedGenerator : IOracle12CGenerator
+{
+}

--- a/src/FluentMigrator.Runner.Oracle/Generators/Oracle/Oracle12CManagedGenerator.cs
+++ b/src/FluentMigrator.Runner.Oracle/Generators/Oracle/Oracle12CManagedGenerator.cs
@@ -1,0 +1,32 @@
+#region License
+// Copyright (c) 2026, Fluent Migrator Project
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System.Collections.Generic;
+
+namespace FluentMigrator.Runner.Generators.Oracle;
+
+/// <summary>
+/// The Oracle 12c Managed SQL generator for FluentMigrator.
+/// </summary>
+public class Oracle12CManagedGenerator : Oracle12CGenerator, IOracle12CManagedGenerator
+{
+    /// <inheritdoc />
+    public override string GeneratorId => GeneratorIdConstants.Oracle12cManaged;
+
+    /// <inheritdoc />
+    public override List<string> GeneratorIdAliases =>
+        new List<string> { GeneratorIdConstants.Oracle, GeneratorIdConstants.Oracle12c };
+}

--- a/src/FluentMigrator.Runner.Oracle/OracleRunnerBuilderExtensions.cs
+++ b/src/FluentMigrator.Runner.Oracle/OracleRunnerBuilderExtensions.cs
@@ -83,6 +83,16 @@ namespace FluentMigrator.Runner
         }
 
         /// <summary>
+        /// Register Oracle 12c Managed generator
+        /// </summary>
+        /// <param name="builder">The builder to add the Oracle-specific services to</param>
+        private static void RegisterOracle12CManagedGenerator(IMigrationRunnerBuilder builder)
+        {
+            builder.Services.TryAddScoped<IOracle12CManagedGenerator, Oracle12CManagedGenerator>();
+            builder.Services.TryAddScoped<IOracle12CGenerator>(sp => sp.GetRequiredService<IOracle12CManagedGenerator>());
+        }
+
+        /// <summary>
         /// Register Oracle processor dependencies
         /// </summary>
         /// <param name="builder">The builder to add the Oracle-specific services to</param>
@@ -228,7 +238,7 @@ namespace FluentMigrator.Runner
         /// <returns>The migration runner builder</returns>
         public static IMigrationRunnerBuilder AddOracle12CManaged(this IMigrationRunnerBuilder builder)
         {
-            RegisterOracle12CGenerator(builder);
+            RegisterOracle12CManagedGenerator(builder);
 
             RegisterOracleManagedProcessor<Oracle12CManagedProcessor>(builder, sp =>
                 new Oracle12CManagedProcessor(
@@ -238,7 +248,7 @@ namespace FluentMigrator.Runner
                     sp.GetRequiredService<IOptionsSnapshot<ProcessorOptions>>(),
                     sp.GetRequiredService<IMigrationConnectionFactory>()));
 
-            builder.Services.AddScoped<IMigrationGenerator>(sp => sp.GetRequiredService<IOracle12CGenerator>());
+            builder.Services.AddScoped<IMigrationGenerator>(sp => sp.GetRequiredService<IOracle12CManagedGenerator>());
 
             return builder;
         }

--- a/src/FluentMigrator/GeneratorIdConstants.cs
+++ b/src/FluentMigrator/GeneratorIdConstants.cs
@@ -30,6 +30,7 @@ namespace FluentMigrator
         public const string Oracle = nameof(Oracle);
         public const string OracleManaged = nameof(OracleManaged);
         public const string Oracle12c = nameof(Oracle12c);
+        public const string Oracle12cManaged = nameof(Oracle12cManaged);
         public const string Postgres = nameof(Postgres);
         public const string Postgres92 = nameof(Postgres92);
         public const string PostgreSQL = nameof(PostgreSQL);

--- a/test/FluentMigrator.Tests/Unit/Runners/OracleRunnerBuilderExtensionsTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Runners/OracleRunnerBuilderExtensionsTests.cs
@@ -20,8 +20,10 @@ using System;
 using System.Collections.Generic;
 
 using FluentMigrator.Runner;
+using FluentMigrator.Runner.Generators;
 using FluentMigrator.Runner.Generators.Oracle;
 using FluentMigrator.Runner.Initialization;
+using FluentMigrator.Runner.Processors;
 using FluentMigrator.Runner.Processors.Oracle;
 
 using Microsoft.Extensions.DependencyInjection;
@@ -91,7 +93,7 @@ namespace FluentMigrator.Tests.Unit.Runners
                     (Action<IMigrationRunnerBuilder>)(r => r.AddOracle12CManaged()),
                     typeof(Oracle12CManagedProcessor),
                     ProcessorIdConstants.Oracle12cManaged,
-                    GeneratorIdConstants.Oracle12c)
+                    GeneratorIdConstants.Oracle12cManaged)
                 .SetArgDisplayNames(nameof(OracleRunnerBuilderExtensions.AddOracle12CManaged));
         }
 
@@ -137,6 +139,58 @@ namespace FluentMigrator.Tests.Unit.Runners
                     Assert.That(oracleGenerator, Is.SameAs(managedGenerator));
                     Assert.That(oracleGenerator.GeneratorId, Is.EqualTo(GeneratorIdConstants.OracleManaged));
                 });
+            }
+        }
+
+        [TestCase(ProcessorIdConstants.Oracle, GeneratorIdConstants.Oracle)]
+        [TestCase(ProcessorIdConstants.OracleManaged, GeneratorIdConstants.OracleManaged)]
+        [TestCase(ProcessorIdConstants.Oracle12c, GeneratorIdConstants.Oracle12c)]
+        [TestCase(ProcessorIdConstants.Oracle12cManaged, GeneratorIdConstants.Oracle12cManaged)]
+        public void EveryOracleProcessorIdSelectsAGenerator(string processorId, string expectedGeneratorId)
+        {
+            // The runner falls back to the processor id when no generator id is configured, which is
+            // what -p does, so every id a processor answers to has to be claimed by a generator.
+            var services = new ServiceCollection()
+                .AddFluentMigratorCore()
+                .ConfigureRunner(r => r
+                    .AddOracle()
+                    .AddOracle12C()
+                    .AddOracleManaged()
+                    .AddOracle12CManaged())
+                .Configure<SelectingProcessorAccessorOptions>(opt => opt.ProcessorId = processorId)
+                .AddScoped<IConnectionStringReader>(
+                    _ => new PassThroughConnectionStringReader("Data Source=fake;User Id=fake;Password=fake"));
+
+            using (var serviceProvider = services.BuildServiceProvider(validateScopes: true))
+            using (var scope = serviceProvider.CreateScope())
+            {
+                var generator = scope.ServiceProvider.GetRequiredService<IGeneratorAccessor>().Generator;
+
+                Assert.That(generator.GeneratorId, Is.EqualTo(expectedGeneratorId));
+            }
+        }
+
+        [TestCase(GeneratorIdConstants.Oracle12cManaged)]
+        [TestCase(GeneratorIdConstants.Oracle12c)]
+        [TestCase(GeneratorIdConstants.Oracle)]
+        public void Oracle12CManagedGeneratorAnswersToTheUnmanagedIds(string generatorId)
+        {
+            // An application that pins the generator explicitly must keep resolving after the
+            // managed 12c generator took over the registration, which is what the unmanaged
+            // aliases are for. OracleManagedGenerator answers to Oracle for the same reason.
+            var services = new ServiceCollection()
+                .AddFluentMigratorCore()
+                .ConfigureRunner(r => r.AddOracle12CManaged())
+                .Configure<SelectingGeneratorAccessorOptions>(opt => opt.GeneratorId = generatorId)
+                .AddScoped<IConnectionStringReader>(
+                    _ => new PassThroughConnectionStringReader("Data Source=fake;User Id=fake;Password=fake"));
+
+            using (var serviceProvider = services.BuildServiceProvider(validateScopes: true))
+            using (var scope = serviceProvider.CreateScope())
+            {
+                var generator = scope.ServiceProvider.GetRequiredService<IGeneratorAccessor>().Generator;
+
+                Assert.That(generator, Is.TypeOf<Oracle12CManagedGenerator>());
             }
         }
 

--- a/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Oracle.verified.md
+++ b/test/FluentMigrator.Tests/Unit/TokenSubstitution/TokenSubstitutionMatrixTests.TokenMatrix_IsStable_family=Oracle.verified.md
@@ -132,7 +132,7 @@ See `TokenSubstitutionMatrix.md` for what each column means.
 
 ### Oracle12CManaged
 
-- generator: `Oracle12CGenerator`
+- generator: `Oracle12CManagedGenerator`
 - generator.Quoter: `OracleQuoter`
 - processor.Quoter: `OracleQuoter`
 


### PR DESCRIPTION
Fixes the second half of #2400.

The first symptom reported there, `-p OracleManaged` failing with "A migration generator with the ID OracleManaged couldn't be found", was fixed by #2269 and is awaiting release. This addresses the second one, which is still live on `main`.

`Oracle12CManagedProcessor` answers to the processor id `Oracle12cManaged`. `SelectingGeneratorAccessor` falls back to the processor id when no generator id is configured, which is exactly what `-p` does, and no generator claimed that id: `AddOracle12CManaged()` registered `Oracle12CGenerator`, whose `GeneratorId` is `Oracle12c`. It is the only Oracle processor id with no generator counterpart, so that provider could never resolve one.

`Oracle12CManagedGenerator` and `IOracle12CManagedGenerator` mirror the `OracleManaged` pair that #2269 added, and `AddOracle12CManaged()` now registers them through the same `TryAdd` indirection `RegisterOracleManagedGenerator` uses. The generator overrides `GeneratorId` and nothing else, so no SQL changes.

It also declares `Oracle` and `Oracle12c` as `GeneratorIdAliases`, the way `OracleManagedGenerator` inherits the `Oracle` alias. Without that, an application registering only `AddOracle12CManaged()` and pinning `GeneratorId = Oracle12c` explicitly would have stopped resolving, since the managed generator takes over the `IOracle12CGenerator` registration.

Tests, in `OracleRunnerBuilderExtensionsTests`:

- `EveryOracleProcessorIdSelectsAGenerator` registers all four Oracle providers the way `FluentMigrator.DotNet.Cli/Setup.cs` does, sets the processor id, and resolves `IGeneratorAccessor`. Without the fix, only the `Oracle12cManaged` case fails, with the same exception and call site as the stack trace in #2400: "A migration generator with the ID Oracle12cManaged couldn't be found. Available generators are: Oracle, Oracle12C, OracleManaged, Oracle12C".
- `Oracle12CManagedGeneratorAnswersToTheUnmanagedIds` pins each of the three ids explicitly against a container holding only `AddOracle12CManaged()`.
- The existing `AddOracle12CManaged` case in `IsolatedRegistrationResolvesProcessorAndGenerator` expected `GeneratorIdConstants.Oracle12c`; it now expects `Oracle12cManaged`, matching the `AddOracleManaged` row directly above it.

`FluentMigrator.Tests.Unit` is 5448 passed, 0 failed on net8.0. The solution builds with the same 12 warnings as `main`.

One line of the Oracle token matrix snapshot changes, since the `Oracle12cManaged` section now reports `Oracle12CManagedGenerator` rather than `Oracle12CGenerator`. #2401 also touches that file; the edits are on different lines and independent.
