### PR TITLE
Fix #2170: report the version table creation from LoadVersionInfoIfRequired

### DIFF
--- a/src/FluentMigrator.Runner.Core/IMigrationRunner.cs
+++ b/src/FluentMigrator.Runner.Core/IMigrationRunner.cs
@@ -116,6 +116,13 @@ namespace FluentMigrator.Runner
         /// <summary>
         /// Creates the required version info database tables
         /// </summary>
+        /// <remarks>
+        /// The default <see cref="IVersionLoader"/> implementation creates any missing version table while it
+        /// is being initialized, which happens on first use. A creation performed by that initialization is
+        /// reported as <c>true</c> as well. Custom <see cref="IVersionLoader"/> implementations that create
+        /// the table during their own initialization cannot report that creation, so <c>false</c> is returned
+        /// for them when the table exists by the time this method checks.
+        /// </remarks>
         /// <returns><c>true</c> if the table had to be created or <c>false</c> when it already existed</returns>
         bool LoadVersionInfoIfRequired();
     }

--- a/src/FluentMigrator.Runner.Core/MigrationRunner.cs
+++ b/src/FluentMigrator.Runner.Core/MigrationRunner.cs
@@ -505,15 +505,24 @@ namespace FluentMigrator.Runner
         /// <inheritdoc />
         public bool LoadVersionInfoIfRequired()
         {
+            // Reading the VersionLoader property below may instantiate the version loader,
+            // and the default VersionLoader implementation creates any missing version table
+            // from its constructor. Capture whether the loader already existed so a creation
+            // triggered by that instantiation can still be reported to the caller (see #2170).
+            var versionLoaderWasInstantiated = _currentVersionLoader != null || _versionLoader.IsValueCreated;
+
             if (VersionLoader.AlreadyCreatedVersionTable && VersionLoader.AlreadyCreatedVersionSchema)
             {
+                if (!versionLoaderWasInstantiated && VersionLoader is VersionLoader versionLoader)
+                {
+                    return versionLoader.HasCreatedVersionTable || versionLoader.HasCreatedVersionSchema;
+                }
+
                 return false;
             }
-            else
-            {
-                VersionLoader.LoadVersionInfo();
-                return true;
-            }
+
+            VersionLoader.LoadVersionInfo();
+            return true;
         }
 
         /// <summary>

--- a/src/FluentMigrator.Runner.Core/VersionLoader.cs
+++ b/src/FluentMigrator.Runner.Core/VersionLoader.cs
@@ -163,6 +163,26 @@ namespace FluentMigrator.Runner
         /// <inheritdoc />
         public bool AlreadyCreatedVersionTable => _processor.TableExists(VersionTableMetaData.SchemaName, VersionTableMetaData.TableName);
 
+        /// <summary>
+        /// Gets a value indicating whether this version loader had to create the schema for the version table
+        /// </summary>
+        /// <remarks>
+        /// The schema is created while the version loader is being constructed, so a live existence check
+        /// such as <see cref="AlreadyCreatedVersionSchema"/> cannot tell a pre-existing schema from one this
+        /// loader just created. This property keeps that distinction.
+        /// </remarks>
+        public bool HasCreatedVersionSchema => _versionSchemaMigrationAlreadyRun;
+
+        /// <summary>
+        /// Gets a value indicating whether this version loader had to create the version table
+        /// </summary>
+        /// <remarks>
+        /// The table is created while the version loader is being constructed, so a live existence check
+        /// such as <see cref="AlreadyCreatedVersionTable"/> cannot tell a pre-existing table from one this
+        /// loader just created. This property keeps that distinction.
+        /// </remarks>
+        public bool HasCreatedVersionTable => _versionMigrationAlreadyRun;
+
         /// <inheritdoc />
         public bool AlreadyMadeVersionUnique => _processor.ColumnExists(VersionTableMetaData.SchemaName, VersionTableMetaData.TableName, VersionTableMetaData.AppliedOnColumnName);
 

--- a/test/FluentMigrator.Tests/Unit/VersionLoaderTests.cs
+++ b/test/FluentMigrator.Tests/Unit/VersionLoaderTests.cs
@@ -16,6 +16,7 @@
 //
 #endregion
 
+using System.Data;
 using System.Linq;
 
 using FluentMigrator.Expressions;
@@ -374,6 +375,70 @@ namespace FluentMigrator.Tests.Unit
             loader.LoadVersionInfo();
 
             runner.Verify(r => r.Up(loader.VersionDescriptionMigration), Times.Once());
+        }
+
+        [Test]
+        public void LoadVersionInfoIfRequiredReportsCreationPerformedByVersionLoaderInitialization()
+        {
+            var processor = CreateStatefulProcessorMock(schemaExists: false, tableExists: false);
+            var serviceProvider = CreateRunnerServiceProvider(processor);
+
+            var runner = serviceProvider.GetRequiredService<IMigrationRunner>();
+
+            runner.LoadVersionInfoIfRequired().ShouldBeTrue();
+            runner.LoadVersionInfoIfRequired().ShouldBeFalse();
+        }
+
+        [Test]
+        public void LoadVersionInfoIfRequiredReturnsFalseWhenVersionTableAlreadyExists()
+        {
+            var processor = CreateStatefulProcessorMock(schemaExists: true, tableExists: true);
+            var serviceProvider = CreateRunnerServiceProvider(processor);
+
+            var runner = serviceProvider.GetRequiredService<IMigrationRunner>();
+
+            runner.LoadVersionInfoIfRequired().ShouldBeFalse();
+        }
+
+        private static Mock<IMigrationProcessor> CreateStatefulProcessorMock(bool schemaExists, bool tableExists)
+        {
+            var processor = new Mock<IMigrationProcessor>();
+
+            processor.Setup(p => p.SchemaExists(It.IsAny<string>())).Returns(() => schemaExists);
+            processor.Setup(p => p.TableExists(It.IsAny<string>(), It.IsAny<string>())).Returns(() => tableExists);
+            processor.Setup(p => p.ColumnExists(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(true);
+            processor.Setup(p => p.Process(It.IsAny<CreateSchemaExpression>())).Callback(() => schemaExists = true);
+            processor.Setup(p => p.Process(It.IsAny<CreateTableExpression>())).Callback(() => tableExists = true);
+            processor.Setup(p => p.ReadTableData(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(
+                    () =>
+                    {
+                        var dataSet = new DataSet();
+                        dataSet.Tables.Add(new DataTable(TestVersionTableMetaData.TABLE_NAME));
+                        return dataSet;
+                    });
+
+            return processor;
+        }
+
+        private static ServiceProvider CreateRunnerServiceProvider(Mock<IMigrationProcessor> processor)
+        {
+            var generatorMock = new Mock<IMigrationGenerator>(MockBehavior.Loose);
+            generatorMock.SetupGet(x => x.Quoter)
+                .Returns(new GenericQuoter());
+            var generatorAccessorMock = new Mock<IGeneratorAccessor>(MockBehavior.Loose);
+
+            generatorAccessorMock.SetupGet(x => x.Generator)
+                .Returns(generatorMock.Object);
+
+            return ServiceCollectionExtensions.CreateServices()
+                .WithProcessor(processor)
+                .AddScoped(_ => generatorAccessorMock.Object)
+                .AddScoped(_ => ConventionSets.NoSchemaName)
+                .AddScoped<IMigrationRunnerConventionsAccessor>(
+                    _ => new PassThroughMigrationRunnerConventionsAccessor(new MigrationRunnerConventions()))
+                .AddScoped<IConnectionStringReader>(_ => new PassThroughConnectionStringReader("No connection"))
+                .BuildServiceProvider();
         }
     }
 }


### PR DESCRIPTION
Fixes #2170.

The XML doc says "true if the table had to be created or false when it already existed", and on a fresh database it always returns false. The reason is ordering: `LoadVersionInfoIfRequired` reads the `VersionLoader` property, and the default `VersionLoader` creates any missing version table from its own constructor, so the `AlreadyCreatedVersionTable` and `AlreadyCreatedVersionSchema` checks, which query the database live, run after the creation has already happened.

On the shape of the fix, since jzabroski's concern above was about taking on more than needed: correcting the documentation to "always false" would just document a method with no reason to exist, and the reporter's use is exactly what it promises. So this is additive only. `VersionLoader` gains `HasCreatedVersionSchema` and `HasCreatedVersionTable`, backed by the `_versionSchemaMigrationAlreadyRun` and `_versionMigrationAlreadyRun` fields it already tracks, and `LoadVersionInfoIfRequired` notes whether the loader was materialised by this very call and, if that materialisation performed the creation, returns true.

`IVersionLoader` is deliberately untouched. Adding a member to that public interface would break every external implementation on net48 and netstandard2.0, where default interface members are not available. A custom `IVersionLoader` therefore behaves exactly as it does today, and the interface remark says so.

`ConnectionlessVersionLoader` needs no change, since its `LoadVersionInfo` never creates anything.

Two tests in `VersionLoaderTests` drive a real `MigrationRunner` and a real `VersionLoader` through the container against a stateful processor mock whose existence flags flip when the create expressions are processed. Against master's source the fresh-database test fails by returning false. With the change, `FluentMigrator.Tests.Unit` is 5442 passed, 0 failed on net8.0.

No API or binary break. The one behaviour change is the intended one: with the default `VersionLoader`, `LoadVersionInfoIfRequired()` on a fresh database now returns true where it previously returned false, contradicting its own documentation. Second and later calls still return false, which is what the existing test pins.
