### PR TITLE
Fix #1982: do not carry index creation options into the reversed delete

### DIFF
--- a/src/FluentMigrator.Abstractions/Expressions/CreateIndexExpression.cs
+++ b/src/FluentMigrator.Abstractions/Expressions/CreateIndexExpression.cs
@@ -43,9 +43,17 @@ namespace FluentMigrator.Expressions
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// The additional features of the index are intentionally not carried over to the
+        /// reversed expression. They describe how the index gets created (for example
+        /// ONLINE or DATA_COMPRESSION on SQL Server) and are not necessarily valid
+        /// options for the DROP INDEX statement.
+        /// </remarks>
         public override IMigrationExpression Reverse()
         {
-            return new DeleteIndexExpression { Index = Index.Clone() as IndexDefinition };
+            var index = (IndexDefinition)Index.Clone();
+            index.AdditionalFeatures.Clear();
+            return new DeleteIndexExpression { Index = index };
         }
 
         /// <inheritdoc />

--- a/src/FluentMigrator.Abstractions/Expressions/CreateIndexExpression.cs
+++ b/src/FluentMigrator.Abstractions/Expressions/CreateIndexExpression.cs
@@ -44,15 +44,20 @@ namespace FluentMigrator.Expressions
 
         /// <inheritdoc />
         /// <remarks>
-        /// The additional features of the index are intentionally not carried over to the
-        /// reversed expression. They describe how the index gets created (for example
-        /// ONLINE or DATA_COMPRESSION on SQL Server) and are not necessarily valid
-        /// options for the DROP INDEX statement.
+        /// For a non-clustered index the additional features are intentionally not carried
+        /// over to the reversed expression. They describe how the index gets created (for
+        /// example ONLINE or DATA_COMPRESSION on SQL Server) and are not valid options for
+        /// dropping one. A clustered index keeps them, since SQL Server can drop a
+        /// clustered index online and the reversal would otherwise lose that option.
         /// </remarks>
         public override IMigrationExpression Reverse()
         {
             var index = (IndexDefinition)Index.Clone();
-            index.AdditionalFeatures.Clear();
+            if (!index.IsClustered)
+            {
+                index.AdditionalFeatures.Clear();
+            }
+
             return new DeleteIndexExpression { Index = index };
         }
 

--- a/test/FluentMigrator.Tests/Unit/Expressions/CreateIndexExpressionTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Expressions/CreateIndexExpressionTests.cs
@@ -128,5 +128,53 @@ namespace FluentMigrator.Tests.Unit.Expressions
 
             Assert.That(processed.Index.SchemaName, Is.EqualTo("testdefault"));
         }
+
+        [Test]
+        public void ReverseReturnsDeleteIndexExpressionForTheSameIndex()
+        {
+            var expression = new CreateIndexExpression
+            {
+                Index = new IndexDefinition
+                {
+                    Name = "IX_Name",
+                    SchemaName = "TestSchema",
+                    TableName = "Table",
+                    Columns = new Collection<IndexColumnDefinition>
+                    {
+                        new IndexColumnDefinition { Name = "Name" },
+                    },
+                },
+            };
+
+            var reversed = (DeleteIndexExpression)expression.Reverse();
+
+            Assert.That(reversed.Index.Name, Is.EqualTo("IX_Name"));
+            Assert.That(reversed.Index.SchemaName, Is.EqualTo("TestSchema"));
+            Assert.That(reversed.Index.TableName, Is.EqualTo("Table"));
+        }
+
+        [Test]
+        public void ReverseDoesNotCarryAdditionalFeaturesOverToTheDeleteIndexExpression()
+        {
+            var expression = new CreateIndexExpression
+            {
+                Index = new IndexDefinition
+                {
+                    Name = "IX_Name",
+                    TableName = "Table",
+                    Columns = new Collection<IndexColumnDefinition>
+                    {
+                        new IndexColumnDefinition { Name = "Name" },
+                    },
+                },
+            };
+
+            expression.AdditionalFeatures["SomeCreateOnlyOption"] = true;
+
+            var reversed = (DeleteIndexExpression)expression.Reverse();
+
+            Assert.That(reversed.AdditionalFeatures, Is.Empty);
+            Assert.That(expression.AdditionalFeatures, Is.Not.Empty);
+        }
     }
 }

--- a/test/FluentMigrator.Tests/Unit/Expressions/CreateIndexExpressionTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Expressions/CreateIndexExpressionTests.cs
@@ -176,5 +176,29 @@ namespace FluentMigrator.Tests.Unit.Expressions
             Assert.That(reversed.AdditionalFeatures, Is.Empty);
             Assert.That(expression.AdditionalFeatures, Is.Not.Empty);
         }
+
+        [Test]
+        public void ReverseKeepsAdditionalFeaturesForAClusteredIndex()
+        {
+            var expression = new CreateIndexExpression
+            {
+                Index = new IndexDefinition
+                {
+                    Name = "IX_Name",
+                    TableName = "Table",
+                    IsClustered = true,
+                    Columns = new Collection<IndexColumnDefinition>
+                    {
+                        new IndexColumnDefinition { Name = "Name" },
+                    },
+                },
+            };
+
+            expression.AdditionalFeatures["SomeCreateOption"] = true;
+
+            var reversed = (DeleteIndexExpression)expression.Reverse();
+
+            Assert.That(reversed.AdditionalFeatures["SomeCreateOption"], Is.True);
+        }
     }
 }

--- a/test/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005IndexTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005IndexTests.cs
@@ -168,6 +168,18 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
         }
 
         [Test]
+        public void CanDropAutoReversedCreateClusteredIndexWithOnlineOnOptionWithOnlineOption()
+        {
+            var expression = GeneratorTestHelper.GetCreateIndexExpression();
+            var builder = new CreateIndexExpressionBuilder(expression);
+            builder.Clustered();
+            builder.Online();
+            var reversed = (DeleteIndexExpression)expression.Reverse();
+            var result = Generator.Generate(reversed);
+            result.ShouldBe("DROP INDEX [TestIndex] ON [dbo].[TestTable1] WITH (ONLINE=ON);");
+        }
+
+        [Test]
         public void CanDropIndexWithOnlineOn()
         {
             var expression = GeneratorTestHelper.GetDeleteIndexExpression();

--- a/test/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005IndexTests.cs
+++ b/test/FluentMigrator.Tests/Unit/Generators/SqlServer2005/SqlServer2005IndexTests.cs
@@ -2,6 +2,7 @@ using System.Linq;
 
 using FluentMigrator.Builders.Create.Index;
 using FluentMigrator.Builders.Delete.Index;
+using FluentMigrator.Expressions;
 using FluentMigrator.Infrastructure.Extensions;
 using FluentMigrator.Runner.Generators.SqlServer;
 using FluentMigrator.SqlServer;
@@ -154,6 +155,16 @@ namespace FluentMigrator.Tests.Unit.Generators.SqlServer2005
             new CreateIndexExpressionBuilder(expression).Online(false);
             var result = Generator.Generate(expression);
             result.ShouldBe("CREATE INDEX [TestIndex] ON [dbo].[TestTable1] ([TestColumn1] ASC) WITH (ONLINE=OFF);");
+        }
+
+        [Test]
+        public void CanDropAutoReversedCreateIndexWithOnlineOnOptionWithoutOnlineOption()
+        {
+            var expression = GeneratorTestHelper.GetCreateIndexExpression();
+            new CreateIndexExpressionBuilder(expression).Online();
+            var reversed = (DeleteIndexExpression)expression.Reverse();
+            var result = Generator.Generate(reversed);
+            result.ShouldBe("DROP INDEX [TestIndex] ON [dbo].[TestTable1];");
         }
 
         [Test]


### PR DESCRIPTION
Fixes #1982.

`CreateIndexExpression.Reverse()` returned `new DeleteIndexExpression { Index = Index.Clone() }`, and `DeleteIndexExpression.AdditionalFeatures` is `Index.AdditionalFeatures`, so the clone carried the creation options onto the drop. An `AutoReversingMigration` that created a non-clustered index with `.WithOptions().Online()` emitted:

```sql
DROP INDEX [TestIndex] ON [dbo].[TestTable1] WITH (ONLINE=ON);
```

which SQL Server rejects with "Only a clustered index can be dropped online." `DATA_COMPRESSION` leaks through the same path.

Additional features on an index describe how it gets created, so `Reverse()` now clears them on the clone when the index is not clustered. A clustered index keeps them: SQL Server can drop a clustered index online, so an auto-reversed `Create.Index(...).WithOptions().Clustered().Online()` still emits `WITH (ONLINE=ON)` on the drop. `IndexDefinition.IsClustered` is a provider-neutral model property set by the fluent `.Clustered()`, and `Clone()` already copies it, so the check adds no provider knowledge to Abstractions.

An explicit `Delete.Index(...).WithOptions().Online()` is untouched and still emits `WITH (ONLINE=ON)`.

I considered fixing it in the generator instead, by emitting `ONLINE` on a drop only where SQL Server accepts it, and rejected it: the delete fluent syntax cannot declare clusteredness, so gating on it there would silently break the existing, tested `Delete.Index(...).WithOptions().Online()` API. Doing it in `Reverse()` also keeps the behaviour consistent with `CreateTableExpression` and `CreateColumnExpression`, which already reverse to identity-only deletes.

Five tests: two in `SqlServer2005IndexTests` pinning the generated SQL for a reversed non-clustered `.Online()` index (bare `DROP INDEX`) and a reversed clustered `.Online()` index (`WITH (ONLINE=ON)` preserved), and three provider-neutral ones in `CreateIndexExpressionTests` covering that `Reverse()` names the same index, drops the additional features for a non-clustered index, and keeps them for a clustered one. Reverting `Reverse()` to a plain clone fails the two non-clustered tests; reverting only the clustered guard fails the two clustered tests. With the change, `FluentMigrator.Tests.Unit` is 5445 passed, 0 failed on net8.0.