### PR TITLE
Fix #2388: generate the inline REFERENCES clause when adding a foreign key column on SQLite

### DIFF
--- a/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteColumn.cs
+++ b/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteColumn.cs
@@ -80,6 +80,31 @@ namespace FluentMigrator.Runner.Generators.SQLite
             return base.FormatForeignKey(fk2, fkNameGeneration);
         }
 
+        /// <summary>
+        /// Formats a foreign key as a column-level constraint, e.g. <c>REFERENCES "Parent" ("Id")</c>.
+        /// </summary>
+        /// <param name="foreignKey">The foreign key to format</param>
+        /// <returns>The column constraint fragment</returns>
+        /// <remarks>
+        /// This is the only foreign key form SQLite accepts in <c>ALTER TABLE ... ADD COLUMN</c>;
+        /// the table-level <c>FOREIGN KEY (...) REFERENCES</c> clause is valid in CREATE TABLE only.
+        /// The referenced table's schema is omitted because SQLite foreign keys must stay within
+        /// the schema of the table itself (see <see cref="FormatForeignKey"/>).
+        /// </remarks>
+        public string FormatColumnLevelForeignKey(ForeignKeyDefinition foreignKey)
+        {
+            var constraintClause = string.IsNullOrEmpty(foreignKey.Name)
+                ? string.Empty
+                : $"CONSTRAINT {Quoter.QuoteConstraintName(foreignKey.Name)} ";
+
+            var primaryColumns = string.Join(", ", foreignKey.PrimaryColumns.Select(Quoter.QuoteColumnName));
+
+            return constraintClause
+                + $"REFERENCES {Quoter.QuoteTableName(foreignKey.PrimaryTable)} ({primaryColumns})"
+                + FormatCascade("DELETE", foreignKey.OnDelete)
+                + FormatCascade("UPDATE", foreignKey.OnUpdate);
+        }
+
         /// <inheritdoc />
         protected override string FormatIdentity(ColumnDefinition column)
         {

--- a/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteGenerator.cs
+++ b/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteGenerator.cs
@@ -131,6 +131,44 @@ namespace FluentMigrator.Runner.Generators.SQLite
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// SQLite accepts a column-level <c>REFERENCES</c> clause in <c>ALTER TABLE ... ADD COLUMN</c>,
+        /// so a column added with a foreign key declared through the fluent syntax, for example
+        /// <c>Alter.Table("Child").AddColumn("ParentId").AsInt32().ForeignKey("Parent", "Id")</c>,
+        /// gets the clause generated inline. The standalone <see cref="CreateForeignKeyExpression"/>
+        /// the builder queues for the same key is marked as handled so it does not fail afterwards,
+        /// mirroring what <see cref="SQLiteColumn"/> does for keys declared in CREATE TABLE.
+        /// </remarks>
+        public override string Generate(CreateColumnExpression expression)
+        {
+            var foreignKey = expression.Column.ForeignKey;
+            if (!expression.Column.IsForeignKey || foreignKey == null)
+            {
+                return base.Generate(expression);
+            }
+
+            var statement = base.Generate(expression);
+            if (string.IsNullOrEmpty(statement))
+            {
+                return statement;
+            }
+
+            var referencesClause = ((SQLiteColumn)Column).FormatColumnLevelForeignKey(foreignKey);
+
+            // The fluent builder also queues a standalone CreateForeignKeyExpression for this key.
+            // Prefix its name so Generate(CreateForeignKeyExpression) knows it has been handled here.
+            foreignKey.Name = "$$IGNORE$$_" + foreignKey.Name;
+
+            var trimmed = statement.TrimEnd();
+            if (trimmed.EndsWith(";"))
+            {
+                return trimmed.Substring(0, trimmed.Length - 1) + " " + referencesClause + ";";
+            }
+
+            return trimmed + " " + referencesClause;
+        }
+
+        /// <inheritdoc />
         public override string Generate(AlterColumnExpression expression)
         {
             return CompatibilityMode.HandleCompatibility("SQLite does not support alter column");
@@ -144,9 +182,10 @@ namespace FluentMigrator.Runner.Generators.SQLite
 
         /// <inheritdoc />
         /// <remarks>
-        /// SQLite accepts foreign keys only as part of a <c>CREATE TABLE</c> statement - there is no
-        /// <c>ALTER TABLE ... ADD CONSTRAINT</c>. Declaring the key on the column when the table is
-        /// created does work and is generated inline; see <see cref="SQLiteColumn"/>.
+        /// SQLite accepts foreign keys only declared inline on a column or table definition - there is
+        /// no <c>ALTER TABLE ... ADD CONSTRAINT</c>. Declaring the key on the column when the table is
+        /// created, or when the column is added, does work and is generated inline; see
+        /// <see cref="SQLiteColumn"/> and <see cref="Generate(CreateColumnExpression)"/>.
         /// </remarks>
         public override string Generate(CreateForeignKeyExpression expression)
         {
@@ -205,7 +244,9 @@ namespace FluentMigrator.Runner.Generators.SQLite
                 $"Foreign key {name}cannot be created with Create.ForeignKey on SQLite. SQLite accepts foreign keys " +
                 "only inside a CREATE TABLE statement; it has no ALTER TABLE ... ADD CONSTRAINT. " +
                 $"Declare the key on the column when the table is created - {example} - which FluentMigrator " +
-                "generates inline and SQLite accepts. To add one to a table that already exists, rebuild the table: " +
+                "generates inline and SQLite accepts. A new column can also be added with its key declared, " +
+                "using Alter.Table(...).AddColumn(...).ForeignKey(...). To add a key to a column that already " +
+                "exists, rebuild the table: " +
                 "create a replacement with the key declared, copy the rows across, drop the original and rename. " +
                 CompatibilityModeHint;
         }

--- a/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteColumnTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SQLite/SQLiteColumnTests.cs
@@ -17,9 +17,12 @@
 #endregion
 
 using System;
+using System.Data;
 using System.Linq;
 
 using FluentMigrator.Exceptions;
+using FluentMigrator.Expressions;
+using FluentMigrator.Model;
 using FluentMigrator.Runner.Generators.SQLite;
 using NUnit.Framework;
 
@@ -268,9 +271,85 @@ namespace FluentMigrator.Tests.Unit.Generators.SQLite
         public override void CanAlterColumnToAddStoredComputedExpression()
         {
             var expression = GeneratorTestHelper.GetAlterColumnExpressionWithStoredComputed();
-            
+
             // SQLite doesn't support altering columns
             Assert.Throws<DatabaseOperationNotSupportedException>(() => Generator.Generate(expression));
+        }
+
+        /// <summary>
+        /// The expression pair produced by Alter.Table("TestTable1").AddColumn("TestColumn1")
+        /// .AsInt32().Nullable().ForeignKey("TestTable2", "TestColumn2"); see issue #2388.
+        /// </summary>
+        private static (CreateColumnExpression AddColumn, CreateForeignKeyExpression ForeignKey) GetCreateColumnWithForeignKeyExpressions(string foreignKeyName = null)
+        {
+            var foreignKey = new ForeignKeyDefinition
+            {
+                Name = foreignKeyName,
+                PrimaryTable = GeneratorTestHelper.TestTableName2,
+                ForeignTable = GeneratorTestHelper.TestTableName1,
+                PrimaryColumns = new[] { GeneratorTestHelper.TestColumnName2 },
+                ForeignColumns = new[] { GeneratorTestHelper.TestColumnName1 }
+            };
+
+            var addColumn = new CreateColumnExpression
+            {
+                TableName = GeneratorTestHelper.TestTableName1,
+                Column = new ColumnDefinition
+                {
+                    Name = GeneratorTestHelper.TestColumnName1,
+                    Type = DbType.Int32,
+                    IsNullable = true,
+                    IsForeignKey = true,
+                    ForeignKey = foreignKey
+                }
+            };
+
+            var createForeignKey = new CreateForeignKeyExpression { ForeignKey = foreignKey };
+
+            return (addColumn, createForeignKey);
+        }
+
+        [Test]
+        public void CanCreateColumnWithForeignKey()
+        {
+            var (addColumn, _) = GetCreateColumnWithForeignKeyExpressions();
+
+            var result = Generator.Generate(addColumn);
+            result.ShouldBe("ALTER TABLE \"TestTable1\" ADD COLUMN \"TestColumn1\" INTEGER REFERENCES \"TestTable2\" (\"TestColumn2\");");
+        }
+
+        [Test]
+        public void CanCreateColumnWithNamedForeignKey()
+        {
+            var (addColumn, _) = GetCreateColumnWithForeignKeyExpressions("FK_TestTable1_TestColumn1");
+
+            var result = Generator.Generate(addColumn);
+            result.ShouldBe("ALTER TABLE \"TestTable1\" ADD COLUMN \"TestColumn1\" INTEGER CONSTRAINT \"FK_TestTable1_TestColumn1\" REFERENCES \"TestTable2\" (\"TestColumn2\");");
+        }
+
+        [Test]
+        public void CanCreateColumnWithForeignKeyWithOnDeleteAndOnUpdateOptions()
+        {
+            var (addColumn, _) = GetCreateColumnWithForeignKeyExpressions();
+            addColumn.Column.ForeignKey.OnDelete = Rule.Cascade;
+            addColumn.Column.ForeignKey.OnUpdate = Rule.SetNull;
+
+            var result = Generator.Generate(addColumn);
+            result.ShouldBe("ALTER TABLE \"TestTable1\" ADD COLUMN \"TestColumn1\" INTEGER REFERENCES \"TestTable2\" (\"TestColumn2\") ON DELETE CASCADE ON UPDATE SET NULL;");
+        }
+
+        [Test]
+        public void CreatingColumnWithForeignKeyMarksTheForeignKeyExpressionAsHandled()
+        {
+            // The fluent builder queues a CreateForeignKeyExpression alongside the
+            // CreateColumnExpression; once the column is generated with its inline
+            // REFERENCES clause, the standalone expression must not throw.
+            var (addColumn, createForeignKey) = GetCreateColumnWithForeignKeyExpressions("FK_TestTable1_TestColumn1");
+
+            Generator.Generate(addColumn);
+
+            var result = Generator.Generate(createForeignKey);
+            result.ShouldBe(string.Empty);
         }
     }
 }


### PR DESCRIPTION
Fixes #2388.

`Alter.Table("Child").AddColumn("ParentId").AsInt32().ForeignKey("Parent", "Id")` emits the ADD COLUMN and then throws `DatabaseOperationNotSupportedException`, because the fluent builder also queues a standalone `CreateForeignKeyExpression` and the SQLite generator refuses those. The refusal is honest but too broad: SQLite has no `ALTER TABLE ... ADD CONSTRAINT`, yet it does accept a column-level `REFERENCES` clause inside `ALTER TABLE ... ADD COLUMN`:

```sql
ALTER TABLE "Child" ADD COLUMN "ParentId" INTEGER REFERENCES "Parent" ("Id")
```

`SQLiteGenerator.Generate(CreateColumnExpression)` now appends that clause when the column carries a foreign key, and marks the queued key as handled by prefixing its name with `$$IGNORE$$_`. That marker is not new: `SQLiteColumn` already writes it for keys declared in `CREATE TABLE` and `Generate(CreateForeignKeyExpression)` already reads it, so this reuses the mechanism rather than inventing one. Standalone `Create.ForeignKey` on an existing column still fails, and its message now also points at the form that works.

`SQLiteColumn.FormatColumnLevelForeignKey` emits the optional `CONSTRAINT` name, the `REFERENCES` clause and any `ON DELETE` / `ON UPDATE` rules. It drops the referenced table's schema for the same reason the existing table-level path does, since a SQLite foreign key cannot leave the schema of its own table.

One behaviour worth stating plainly: SQLite only permits `ADD COLUMN` with a `REFERENCES` clause when the column's default is NULL and foreign keys are enabled. Such a column previously failed at FluentMigrator, and now fails at SQLite with SQLite's own error at migration time. I did not add a pre-validation guard, since whether the constraint is enforced depends on the connection's `PRAGMA foreign_keys`, which the generator cannot see.

Four new tests in `SQLiteColumnTests` cover the unnamed key, the named key, cascade rules, and that the follow-up expression is marked as handled; they run in both the standard and strict-tables fixtures. The `FluentMigrator.Tests.Unit` namespace is 5448 passed, 0 failed on net8.0, and the SQLite filter is 328 passed, 0 failed. I also ran the generated statement against real `sqlite3` with `PRAGMA foreign_keys=ON` and confirmed the constraint rejects an insert that violates it.
